### PR TITLE
Allow more than one hostname for ingress

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.ingress.enabled }}
+{{- $fullName := include "retool.fullname" . -}}
+{{- $svcPort := .Values.service.externalPort -}}
+{{- $pathType := .Values.ingress.pathType -}}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
 {{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
@@ -20,25 +23,47 @@ metadata:
   name: {{ template "retool.fullname" . }}
 spec:
   rules:
-  - http:
-      paths:
-      - path: {{ .path }}
-        {{- if and .Values.ingress.pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-        pathType: {{ .Values.ingress.pathType }}
-        {{- end }}
-        backend:
-          {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-          service:
-            name: {{ template "retool.fullname" . }}
-            port: 
-              number: {{ .Values.service.externalPort }}
-          {{- else }}
-          serviceName: {{ template "retool.fullname" . }}
-          servicePort: {{ .Values.service.externalPort }}
+    {{- if .Values.ingress.hostName }}
+    - host: {{ .Values.ingress.hostName | quote }}
+      http:
+        paths:
+          - path:
+            {{- if and $pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ $pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+    {{- else }}
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and $pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ $pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
           {{- end }}
-{{- if .Values.ingress.hostName }}
-    host: {{ .Values.ingress.hostName | quote }}
-{{- end }}
+    {{- end }}
+    {{- end }}
 {{- if .Values.ingress.tls }}
   tls:
 {{ toYaml .Values.ingress.tls | indent 4 }}

--- a/values.yaml
+++ b/values.yaml
@@ -95,8 +95,10 @@ ingress:
   annotations: {}
   # kubernetes.io/ingress.class: nginx
   # kubernetes.io/tls-acme: "true"
-  # configures the hostname e.g. retool.example.com
-  hostName:
+  hosts:
+  # - host: retool.example.com
+  #   paths:
+  #     - path: /
   tls:
   # - secretName: retool.example.com
   #   hosts:


### PR DESCRIPTION
This also makes it possible to specify a path; currently setting a
path for the ingress is broken, as it uses `{{ .path }}`, which
appears to have been copied from the default ingress template (as
created by `helm init`) without the `range` that would make that
possible.