### PR TITLE
[DTC-3268] codify the resource request for jobs runner and make it a separate pod by default

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -197,17 +197,17 @@ extraVolumeMounts: []
 
 extraVolumes: []
 
-resources: {}
+resources:
   # If you have more than 1 replica, the minimum recommended resources configuration is as follows:
   # - cpu: 2048m
   # - memory: 4096Mi
   # If you only have 1 replica, please double the above numbers.
-  # limits:
-  #   cpu: 4096m
-  #   memory: 8192Mi
-  # requests:
-  #   cpu: 2048m
-  #   memory: 4096Mi
+  limits:
+    cpu: 4096m
+    memory: 8192Mi
+  requests:
+    cpu: 2048m
+    memory: 4096Mi
 
 priorityClassName: ""
 
@@ -228,7 +228,7 @@ podAnnotations: {}
 
 # Increasing replica count will deploy a separate pod for backend and jobs
 # Example: with 3 replicas, you will end up with 3 backends + 1 jobs pod
-replicaCount: 1
+replicaCount: 2
 revisionHistoryLimit: 3
 
 # Optional pod disruption budget, for ensuring higher availability of the


### PR DESCRIPTION
1. It could avoid customers setting low resources without checking our recommendation
2. Separate jobs runner pod by default would make it easier for the liveness detection https://github.com/tryretool/retool_development/pull/18728 