### PR TITLE
Support EKS

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -2,9 +2,9 @@
 {{- $fullName := include "retool.fullname" . -}}
 {{- $svcPort := .Values.service.externalPort -}}
 {{- $pathType := .Values.ingress.pathType -}}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.Version -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.Version -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -22,7 +22,7 @@ metadata:
 {{- end }}
   name: {{ template "retool.fullname" . }}
 spec:
-  {{- if and .Values.ingress.ingressClassName (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+  {{- if and .Values.ingress.ingressClassName (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.Version) }}
   ingressClassName: {{ .Values.ingress.ingressClassName }}
   {{- end }}
   rules:
@@ -31,11 +31,11 @@ spec:
       http:
         paths:
           - path:
-            {{- if and $pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            {{- if and $pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.Version) }}
             pathType: {{ $pathType }}
             {{- end }}
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.Version }}
               service:
                 name: {{ $fullName }}
                 port:


### PR DESCRIPTION
use `.Capabilities.KubeVersion.Version` instead of `.Capabilities.KubeVersion.GitVersion`
in order to support EKS flavored k8s cluster.

Tested all conditions locally via:
```
helm template ./  --version 5.0.3 --namespace retool --set config.encryptionKey="abc" --set image.tag=2.110.3 --kube-version "v1.13.16-eks-48e63afoobar"
helm template ./  --version 5.0.3 --namespace retool --set config.encryptionKey="abc" --set image.tag=2.110.3 --kube-version "v1.15.16-eks-48e63afoobar"
helm template ./  --version 5.0.3 --namespace retool --set config.encryptionKey="abc" --set image.tag=2.110.3 --kube-version "v1.19.16-eks-48e63afoobar"
```

and successfully deployed on EKS 1.23 using packaged helm chart (via flux) from my main branch (modified for auto-release via github actions)
https://asaf400.github.io/retool-helm/index.yaml
https://github.com/asaf400/retool-helm