### PR TITLE
Update Helm 3 readme with instructions to set `encryptionKey` and `jwtSecret`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,19 +20,21 @@ Guide](https://docs.retool.com/docs/setup-instructions).
         $ helm repo add retool https://charts.retool.com
         "retool" has been added to your repositories
 
-2. Ensure you have access to the `retool` chart:
+1. Ensure you have access to the `retool` chart:
 
         $ helm search repo retool/retool
         NAME         	CHART VERSION	APP VERSION	DESCRIPTION                
         retool/retool	4.0.0        	2.66.2     	A Helm chart for Kubernetes
 
-2. In the `values.yaml` file, disable the included postgresql chart by setting `postgresql.enabled` to `false`. Then specify your external database through the `config.postgresql.\*` properties at the top of the file.
+1. In the `values.yaml` file, disable the included postgresql chart by setting `postgresql.enabled` to `false`. Then specify your external database through the `config.postgresql.\*` properties at the top of the file.
 
-3. In the `values.yaml` file, set the version of Retool you want to install in the `image.tag` field. See our guide on [Retool Release Versions](https://docs.retool.com/docs/updating-retool-on-premise#retool-release-versions) to see your options, and [Docker Hub](https://hub.docker.com/r/tryretool/backend/tags) for the latest version numbers. To prevent issues while upgrading Retool, set a specific semver version number (i.e. a version in the format X.Y.Z) instead of a tag name.
+1. In the `values.yaml` file, set values for `encryptionKey` and `jwtSecret`. They should each be a different long, random string that you keep private. See our docs on [Environment Variables](https://docs.retool.com/docs/environment-variables) for more information on how they are used.
+
+1. In the `values.yaml` file, set the version of Retool you want to install in the `image.tag` field. See our guide on [Retool Release Versions](https://docs.retool.com/docs/updating-retool-on-premise#retool-release-versions) to see your options, and [Docker Hub](https://hub.docker.com/r/tryretool/backend/tags) for the latest version numbers. To prevent issues while upgrading Retool, set a specific semver version number (i.e. a version in the format X.Y.Z) instead of a tag name.
     * If you're not sure which version to install, we recommend starting with the "release-candidate". To find out the specific version number of the "release-candidate", visit [Retool Release Versions](https://docs.retool.com/docs/updating-retool-on-premise#retool-release-versions). (As of early April 2021 the "release-candidate" version is "2.65.3".)
 
-4. Please see the many other options supported in the `values.yaml` file.
+1. Please see the many other options supported in the `values.yaml` file.
 
-5. Now you're all ready to install Retool:
+1. Now you're all ready to install Retool:
 
         $ helm install my-retool retool/retool


### PR DESCRIPTION
Motivation: 
@alexwestreich points out that it's vital to set these two env vars. We can update the Environment Variables page itself to give more color on what changing these values will lead to.