### PR TITLE
Fix Helm Lint error by defaulting

### DIFF
--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -11,15 +11,16 @@ metadata:
 {{- end }}
 type: Opaque
 {{- $secretName := (include "retool.fullname" .) }}
-{{- $secret := lookup "v1" "Secret" .Release.Namespace $secretName }}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace $secretName | default dict }}
+{{- $secretData := (get $secret "data") | default dict }}
 data:
   license-key: {{ .Values.config.licenseKey | default "" | b64enc | quote }}
 
   {{ if not .Values.config.jwtSecretSecretName }}
   {{ if .Values.config.jwtSecret }}
   jwt-secret: {{ .Values.config.jwtSecret | b64enc | quote }}
-  {{ else if and $secret (index $secret.data "jwt-secret") }}
-  jwt-secret: {{ index $secret.data "jwt-secret" }}
+  {{ else if (get $secretData "jwt-secret") }}
+  jwt-secret: {{ (get $secretData "jwt-secret") }}
   {{ else }}
   jwt-secret: {{ randAlphaNum 20 | b64enc | quote }}
   {{ end }}
@@ -28,8 +29,8 @@ data:
   {{ if not .Values.config.encryptionKeySecretName }}
   {{ if .Values.config.encryptionKey }}
   encryption-key: {{ .Values.config.encryptionKey | b64enc | quote }}
-  {{ else if and $secret (index $secret.data "encryption-key") }}
-  encryption-key: {{ index $secret.data "encryption-key" }}
+  {{ else if (get $secretData "encryption-key") }}
+  encryption-key: {{ get $secretData "encryption-key" }}
   {{ else }}
   encryption-key: {{ required "Please set a value for .Values.config.encryptionKey" .Values.config.encryptionKey }}
   {{ end }}


### PR DESCRIPTION
# Issue
```
==> Linting helm/charts/retool-4.11.5.tgz
[INFO] Chart.yaml: icon is recommended
[ERROR] templates/: template: retool/templates/secret.yaml:21:26: executing "retool/templates/secret.yaml" at <index $secret.data "jwt-secret">: error calling index: index of untyped nil
```

# Fix
If `$secret` is not defined fallback to using a `default dict`

# Resource
https://itnext.io/manage-auto-generated-secrets-in-your-helm-charts-5aee48ba6918

# Now - Expected pass ✅
`helm lint`
```
engine.go:159: [INFO] Missing required value: Please set a value for .Values.config.encryptionKey
engine.go:167: [INFO] Missing required value: Please set a value for .Values.image.tag
==> Linting .
[INFO] Chart.yaml: icon is recommended
[WARNING] /Users/ajunpreetbambrah/code/retool-helm: chart directory is missing these dependencies: postgresql

1 chart(s) linted, 0 chart(s) failed
```