### PR TITLE
Include DB_SSH_CONNECTOR when we scale up replica counts

### DIFF
--- a/templates/deployment_backend.yaml
+++ b/templates/deployment_backend.yaml
@@ -59,7 +59,7 @@ spec:
             value: production
           {{- if gt (int (toString (.Values.replicaCount))) 1 }}
           - name: SERVICE_TYPE
-            value: MAIN_BACKEND,DB_CONNECTOR
+            value: MAIN_BACKEND,DB_CONNECTOR,DB_SSH_CONNECTOR
           {{- end }}
           - name: CLIENT_ID
             value: {{ default "" .Values.config.auth.google.clientId }}


### PR DESCRIPTION
seems like our intention when we increase replica count is just to split out the jobs runner container, meaning we have to specify SERVICE_TYPES explicitly.

looks like we were never specifying the one for the ssh dbconnector, meaning on multi-replica deployments, it'll always be turned off lmao