### PR TITLE
Add Values.extraEnvs

### DIFF
--- a/templates/deployment_backend.yaml
+++ b/templates/deployment_backend.yaml
@@ -145,6 +145,9 @@ spec:
                 name: {{ .secretKeyRef.name }}
                 key: {{ .secretKeyRef.key }}
           {{- end }}
+          {{- with .Values.extraEnvs }}
+          {{ toYaml . | indent 10 }}
+          {{- end }}
         {{- if .Values.externalSecrets.enabled }}
         envFrom:
         - secretRef:

--- a/templates/deployment_backend.yaml
+++ b/templates/deployment_backend.yaml
@@ -145,7 +145,7 @@ spec:
                 name: {{ .secretKeyRef.name }}
                 key: {{ .secretKeyRef.key }}
           {{- end }}
-          {{- with .Values.extraEnvs }}
+          {{- with .Values.environmentVariables }}
           {{ toYaml . | indent 10 }}
           {{- end }}
         {{- if .Values.externalSecrets.enabled }}

--- a/values.yaml
+++ b/values.yaml
@@ -65,7 +65,7 @@ environmentSecrets: []
 
 # Optionally specify environmental variables. Useful for variables that are not key-value, as env: {} above requires.
 # Can also include environment secrets here instead of in environmentSecrets
-extraEnvs: []
+environmentVariables: []
   #   - name: SCIM_AUTH_TOKEN
   #     valueFrom:
   #       secretKeyRef:
@@ -76,7 +76,7 @@ extraEnvs: []
   #       secretKeyRef:
   #         name: retool-github-app-private-key
   #         key: private-key
-  #   - name: NAME
+  #   - name: POD_HOST_IP
   #     valueFrom:
   #       fieldRef:
   #         fieldPath: status.hostIP

--- a/values.yaml
+++ b/values.yaml
@@ -63,6 +63,8 @@ environmentSecrets: []
   #     name: retool-github-app-private-key
   #     key: private-key
 
+extraEnvs: []
+
 # Enables support for the legacy external secrets (enabled) and the modern External Secrets Operator (externalSecretsOperator.enabled).
 # These are mutually exclusive as both enable reading in environments variables via External Secrets.
 externalSecrets:

--- a/values.yaml
+++ b/values.yaml
@@ -63,7 +63,23 @@ environmentSecrets: []
   #     name: retool-github-app-private-key
   #     key: private-key
 
+# Optionally specify environmental variables. Useful for variables that are not key-value, as env: {} above requires.
+# Can also include environment secrets here instead of in environmentSecrets
 extraEnvs: []
+  #   - name: SCIM_AUTH_TOKEN
+  #     valueFrom:
+  #       secretKeyRef:
+  #         name: retool-scim-auth-token
+  #         key: auth-token
+  #   - name: GITHUB_APP_PRIVATE_KEY
+  #     valueFrom:
+  #       secretKeyRef:
+  #         name: retool-github-app-private-key
+  #         key: private-key
+  #   - name: NAME
+  #     valueFrom:
+  #       fieldRef:
+  #         fieldPath: status.hostIP
 
 # Enables support for the legacy external secrets (enabled) and the modern External Secrets Operator (externalSecretsOperator.enabled).
 # These are mutually exclusive as both enable reading in environments variables via External Secrets.


### PR DESCRIPTION
Add support for env variables that aren't key-value with a new variable called `extraEnvs`. This will make the existing `env` and `environmentSecrets` redundant, but leaving them in so as not to break existing things. 