### PR TITLE
Allow more granular control for secrets

### DIFF
--- a/templates/deployment_backend.yaml
+++ b/templates/deployment_backend.yaml
@@ -67,17 +67,29 @@ spec:
           - name: LICENSE_KEY
             valueFrom:
               secretKeyRef:
+                {{- if .Values.config.licenseKeySecretName }}
+                name: {{ .Values.config.licenseKeySecretName }}
+                {{- else }}
                 name: {{ template "retool.fullname" . }}
+                {{- end }}
                 key: license-key
           - name: JWT_SECRET
             valueFrom:
               secretKeyRef:
+                {{- if .Values.config.jwtSecretName }}
+                name: {{ .Values.config.jwtSecretName }}
+                {{- else }}
                 name: {{ template "retool.fullname" . }}
+                {{- end }}
                 key: jwt-secret
           - name: ENCRYPTION_KEY
             valueFrom:
               secretKeyRef:
+                {{- if .Values.config.encryptionKeySecretName }}
+                name: {{ .Values.config.encryptionKeySecretName }}
+                {{- else }}
                 name: {{ template "retool.fullname" . }}
+                {{- end }}
                 key: encryption-key
           - name: POSTGRES_USER
             value: {{ template "retool.postgresql.user" . }}
@@ -88,8 +100,12 @@ spec:
               secretKeyRef:
           {{- if  .Values.postgresql.enabled }}
                 name: {{ template "retool.postgresql.fullname" . }}
-          {{- else  }}
+          {{- else }}
+                {{- if .Values.config.postgresql.passwordSecretName }}
+                name: {{ .Values.config.postgresql.passwordSecretName }}
+                {{- else }}
                 name: {{ template "retool.fullname" . }}
+                {{- end }}
           {{- end }}
                 key: postgresql-password
           - name: CLIENT_ID
@@ -97,7 +113,11 @@ spec:
           - name: CLIENT_SECRET
             valueFrom:
               secretKeyRef:
+                {{- if .Values.config.auth.google.clientSecretSecretName }}
+                name: {{ .Values.config.auth.google.clientSecretSecretName }}
+                {{- else }}
                 name: {{ template "retool.fullname" . }}
+                {{- end }}
                 key: google-client-secret
           - name: RESTRICTED_DOMAIN
             value: {{ default "" .Values.config.auth.google.domain }}

--- a/templates/deployment_backend.yaml
+++ b/templates/deployment_backend.yaml
@@ -69,28 +69,31 @@ spec:
               secretKeyRef:
                 {{- if .Values.config.licenseKeySecretName }}
                 name: {{ .Values.config.licenseKeySecretName }}
+                key: {{ .Values.config.licenseKeySecretKey | default "license-key" }}
                 {{- else }}
                 name: {{ template "retool.fullname" . }}
-                {{- end }}
                 key: license-key
+                {{- end }}
           - name: JWT_SECRET
             valueFrom:
               secretKeyRef:
                 {{- if .Values.config.jwtSecretName }}
                 name: {{ .Values.config.jwtSecretName }}
+                key: {{ .Values.config.jwtSecretKey | default "jwt-secret" }}
                 {{- else }}
                 name: {{ template "retool.fullname" . }}
-                {{- end }}
                 key: jwt-secret
+                {{- end }}
           - name: ENCRYPTION_KEY
             valueFrom:
               secretKeyRef:
                 {{- if .Values.config.encryptionKeySecretName }}
                 name: {{ .Values.config.encryptionKeySecretName }}
+                key: {{ .Values.config.encryptionKeySecretKey | default "encryption-key" }}
                 {{- else }}
                 name: {{ template "retool.fullname" . }}
-                {{- end }}
                 key: encryption-key
+                {{- end }}
           - name: POSTGRES_USER
             value: {{ template "retool.postgresql.user" . }}
           - name: POSTGRES_SSL_ENABLED
@@ -100,14 +103,16 @@ spec:
               secretKeyRef:
           {{- if  .Values.postgresql.enabled }}
                 name: {{ template "retool.postgresql.fullname" . }}
+                key: postgresql-password
           {{- else }}
                 {{- if .Values.config.postgresql.passwordSecretName }}
                 name: {{ .Values.config.postgresql.passwordSecretName }}
+                key: {{ .Values.config.postgresql.passwordSecretKey | default "postgresql-password" }}
                 {{- else }}
                 name: {{ template "retool.fullname" . }}
+                key: postgresql-password
                 {{- end }}
           {{- end }}
-                key: postgresql-password
           - name: CLIENT_ID
             value: {{ default "" .Values.config.auth.google.clientId }}
           - name: CLIENT_SECRET
@@ -115,10 +120,11 @@ spec:
               secretKeyRef:
                 {{- if .Values.config.auth.google.clientSecretSecretName }}
                 name: {{ .Values.config.auth.google.clientSecretSecretName }}
+                key: {{ .Values.config.auth.google.clientSecretSecretKey | default "google-client-secret" }}
                 {{- else }}
                 name: {{ template "retool.fullname" . }}
-                {{- end }}
                 key: google-client-secret
+                {{- end }}
           - name: RESTRICTED_DOMAIN
             value: {{ default "" .Values.config.auth.google.domain }}
           {{- end }}

--- a/templates/deployment_jobs.yaml
+++ b/templates/deployment_jobs.yaml
@@ -68,17 +68,29 @@ spec:
           - name: LICENSE_KEY
             valueFrom:
               secretKeyRef:
+                {{- if .Values.config.licenseKeySecretName }}
+                name: {{ .Values.config.licenseKeySecretName }}
+                {{- else }}
                 name: {{ template "retool.fullname" . }}
+                {{- end }}
                 key: license-key
           - name: JWT_SECRET
             valueFrom:
               secretKeyRef:
+                {{- if .Values.config.jwtSecretName }}
+                name: {{ .Values.config.jwtSecretName }}
+                {{- else }}
                 name: {{ template "retool.fullname" . }}
+                {{- end }}
                 key: jwt-secret
           - name: ENCRYPTION_KEY
             valueFrom:
               secretKeyRef:
+                {{- if .Values.config.encryptionKeySecretName }}
+                name: {{ .Values.config.encryptionKeySecretName }}
+                {{- else }}
                 name: {{ template "retool.fullname" . }}
+                {{- end }}
                 key: encryption-key
           - name: POSTGRES_USER
             value: {{ template "retool.postgresql.user" . }}
@@ -87,8 +99,12 @@ spec:
               secretKeyRef:
           {{- if  .Values.postgresql.enabled }}
                 name: {{ template "retool.postgresql.fullname" . }}
-          {{- else  }}
+          {{- else }}
+                {{- if .Values.config.postgresql.passwordSecretName }}
+                name: {{ .Values.config.postgresql.passwordSecretName }}
+                {{- else }}
                 name: {{ template "retool.fullname" . }}
+                {{- end }}
           {{- end }}
                 key: postgresql-password
           - name: CLIENT_ID
@@ -96,7 +112,11 @@ spec:
           - name: CLIENT_SECRET
             valueFrom:
               secretKeyRef:
+                {{- if .Values.config.auth.google.clientSecretSecretName }}
+                name: {{ .Values.config.auth.google.clientSecretSecretName }}
+                {{- else }}
                 name: {{ template "retool.fullname" . }}
+                {{- end }}
                 key: google-client-secret
           - name: RESTRICTED_DOMAIN
             value: {{ default "" .Values.config.auth.google.domain }}

--- a/templates/deployment_jobs.yaml
+++ b/templates/deployment_jobs.yaml
@@ -70,28 +70,31 @@ spec:
               secretKeyRef:
                 {{- if .Values.config.licenseKeySecretName }}
                 name: {{ .Values.config.licenseKeySecretName }}
+                key: {{ .Values.config.licenseKeySecretKey | default "license-key" }}
                 {{- else }}
                 name: {{ template "retool.fullname" . }}
-                {{- end }}
                 key: license-key
+                {{- end }}
           - name: JWT_SECRET
             valueFrom:
               secretKeyRef:
                 {{- if .Values.config.jwtSecretName }}
                 name: {{ .Values.config.jwtSecretName }}
+                key: {{ .Values.config.jwtSecretKey | default "jwt-secret" }}
                 {{- else }}
                 name: {{ template "retool.fullname" . }}
-                {{- end }}
                 key: jwt-secret
+                {{- end }}
           - name: ENCRYPTION_KEY
             valueFrom:
               secretKeyRef:
                 {{- if .Values.config.encryptionKeySecretName }}
                 name: {{ .Values.config.encryptionKeySecretName }}
+                key: {{ .Values.config.encryptionKeySecretKey | default "encryption-key" }}
                 {{- else }}
                 name: {{ template "retool.fullname" . }}
-                {{- end }}
                 key: encryption-key
+                {{- end }}
           - name: POSTGRES_USER
             value: {{ template "retool.postgresql.user" . }}
           - name: POSTGRES_PASSWORD
@@ -99,14 +102,16 @@ spec:
               secretKeyRef:
           {{- if  .Values.postgresql.enabled }}
                 name: {{ template "retool.postgresql.fullname" . }}
+                key: postgresql-password
           {{- else }}
                 {{- if .Values.config.postgresql.passwordSecretName }}
                 name: {{ .Values.config.postgresql.passwordSecretName }}
+                key: {{ .Values.config.postgresql.passwordSecretKey | default "postgresql-password" }}
                 {{- else }}
                 name: {{ template "retool.fullname" . }}
+                key: postgresql-password
                 {{- end }}
           {{- end }}
-                key: postgresql-password
           - name: CLIENT_ID
             value: {{ default "" .Values.config.auth.google.clientId }}
           - name: CLIENT_SECRET
@@ -114,10 +119,11 @@ spec:
               secretKeyRef:
                 {{- if .Values.config.auth.google.clientSecretSecretName }}
                 name: {{ .Values.config.auth.google.clientSecretSecretName }}
+                key: {{ .Values.config.auth.google.clientSecretSecretKey | default "google-client-secret" }}
                 {{- else }}
                 name: {{ template "retool.fullname" . }}
-                {{- end }}
                 key: google-client-secret
+                {{- end }}
           - name: RESTRICTED_DOMAIN
             value: {{ default "" .Values.config.auth.google.domain }}
           {{- end }}

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -11,7 +11,7 @@ metadata:
 {{- end }}
 type: Opaque
 data:
-  license-key: {{ .Values.config.licenseKey | b64enc | quote }}
+  license-key: {{ .Values.config.licenseKey | default "" | b64enc | quote }}
 
   {{ if .Values.config.jwtSecret }}
   jwt-secret: {{ .Values.config.jwtSecret | b64enc | quote }}
@@ -26,9 +26,9 @@ data:
   {{ end }}
 
   {{ if .Values.config.auth.google.clientSecret }}
-  google-client-secret: {{ .Values.config.auth.google.clientSecret | b64enc |quote }}
+  google-client-secret: {{ .Values.config.auth.google.clientSecret | b64enc | quote }}
   {{ else  }}
-  google-client-secret: "" 
+  google-client-secret: ""
   {{ end }}
 
   {{ if not .Values.postgresql.enabled }}

--- a/values.yaml
+++ b/values.yaml
@@ -3,17 +3,21 @@
 
 config:
   licenseKey: "EXPIRED-LICENSE-KEY-TRIAL"
+  # licenseKeySecretName is the name of the secret where the Retool license key is stored (can be used instead of licenseKey), expected key name is license-key
   # licenseKeySecretName:
   useInsecureCookies: true
   auth:
     google:
       clientId:
       clientSecret:
+      # clientSecretSecretName is the name of the secret where the google client secret is stored (can be used instead of clientSecret), expected key name is google-client-secret
       # clientSecretSecretName:
       domain:
   encryptionKey:
+  # encryptionKeySecretName is the name of the secret where the encryption key is stored (can be used instead of encryptionKey), expected key name is encryption-key
   # encryptionKeySecretName:
   jwtSecret:
+  # jwtSecretSecretName is the name of the secret where the jwt secret is stored (can be used instead of jwtSecret), expected key name is jwt-secret
   # jwtSecretSecretName:
 
   postgresql: {}
@@ -23,6 +27,7 @@ config:
     # db:
     # user:
     # password:
+    # passwordSecretName is the name of the secret where the pg password is stored (can be used instead of password), expected key name is postgresql-password
     # passwordSecretName:
 
 image:
@@ -84,7 +89,6 @@ postgresql:
   postgresqlDatabase: hammerhead_production
   postgresqlUsername: retool
   postgresqlPassword: retool
-  #postgresqlPasswordSecretName:
   service:
     port: 5432
   # Use the offical docker image rather than bitnami/docker

--- a/values.yaml
+++ b/values.yaml
@@ -3,22 +3,30 @@
 
 config:
   licenseKey: "EXPIRED-LICENSE-KEY-TRIAL"
-  # licenseKeySecretName is the name of the secret where the Retool license key is stored (can be used instead of licenseKey), expected key name is license-key
+  # licenseKeySecretName is the name of the secret where the Retool license key is stored (can be used instead of licenseKey)
   # licenseKeySecretName:
+  # licenseKeySecretKey is the key in the k8s secret, default: license-key
+  # licenseKeySecretKey:
   useInsecureCookies: true
   auth:
     google:
       clientId:
       clientSecret:
-      # clientSecretSecretName is the name of the secret where the google client secret is stored (can be used instead of clientSecret), expected key name is google-client-secret
+      # clientSecretSecretName is the name of the secret where the google client secret is stored (can be used instead of clientSecret)
       # clientSecretSecretName:
+      # clientSecretSecretKey is the key in the k8s secret, default: google-client-secret
+      # clientSecretSecretKey:
       domain:
   encryptionKey:
-  # encryptionKeySecretName is the name of the secret where the encryption key is stored (can be used instead of encryptionKey), expected key name is encryption-key
+  # encryptionKeySecretName is the name of the secret where the encryption key is stored (can be used instead of encryptionKey)
   # encryptionKeySecretName:
+  # encryptionKeySecretKey is the key in the k8s secret, default: encryption-key
+  # encryptionKeySecretKey:
   jwtSecret:
-  # jwtSecretSecretName is the name of the secret where the jwt secret is stored (can be used instead of jwtSecret), expected key name is jwt-secret
+  # jwtSecretSecretName is the name of the secret where the jwt secret is stored (can be used instead of jwtSecret)
   # jwtSecretSecretName:
+  # jwtSecretSecretKey is the key in the k8s secret, default: jwt-secret
+  # jwtSecretSecretKey:
 
   postgresql: {}
     # Specify if postgresql subchart is disabled
@@ -27,8 +35,10 @@ config:
     # db:
     # user:
     # password:
-    # passwordSecretName is the name of the secret where the pg password is stored (can be used instead of password), expected key name is postgresql-password
+    # passwordSecretName is the name of the secret where the pg password is stored (can be used instead of password)
     # passwordSecretName:
+    # passwordSecretKey is the key in the k8s secret, default: postgresql-password
+    # passwordSecretKey:
 
 image:
   repository: "tryretool/backend"

--- a/values.yaml
+++ b/values.yaml
@@ -3,14 +3,18 @@
 
 config:
   licenseKey: "EXPIRED-LICENSE-KEY-TRIAL"
+  # licenseKeySecretName:
   useInsecureCookies: true
   auth:
     google:
       clientId:
       clientSecret:
+      # clientSecretSecretName:
       domain:
   encryptionKey:
+  # encryptionKeySecretName:
   jwtSecret:
+  # jwtSecretSecretName:
 
   postgresql: {}
     # Specify if postgresql subchart is disabled
@@ -19,6 +23,7 @@ config:
     # db:
     # user:
     # password:
+    # passwordSecretName:
 
 image:
   repository: "tryretool/backend"
@@ -79,6 +84,7 @@ postgresql:
   postgresqlDatabase: hammerhead_production
   postgresqlUsername: retool
   postgresqlPassword: retool
+  #postgresqlPasswordSecretName:
   service:
     port: 5432
   # Use the offical docker image rather than bitnami/docker


### PR DESCRIPTION
As it is, it's somewhat annoying to use some secrets and not others since the current mechanism to use external secrets is all-or-nothing with a whole block of env vars.

This allows you to optionally use:
1. `config.licenseKeySecretName` instead of `config.licenseKey`
2. `config.jwtSecretSecretName` instead of `config. jwtSecret`
2. `config.encryptionKeySecretName` instead of `config.encryptionKey`
3. `config.auth.google.clientSecretSecretName` instead of `config.auth.google.clientSecret`
4. `config.postgresql.passwordSecretName` instead of `config.postgresql.password`

In all of these instances, the alternative `<x>SecretName` allows you to specify the name of the k8s secret as an alternative to hardcoding the secrets into values and having the chart put them in secrets.