### PR TITLE
Feat: Add support for sidecar containers

### DIFF
--- a/templates/deployment_backend.yaml
+++ b/templates/deployment_backend.yaml
@@ -186,6 +186,9 @@ spec:
           mountPath: {{ .mountPath }}
           subPath: {{ .subPath }}
 {{- end }}
+{{- if .Values.extraSidecarContainers.enabled }}
+{{ toYaml .Values.extraSidecarContainers.containers | indent 8 }}
+{{- end }}
     {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.image.pullSecrets | indent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -235,3 +235,29 @@ extraManifests: []
 #    spec:
 #      securityPolicy:
 #        name: "my-gcp-cloud-armor-policy"
+
+extraSidecarContainers:
+  enabled: false
+  containers: []
+  # containers:
+  #   - name: mySidecarContainer
+  #     image: "resourceAddress:version"
+  #     imagePullPolicy: IfNotPresent
+  #     resources:
+  #       limits:
+  #         cpu: 100m
+  #         memory: 128Mi
+  #       requests:
+  #         cpu: 100m
+  #         memory: 128Mi
+  #     env:
+  #       - name: POD_NAME
+  #         valueFrom:
+  #           fieldRef:
+  #             apiVersion: v1
+  #             fieldPath: metadata.name
+  #       - name: POD_NAMESPACE
+  #         valueFrom:
+  #           fieldRef:
+  #             apiVersion: v1
+  #             fieldPath: metadata.namespace 


### PR DESCRIPTION
This change adds support for loading [sidecar containers](https://medium.com/bb-tutorials-and-thoughts/kubernetes-learn-sidecar-container-pattern-6d8c21f873d) in the retool pod.