### PR TITLE
Retool helm chart reads the previous encryption key and jwt secret if…

### DIFF
--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -10,13 +10,17 @@ metadata:
     "helm.sh/resource-policy": no-upgrade-existing
 {{- end }}
 type: Opaque
+{{- $secretName := (include "retool.fullname" .) }}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace $secretName }}
 data:
   license-key: {{ .Values.config.licenseKey | default "" | b64enc | quote }}
 
   {{ if not .Values.config.jwtSecretSecretName }}
   {{ if .Values.config.jwtSecret }}
   jwt-secret: {{ .Values.config.jwtSecret | b64enc | quote }}
-  {{ else  }}
+  {{ else if and $secret (index $secret.data "jwt-secret") }}
+  jwt-secret: {{ index $secret.data "jwt-secret" }}
+  {{ else }}
   jwt-secret: {{ randAlphaNum 20 | b64enc | quote }}
   {{ end }}
   {{ end }}
@@ -24,7 +28,9 @@ data:
   {{ if not .Values.config.encryptionKeySecretName }}
   {{ if .Values.config.encryptionKey }}
   encryption-key: {{ .Values.config.encryptionKey | b64enc | quote }}
-  {{ else  }}
+  {{ else if and $secret (index $secret.data "encryption-key") }}
+  encryption-key: {{ index $secret.data "encryption-key" }}
+  {{ else }}
   encryption-key: {{ randAlphaNum 20 | b64enc | quote }}
   {{ end }}
   {{ end }}

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -31,7 +31,7 @@ data:
   {{ else if and $secret (index $secret.data "encryption-key") }}
   encryption-key: {{ index $secret.data "encryption-key" }}
   {{ else }}
-  encryption-key: {{ randAlphaNum 20 | b64enc | quote }}
+  encryption-key: {{ required "Please set a value for .Values.config.encryptionKey" .Values.config.encryptionKey }}
   {{ end }}
   {{ end }}
 


### PR DESCRIPTION
Reads from the existing autogenerated encryptionKey and jwtSecret if a specific place for them or new values for them aren't specified

to accomplish this, i'm using the lookup function which seems to be the community-agreed-on workaround: https://github.com/helm/helm/issues/3053

the syntax here was kind of confusing because i had to 
1) get the secret name to respect the template we were using
2) the names of the keys themselves were hyphenated and break with standard templating so i had to use 'include' to get around that
