### PR TITLE
[feat] add support for PodDisruptionBudgets for retool backend

### DIFF
--- a/templates/deployment_backend.yaml
+++ b/templates/deployment_backend.yaml
@@ -180,3 +180,15 @@ spec:
 {{- if .Values.extraVolumes }}
 {{ toYaml .Values.extraVolumes | indent 8 }}
 {{- end }}
+---
+{{- if .Values.podDisruptionBudget }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "retool.fullname" . }}
+spec:
+  {{ toYaml .Values.podDisruptionBudget }}
+  selector:
+    matchLabels:
+  {{- include "retool.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -148,6 +148,15 @@ podAnnotations: {}
 replicaCount: 1
 revisionHistoryLimit: 3
 
+# Optional pod disruption budget, for ensuring higher availability of the
+# Retool application.  Specify either minAvailable or maxUnavailable, as
+# either an integer pod count (1) or a string percentage ("50%").
+# Ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+#
+# Example:
+# podDisruptionBudget:
+#   maxUnavailable: 1
+
 # Custom labels for pod assignment
 podLabels: {}
 


### PR DESCRIPTION
This diff allows users to specify a PodDisruptionBudget in their values file,
instructing Kubernetes to protect the application

# Testing plan
1. Create a minikube cluster with two nodes:

```
$ minikube start
$ minikube node add
```

2. Install retool into the cluster, with a replica count of three:
```
$ helm upgrade --install --values values.yaml  myretool . --set replicaCount=3
```

3. Uncomment the example in the values file, then upgrade again:
```
$ helm upgrade --values values.yaml  myretool . --set replicaCount=3
```

4. Confirm presence of PodDisruptionBudget:
```
$ kubectl describe poddisruptionbudget myretool
Name:             myretool
Namespace:        default
Max unavailable:  1
Selector:         app.kubernetes.io/instance=myretool,app.kubernetes.io/name=retool
Status:
    Allowed disruptions:  0
    Current:              1
    Desired:              2
    Total:                3
Events:                   <none>
```

5. Attempt to take down a node running two copies of `myretool`:
```
± % kubectl drain minikube-m02 --ignore-daemonsets
node/minikube-m02 cordoned
WARNING: ignoring DaemonSet-managed Pods: kube-system/kindnet-zmd4g, kube-system/kube-proxy-g8mhx
evicting pod default/myretool-fcdd777fc-q4hzq
evicting pod default/myretool-fcdd777fc-9b45f
error when evicting pods/"myretool-fcdd777fc-9b45f" -n "default" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
```