### PR TITLE
Remove appVersion from chart

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,6 @@ name: retool
 description: A Helm chart for Kubernetes
 type: application
 version: 4.3.0
-appVersion: "2.66.14"
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com


### PR DESCRIPTION
It doesn't make sense for us to declare a static version here as this chart is not released per new version of Retool. Given our updated instructions (https://github.com/tryretool/retool-helm/pull/11) to specify a Retool version, we should just remove this.

Per Helm, it is optional: https://helm.sh/docs/topics/charts/#the-appversion-field