### PR TITLE
update the values.yaml to default X.Y.Z

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -23,7 +23,7 @@ config:
 image:
   repository: "tryretool/backend"
   # Will default to Chart AppVersion if left empty
-  tag: X.Y.Z
+  tag: "X.Y.Z"
   pullPolicy: "IfNotPresent"
 
 commandline:

--- a/values.yaml
+++ b/values.yaml
@@ -23,7 +23,7 @@ config:
 image:
   repository: "tryretool/backend"
   # Will default to Chart AppVersion if left empty
-  tag:
+  tag: X.Y.Z
   pullPolicy: "IfNotPresent"
 
 commandline:


### PR DESCRIPTION
This change is done in order to ensure that the developer can find the right version of helm based on the retool version (see README) as opposed to defaulting to an out-of-date value. A future change will be added to no longer use the appVersion in the Chart.yaml file.