### PR TITLE
Update Helm 2 README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # retool-helm
 
-This repository contains the Helm 2 chart for installing and configuring
+This repository contains the **Helm 2** chart for installing and configuring
 Retool on Kubernetes. For full documentation on all the ways you can deploy
 Retool on your own infrastructure, please see the [Setup
 Guide](https://docs.retool.com/docs/setup-instructions).
@@ -8,20 +8,23 @@ Guide](https://docs.retool.com/docs/setup-instructions).
 ## Prerequisites
 
 - This chart requires **Helm 2.0** and **Kubernetes 1.16+**.
-- Persistent volumes are not reliable - we recommend that a long-term
-  installation of Retool host the database on an externally managed database
-  like RDS. Please disable the included postgresql chart by setting
-  postgresql.enabled to false and then specifying your external database
-  through the config.postgresql.\* properties.
+- A PostgreSQL database.
+  - Persistent volumes are not reliable - we strongly recommend that a long-term
+  installation of Retool host the database on an externally managed database (for example, AWS RDS).
 
 ## Usage
-
 1.  Clone this repo
 
         $ git clone git@github.com:tryretool/retool-helm.git
 
-2.  Now you're all ready to install Retool:
+2. In the `values.yaml` file, disable the included postgresql chart by setting
+`postgresql.enabled` to `false`. Then specify your external database
+through the `config.postgresql.\*` properties at the top of the file.
+
+3. In the `values.yaml` file, set the version of Retool you want to install in the `image.tag` field. See our guide on [Retool Release Versions](https://docs.retool.com/docs/updating-retool-on-premise#retool-release-versions) to see your options, and [Docker Hub](https://hub.docker.com/r/tryretool/backend/tags) for the latest version numbers. To prevent issues while upgrading Retool, set a specific semver version number (i.e. a version in the format X.Y.Z) instead of a tag name.
+
+4. Please see the many other options supported in the `values.yaml` file.
+
+5. Now you're all ready to install Retool:
 
         $ helm install my-retool ./
-
-Please see the many options supported in the `values.yaml` file.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Guide](https://docs.retool.com/docs/setup-instructions).
 through the `config.postgresql.\*` properties at the top of the file.
 
 3. In the `values.yaml` file, set the version of Retool you want to install in the `image.tag` field. See our guide on [Retool Release Versions](https://docs.retool.com/docs/updating-retool-on-premise#retool-release-versions) to see your options, and [Docker Hub](https://hub.docker.com/r/tryretool/backend/tags) for the latest version numbers. To prevent issues while upgrading Retool, set a specific semver version number (i.e. a version in the format X.Y.Z) instead of a tag name.
-    * For example, if you want to install the latest "release-candidate", go to [Retool Release Versions](https://docs.retool.com/docs/updating-retool-on-premise#retool-release-versions) and look up the current Retool release number associated with the "release-candidate" and fill in the specific version number. (As of early April 2021 the "release-candidate" version is "2.65.3".)
+    * If you're not sure which version to install, we recommend starting with the "release-candidate". To find out the specific version number of the "release-candidate", visit [Retool Release Versions](https://docs.retool.com/docs/updating-retool-on-premise#retool-release-versions). (As of early April 2021 the "release-candidate" version is "2.65.3".)
 
 4. Please see the many other options supported in the `values.yaml` file.
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Guide](https://docs.retool.com/docs/setup-instructions).
 through the `config.postgresql.\*` properties at the top of the file.
 
 3. In the `values.yaml` file, set the version of Retool you want to install in the `image.tag` field. See our guide on [Retool Release Versions](https://docs.retool.com/docs/updating-retool-on-premise#retool-release-versions) to see your options, and [Docker Hub](https://hub.docker.com/r/tryretool/backend/tags) for the latest version numbers. To prevent issues while upgrading Retool, set a specific semver version number (i.e. a version in the format X.Y.Z) instead of a tag name.
+    * For example, if you want to install the latest "release-candidate", go to  [Retool Release Versions](https://docs.retool.com/docs/updating-retool-on-premise#retool-release-versions) and look up the current Retool release number associated with the "release-candidate" and fill in the specific version number. (As of early April 2021 the "release-candidate" version is "2.65.3".)
 
 4. Please see the many other options supported in the `values.yaml` file.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Guide](https://docs.retool.com/docs/setup-instructions).
 through the `config.postgresql.\*` properties at the top of the file.
 
 3. In the `values.yaml` file, set the version of Retool you want to install in the `image.tag` field. See our guide on [Retool Release Versions](https://docs.retool.com/docs/updating-retool-on-premise#retool-release-versions) to see your options, and [Docker Hub](https://hub.docker.com/r/tryretool/backend/tags) for the latest version numbers. To prevent issues while upgrading Retool, set a specific semver version number (i.e. a version in the format X.Y.Z) instead of a tag name.
-    * For example, if you want to install the latest "release-candidate", go to  [Retool Release Versions](https://docs.retool.com/docs/updating-retool-on-premise#retool-release-versions) and look up the current Retool release number associated with the "release-candidate" and fill in the specific version number. (As of early April 2021 the "release-candidate" version is "2.65.3".)
+    * For example, if you want to install the latest "release-candidate", go to [Retool Release Versions](https://docs.retool.com/docs/updating-retool-on-premise#retool-release-versions) and look up the current Retool release number associated with the "release-candidate" and fill in the specific version number. (As of early April 2021 the "release-candidate" version is "2.65.3".)
 
 4. Please see the many other options supported in the `values.yaml` file.
 


### PR DESCRIPTION
* Explicitly call out that you should specify a Retool version, and add links to help the user figure out the version they want.
* Pull the instructions for specifying the Postgres DB details into the set up steps.

Will make a similar change for the Helm 3 README, after getting review on this one.