### PR TITLE
Add support for AWS Security groups for pods

### DIFF
--- a/templates/securitygrouppolicy.yaml
+++ b/templates/securitygrouppolicy.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.securityGroupPolicy.enabled -}}
+apiVersion: vpcresources.k8s.aws/v1beta1
+kind: SecurityGroupPolicy
+metadata:
+  name: {{ template "retool.fullname" . }}
+  labels: {{- include "retool.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels: {{- include "retool.selectorLabels" . | nindent 6 }}
+  securityGroups:
+    groupIds: {{ toYaml .Values.securityGroupPolicy.groupIds | nindent 6 }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -235,3 +235,9 @@ extraManifests: []
 #    spec:
 #      securityPolicy:
 #        name: "my-gcp-cloud-armor-policy"
+
+# Support for AWS Security groups for pods
+# Ref: https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html
+securityGroupPolicy:
+  enabled: false
+  groupIds: []


### PR DESCRIPTION
This change adds support for [AWS Security groups for pods](https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html). AWS SG for pods allows integrate Amazon EC2 security groups with Retool pods and define inbound and outbound network traffic rules.

See the [Introducing security groups for pods](https://aws.amazon.com/es/blogs/containers/introducing-security-groups-for-pods/) blog post for more information