### PR TITLE
update default postgres credentials

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -152,8 +152,8 @@ postgresql:
   ssl_enabled: false
   auth:
     database: hammerhead_production
-    username: retool
-    password: retool
+    username: postgres
+    postgresPassword: retool
   service:
     port: 5432
   # Use the offical docker image rather than bitnami/docker


### PR DESCRIPTION
This pg subchart currently doesn't work with the default credentials. The subchart exposes secret keys postgres-password (for root user) and password (for non-root user), and our [deployment templates](https://github.com/tryretool/retool-helm/blob/main/templates/deployment_backend.yaml#L114) currently consumes the root user password. This change switches the user retool uses to be the root pg user, and explicitly sets the root password instead of having it randomly generated. 

Alternatively, we could change the template to consume the non-root user password but this seems less invasive. 