### PR TITLE
Additional comments for disabling postgres subchart

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -28,6 +28,8 @@ config:
   # jwtSecretSecretKey is the key in the k8s secret, default: jwt-secret
   # jwtSecretSecretKey:
 
+  # IMPORTANT: Incompatible with postgresql subchart
+  # Please disable the subchart in order to use a managed or external postgres instance.
   postgresql: {}
     # Specify if postgresql subchart is disabled
     # host:


### PR DESCRIPTION
Had some users recently run into deployment errors due to having the subchart enabled along-side the postgres config block. Adding some comments here to better guide users.