### PR TITLE
new major version including fixes for postgresql 12.1.5

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 4.12.1
+version: 5.0.0
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -104,7 +104,7 @@ Set postgresql db
 */}}
 {{- define "retool.postgresql.db" -}}
 {{- if .Values.postgresql.enabled -}}
-{{- .Values.postgresql.postgresqlDatabase | quote -}}
+{{- .Values.postgresql.auth.database | quote -}}
 {{- else -}}
 {{- .Values.config.postgresql.db | quote -}}
 {{- end -}}
@@ -115,7 +115,7 @@ Set postgresql user
 */}}
 {{- define "retool.postgresql.user" -}}
 {{- if .Values.postgresql.enabled -}}
-{{- .Values.postgresql.postgresqlUsername | quote -}}
+{{- .Values.postgresql.auth.username | quote -}}
 {{- else -}}
 {{- .Values.config.postgresql.user | quote -}}
 {{- end -}}

--- a/templates/deployment_backend.yaml
+++ b/templates/deployment_backend.yaml
@@ -117,10 +117,10 @@ spec:
           {{- else }}
                 {{- if .Values.config.postgresql.passwordSecretName }}
                 name: {{ .Values.config.postgresql.passwordSecretName }}
-                key: {{ .Values.config.postgresql.passwordSecretKey | default "postgres-password" }}
+                key: {{ .Values.config.postgresql.passwordSecretKey | default "postgresql-password" }}
                 {{- else }}
                 name: {{ template "retool.fullname" . }}
-                key: postgres-password
+                key: postgresql-password
                 {{- end }}
           {{- end }}
           - name: CLIENT_SECRET

--- a/templates/deployment_backend.yaml
+++ b/templates/deployment_backend.yaml
@@ -113,14 +113,14 @@ spec:
               secretKeyRef:
           {{- if  .Values.postgresql.enabled }}
                 name: {{ template "retool.postgresql.fullname" . }}
-                key: postgresql-password
+                key: postgres-password
           {{- else }}
                 {{- if .Values.config.postgresql.passwordSecretName }}
                 name: {{ .Values.config.postgresql.passwordSecretName }}
-                key: {{ .Values.config.postgresql.passwordSecretKey | default "postgresql-password" }}
+                key: {{ .Values.config.postgresql.passwordSecretKey | default "postgres-password" }}
                 {{- else }}
                 name: {{ template "retool.fullname" . }}
-                key: postgresql-password
+                key: postgres-password
                 {{- end }}
           {{- end }}
           - name: CLIENT_SECRET

--- a/templates/deployment_jobs.yaml
+++ b/templates/deployment_jobs.yaml
@@ -114,14 +114,14 @@ spec:
               secretKeyRef:
           {{- if  .Values.postgresql.enabled }}
                 name: {{ template "retool.postgresql.fullname" . }}
-                key: postgresql-password
+                key: postgres-password
           {{- else }}
                 {{- if .Values.config.postgresql.passwordSecretName }}
                 name: {{ .Values.config.postgresql.passwordSecretName }}
                 key: {{ .Values.config.postgresql.passwordSecretKey | default "postgresql-password" }}
                 {{- else }}
                 name: {{ template "retool.fullname" . }}
-                key: postgresql-password
+                key: postgres-password
                 {{- end }}
           {{- end }}
           - name: CLIENT_SECRET

--- a/templates/deployment_jobs.yaml
+++ b/templates/deployment_jobs.yaml
@@ -121,7 +121,7 @@ spec:
                 key: {{ .Values.config.postgresql.passwordSecretKey | default "postgresql-password" }}
                 {{- else }}
                 name: {{ template "retool.fullname" . }}
-                key: postgres-password
+                key: postgresql-password
                 {{- end }}
           {{- end }}
           - name: CLIENT_SECRET

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -43,6 +43,6 @@ data:
   {{ end }}
 
   {{ if not .Values.postgresql.enabled }}
-  postgres-password: {{ .Values.config.postgresql.auth.password | default "" | b64enc | quote }}
+  postgresql-password: {{ .Values.config.postgresql.password | default "" | b64enc | quote }}
   {{ end }}
 {{- end }}

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -43,6 +43,6 @@ data:
   {{ end }}
 
   {{ if not .Values.postgresql.enabled }}
-  postgresql-password: {{ .Values.config.postgresql.password | default "" | b64enc | quote }}
+  postgres-password: {{ .Values.config.postgresql.auth.password | default "" | b64enc | quote }}
   {{ end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -153,20 +153,21 @@ postgresql:
   auth:
     database: hammerhead_production
     username: retool
-    password: retool
+    postgresPassword: retool
   service:
     port: 5432
   # Use the offical docker image rather than bitnami/docker
   # since Retool depends on the uuid-ossp extension
   image:
     repository: "postgres"
-    # 10.6 is a default, please use 13.4+
+    # 11 is a default, please use 13.4+
     # see https://www.postgresql.org/support/versioning/
-    tag: "10.6"
+    tag: "11"
   postgresqlDataDir: "/data/pgdata"
-  persistence:
-    enabled: true
-    mountPath: "/data/"
+  primary:
+    persistence:
+      enabled: true
+      mountPath: "/data/"
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/values.yaml
+++ b/values.yaml
@@ -40,7 +40,7 @@ config:
     # ssl_enabled:
     # passwordSecretName is the name of the secret where the pg password is stored (can be used instead of password)
     # passwordSecretName:
-    # passwordSecretKey is the key in the k8s secret, default: postgresql-password
+    # passwordSecretKey is the key in the k8s secret, default: postgres-password
     # passwordSecretKey:
 
 image:
@@ -150,9 +150,10 @@ postgresql:
   # or self-host more permanantly. Use enabled: false and set in config above to do so.
   enabled: true
   ssl_enabled: false
-  postgresqlDatabase: hammerhead_production
-  postgresqlUsername: retool
-  postgresqlPassword: retool
+  auth:
+    database: hammerhead_production
+    username: retool
+    password: retool
   service:
     port: 5432
   # Use the offical docker image rather than bitnami/docker

--- a/values.yaml
+++ b/values.yaml
@@ -40,7 +40,7 @@ config:
     # ssl_enabled:
     # passwordSecretName is the name of the secret where the pg password is stored (can be used instead of password)
     # passwordSecretName:
-    # passwordSecretKey is the key in the k8s secret, default: postgres-password
+    # passwordSecretKey is the key in the k8s secret, default: postgresql-password
     # passwordSecretKey:
 
 image:


### PR DESCRIPTION
- our current chart isn't super compatible with bitnami postgresql 12/1/5 (11.0 and higher) as there are breaking changes to how the auth data (database name, username, and password) is named and referenced (now nested under auth map with new field names)
- this changes the values template to match this new structure and also the references to it in our deployments