### PR TITLE
Fix missing usage of postgresql.ssl_enabled in jobs deployment

### DIFF
--- a/templates/deployment_backend.yaml
+++ b/templates/deployment_backend.yaml
@@ -148,6 +148,7 @@ spec:
             port: {{ .Values.service.internalPort }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          failureThreshold:  {{ .Values.livenessProbe.failureThreshold }}
 {{- end }}
 {{- if .Values.readinessProbe.enabled }}
         readinessProbe:

--- a/templates/deployment_jobs.yaml
+++ b/templates/deployment_jobs.yaml
@@ -64,6 +64,8 @@ spec:
             value: {{ template "retool.postgresql.port" . }}
           - name: POSTGRES_DB
             value: {{ template "retool.postgresql.db" . }}
+          - name: POSTGRES_SSL_ENABLED
+            value: {{ template "retool.postgresql.ssl_enabled" . }}
           {{- if not .Values.externalSecrets.enabled }}
           - name: LICENSE_KEY
             valueFrom:

--- a/values.yaml
+++ b/values.yaml
@@ -125,6 +125,7 @@ livenessProbe:
   path: /api/checkHealth
   initialDelaySeconds: 30
   timeoutSeconds: 10
+  failureThreshold: 3
 
 readinessProbe:
   enabled: true


### PR DESCRIPTION
Azure Postgres requires SSL to communicate.
The flag exist in the retool server deployment but not in the backend job deployment.
This causes upgrades to fail as the backend job is unable to complete migrations against postgres.
This fix also includes support for liveness failure threshold so that it can be modified