### PR TITLE
[helm2] Change the latest tag to a defined version number

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -22,7 +22,7 @@ config:
 
 image:
   repository: "tryretool/backend"
-  tag: "2.66.65"
+  tag: "X.Y.Z"
   pullPolicy: "IfNotPresent"
 
 commandline:

--- a/values.yaml
+++ b/values.yaml
@@ -22,7 +22,7 @@ config:
 
 image:
   repository: "tryretool/backend"
-  tag: "latest"
+  tag: "2.66.65"
   pullPolicy: "IfNotPresent"
 
 commandline:


### PR DESCRIPTION
In this PR, @jssln and I are changing the previous "latest" tag to a defined version number. The reason for this is to ensure there are no inconsistencies with upgrades to different version numbers. Because we have two containers, it's possible that one of the containers will have a different version due to the underlying "latest" changing. 

### Test Plan:

Deployed our own on-premise build to confirm installation is smooth and works. 
<img width="207" alt="Screen Shot 2021-04-03 at 9 59 53 PM" src="https://user-images.githubusercontent.com/1017111/113517308-f880e680-9533-11eb-8f01-c7963b9b0e76.png">

We will also add updated documentation in our README regarding the image.tag value and what it means to change it. 
* PR for the README change: https://github.com/tryretool/retool-helm/pull/10
