### PR TITLE
Implement PVC 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 charts
+.prettierignore

--- a/templates/deployment_backend.yaml
+++ b/templates/deployment_backend.yaml
@@ -191,6 +191,10 @@ spec:
           mountPath: "/usr/share/retool/config/{{ $configFile }}"
           subPath: {{ $configFile }}
         {{- end }}
+        {{if and .Values.persistentVolumeClaim.enabled .Values.persistentVolumeClaim.mountPath }}
+        - name: retool-pv
+          mountPath: {{ .Values.persistentVolumeClaim.mountPath }}
+        {{- end }}
 {{- if .Values.extraVolumeMounts }}
 {{ toYaml .Values.extraVolumeMounts | indent 8 }}
 {{- end }}
@@ -227,6 +231,11 @@ spec:
           configMap:
             name: {{ .configMap }}
 {{- end }}
+        {{- if .Values.persistentVolumeClaim.enabled }}
+        - name: retool-pv
+          persistentVolumeClaim:
+            claimName: {{ default (include "retool.fullname" .) .Values.persistentVolumeClaim.existingClaim }}
+        {{- end }}
 {{- if .Values.extraVolumes }}
 {{ toYaml .Values.extraVolumes | indent 8 }}
 {{- end }}

--- a/templates/deployment_jobs.yaml
+++ b/templates/deployment_jobs.yaml
@@ -178,6 +178,10 @@ spec:
           mountPath: "/usr/share/retool/config/{{ $configFile }}"
           subPath: {{ $configFile }}
         {{- end }}
+        {{if and .Values.persistentVolumeClaim.enabled .Values.persistentVolumeClaim.mountPath }}
+        - name: retool-pv
+          mountPath: {{ .Values.persistentVolumeClaim.mountPath }}
+        {{- end }}
 {{- if .Values.extraVolumeMounts }}
 {{ toYaml .Values.extraVolumeMounts | indent 8 }}
 {{- end }}
@@ -214,6 +218,11 @@ spec:
           configMap:
             name: {{ .configMap }}
 {{- end }}
+      {{- if .Values.persistentVolumeClaim.enabled }}
+        - name: retool-pv
+          persistentVolumeClaim:
+            claimName: {{ default (include "retool.fullname" .) .Values.persistentVolumeClaim.existingClaim }}
+      {{- end }}
 {{- if .Values.extraVolumes }}
 {{ toYaml .Values.extraVolumes | indent 8 }}
 {{- end }}

--- a/templates/pvc.yaml
+++ b/templates/pvc.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.persistentVolumeClaim.enabled (not .Values.persistentVolumeClaim.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "retool.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{- if .Values.persistentVolumeClaim.annotations }}
+  annotations:
+{{ toYaml .Values.persistentVolumeClaim.annotations | indent 4 }}
+{{- end }}
+spec:
+  {{- if .Values.persistentVolumeClaim.storageClass }}
+  {{- if (eq "-" .Values.persistentVolumeClaim.storageClass) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: "{{ .Values.persistentVolumeClaim.storageClass }}"
+{{- end }}
+{{- end }}
+  {{- if not (empty .Values.persistentVolumeClaim.accessModes) }}
+  accessModes:
+  {{- range .Values.persistentVolumeClaim.accessModes }}
+    - {{ . | quote }}
+  {{- end }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistentVolumeClaim.size | quote  }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -262,10 +262,9 @@ backend:
 persistentVolumeClaim:
   # set to true to use pvc
   enabled: false
-  # set to true to use you own pvc
-  existingClaim: false
+  # set to the name of the existing pvc
+  existingClaim: ""
   annotations: {}
-
   accessModes:
     - ReadWriteOnce
   size: "15Gi"
@@ -275,7 +274,8 @@ persistentVolumeClaim:
   ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
   ##   GKE, AWS & OpenStack)
   ##
-  # storageClass: "-"
+  storageClass: ""
+  mountPath: /retool_backend/pv-data
 
 # default security context
 securityContext:


### PR DESCRIPTION
Values.persistentVolumeClaim was previously unused. This adds the ability to create or use an existing PVC and mount it to the Retool deployments. This will hopefully make it more straightforward for teams to mount volumes for protos, certs, etc. 