### PR TITLE
add option to create secret

### DIFF
--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.externalSecrets.enabled }}
+{{- if and (not .Values.externalSecrets.enabled) (.Values.secret.create) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/values.yaml
+++ b/values.yaml
@@ -40,6 +40,10 @@ config:
     # passwordSecretKey is the key in the k8s secret, default: postgresql-password
     # passwordSecretKey:
 
+# If false, you need to provide your own secret
+secret:
+  create: true
+
 image:
   repository: "tryretool/backend"
   # Will default to Chart AppVersion if left empty


### PR DESCRIPTION
Add option to choose whether create the secret or not.

Currently, even if the secret name is not empty (`licenseKeySecretName`, `encryptionKeySecretName`, ...) the secret is always created.
Moreover, if you provide a secret name equals to `{{ template "retool.fullname" . }}` you'll get the error from Helm `rendered manifests contain a resource that already exists`

Thanks