### PR TITLE
Fix fullnameOverride and externalSecrets.externalSecretsOperator.secretRef

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -1,5 +1,5 @@
 # nameOverride:
-# fullNameOverride:
+# fullnameOverride:
 
 config:
   licenseKey: "EXPIRED-LICENSE-KEY-TRIAL"
@@ -95,7 +95,7 @@ externalSecrets:
     # Default set to AWS Secrets Manager.
     backendType: secretsManager
     # Array of name/path key/value pairs to use for the External Secrets Objects.
-    secretRef: {}
+    secretRef: []
       # - name: retool-config
       #   path: global-retool-config
       # - name: retool-db


### PR DESCRIPTION
When implementing on-prem retool I noticed a couple of discrepancies in the values file.

1) fullNameOverride -> fullnameOverride 
2) externalSecrets.externalSecretsOperator.secretRef is defaulted to a map but the comment above specifies it's an array.  My local overrides also failed unless i corrected the values file to be a `[]` instead. Also the examples is an array of maps rather than a map.

