### PR TITLE
Fixup: remove references to AppVersion

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 4.6.0
+version: 4.6.1
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/templates/deployment_backend.yaml
+++ b/templates/deployment_backend.yaml
@@ -39,7 +39,7 @@ spec:
 {{- end }}
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+        image: "{{ .Values.image.repository }}:{{ required "Please set a value for .Values.image.tag" .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
           - bash

--- a/templates/deployment_jobs.yaml
+++ b/templates/deployment_jobs.yaml
@@ -42,7 +42,7 @@ spec:
 {{- end }}
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+        image: "{{ .Values.image.repository }}:{{ required "Please set a value for .Values.image.tag" .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
           - bash

--- a/values.yaml
+++ b/values.yaml
@@ -42,8 +42,8 @@ config:
 
 image:
   repository: "tryretool/backend"
-  # Will default to Chart AppVersion if left empty
-  tag: "X.Y.Z"
+  # You need to pick a specific tag here, this chart will not make a decision for you
+  tag: ""
   pullPolicy: "IfNotPresent"
 
 commandline:


### PR DESCRIPTION
Hey @rhinon @kyle-retool ,

I see we've removed the default to AppVersion in #20 (with discussion in #17).

This PR cleans up a few loose ends from that PR:
- Removes the `default`, and makes `.Values.image.tag` mandatory
- Remove the outdated comment about defaulting to AppVersion

Feel free to close this PR if the goal is to come back to using AppVersion as alluded to in #17 !