### PR TITLE
Allow for different annotations/labels for job runners and backend pods

### DIFF
--- a/templates/deployment_backend.yaml
+++ b/templates/deployment_backend.yaml
@@ -20,10 +20,16 @@ spec:
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
+{{- if .Values.backend.annotations }}
+{{ toYaml .Values.backend.annotations | indent 8 }}
+{{- end }}
       labels:
 {{- include "retool.selectorLabels" . | nindent 8 }}
 {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
+{{- if .Values.backend.labels }}
+{{ toYaml .Values.backend.labels | indent 8 }}
 {{- end }}
     spec:
       serviceAccountName: {{ template "retool.serviceAccountName" . }}

--- a/templates/deployment_jobs.yaml
+++ b/templates/deployment_jobs.yaml
@@ -22,11 +22,17 @@ spec:
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
+{{- if .Values.jobRunner.annotations }}
+{{ toYaml .Values.jobRunner.annotations | indent 8 }}
+{{- end }}
       labels:
         app.kubernetes.io/name: {{ include "retool.name" . }}-jobs-runner
         app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
+{{- if .Values.jobRunner.labels }}
+{{ toYaml .Values.jobRunner.labels | indent 8 }}
 {{- end }}
     spec:
       serviceAccountName: {{ template "retool.serviceAccountName" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -179,7 +179,9 @@ tolerations: []
 # Ref: https://kubernetes.io/docs/user-guide/node-selection/
 nodeSelector: {}
 
+# Common annotations for all pods (backend and job runner).
 podAnnotations: {}
+
 # Increasing replica count will deploy a separate pod for backend and jobs
 # Example: with 3 replicas, you will end up with 3 backends + 1 jobs pod
 replicaCount: 1
@@ -194,8 +196,22 @@ revisionHistoryLimit: 3
 # podDisruptionBudget:
 #   maxUnavailable: 1
 
-# Custom labels for pod assignment
+# Common labels for all pods (backend and job runner) for pod assignment
 podLabels: {}
+
+jobRunner:
+  # Annotations for job runner pods
+  annotations: {}
+
+  # Labels for job runner pods
+  labels: {}
+
+backend:
+  # Annotations for backendpods
+  annotations: {}
+
+  # Labels for backend pods
+  labels: {}
 
 persistentVolumeClaim:
   # set to true to use pvc


### PR DESCRIPTION
Our specific use case is to set up Datadog monitoring with annotations
on the backend pods, but not the job runners. (E.g., an HTTP probe
against the job runners isn't much use.)

This approach should be expanded to other things, like resources,
affinity/anti-affinity, etc.