### PR TITLE
rename postgres secret to postgresql-password

### DIFF
--- a/templates/deployment_backend.yaml
+++ b/templates/deployment_backend.yaml
@@ -113,7 +113,7 @@ spec:
               secretKeyRef:
           {{- if  .Values.postgresql.enabled }}
                 name: {{ template "retool.postgresql.fullname" . }}
-                key: postgres-password
+                key: postgresql-password
           {{- else }}
                 {{- if .Values.config.postgresql.passwordSecretName }}
                 name: {{ .Values.config.postgresql.passwordSecretName }}

--- a/templates/deployment_jobs.yaml
+++ b/templates/deployment_jobs.yaml
@@ -114,7 +114,7 @@ spec:
               secretKeyRef:
           {{- if  .Values.postgresql.enabled }}
                 name: {{ template "retool.postgresql.fullname" . }}
-                key: postgres-password
+                key: postgresql-password
           {{- else }}
                 {{- if .Values.config.postgresql.passwordSecretName }}
                 name: {{ .Values.config.postgresql.passwordSecretName }}


### PR DESCRIPTION
bitnami creates the postgres secret as `postgresql-password`, this is currently breaking if you're trying to use the postgresql statefulset