### PR TITLE
[feat][DTC-3385] add liveness probe for standalone jobs runner

### DIFF
--- a/templates/deployment_jobs.yaml
+++ b/templates/deployment_jobs.yaml
@@ -163,6 +163,15 @@ spec:
         {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+        {{- if and (regexMatch "^[.0-9]+$" .Values.image.tag) (semverCompare ">=2.110.0" .Values.image.tag) }}
+        livenessProbe:
+          httpGet:
+            path: /api/checkJobsRunnerHealth
+            port: 3003
+          initialDelaySeconds: 120
+          periodSeconds: 30
+          timeoutSeconds: 3
+        {{- end }}
         volumeMounts:
         {{- range $configFile := (keys .Values.files) }}
         - name: {{ template "retool.name" $ }}


### PR DESCRIPTION
This follows up on https://github.com/tryretool/retool_development/pull/18728 and makes the new liveness probe we developed public facing. The new probe will be by default enabled for all releases 2.110+ (the first release to contain the probe code).

The probe has been functioning in our garden environments for the past month, so we have pretty high confidence that it works.

I'm not sure how our helm charts are tested here, but helm lint didn't complain 🤷 . 