### PR TITLE
Skip unnecessary secret generation

### DIFF
--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -13,16 +13,20 @@ type: Opaque
 data:
   license-key: {{ .Values.config.licenseKey | default "" | b64enc | quote }}
 
+  {{ if not .Values.config.jwtSecretSecretName }}
   {{ if .Values.config.jwtSecret }}
   jwt-secret: {{ .Values.config.jwtSecret | b64enc | quote }}
   {{ else  }}
   jwt-secret: {{ randAlphaNum 20 | b64enc | quote }}
   {{ end }}
+  {{ end }}
 
+  {{ if not .Values.config.encryptionKeySecretName }}
   {{ if .Values.config.encryptionKey }}
   encryption-key: {{ .Values.config.encryptionKey | b64enc | quote }}
   {{ else  }}
   encryption-key: {{ randAlphaNum 20 | b64enc | quote }}
+  {{ end }}
   {{ end }}
 
   {{ if .Values.config.auth.google.clientSecret }}


### PR DESCRIPTION
If you use `.Values.config.jwtSecretSecretName` and `.Values.config.encryptionKeySecretName` instead of specifying one in your values file, the helm chart will still generate random secrets for you. 

This is usually fine because of helm resource policy (`no-upgrade-existing`), but the terraform helm provider detects this as the provider producing inconsistent terraform plans. So this changes the secrets to not generate when those config values are used. Otherwise the helm provider thinks it is generating new random secrets on every terraform plan and terraform apply and never works.