### PR TITLE
Fix indentation of environmentVariables

### DIFF
--- a/templates/deployment_backend.yaml
+++ b/templates/deployment_backend.yaml
@@ -146,7 +146,7 @@ spec:
                 key: {{ .secretKeyRef.key }}
           {{- end }}
           {{- with .Values.environmentVariables }}
-          {{ toYaml . | indent 10 }}
+{{ toYaml . | indent 10 }}
           {{- end }}
         {{- if .Values.externalSecrets.enabled }}
         envFrom:


### PR DESCRIPTION
When using environmentVariables, the template was being rendered like
this:
```yaml
          - name: CLIENT_SECRET
            valueFrom:
              secretKeyRef:
                name: retool
                key: google-client-secret
                    - name: asd
            value: asd
          - name: zxc
            valueFrom:
              fieldRef:
                fieldKey: asd
```

Notice how the indentation for 'asd' is wrong.