### PR TITLE
fix ingress path value

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -22,7 +22,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: {{ .path }}
+      - path: {{ .Values.ingress.path }}
         {{- if and .Values.ingress.pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
         pathType: {{ .Values.ingress.pathType }}
         {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -102,6 +102,7 @@ ingress:
   #   hosts:
   #     - retool.example.com
   # servicePort: service-port
+  path: "/"
   pathType: ImplementationSpecific
 
 postgresql:


### PR DESCRIPTION
The ingress {{ .path }} template is invalid.  This PR fixes it and exposes an `ingress.path` value to correspond with it.  This addresses #41.