### PR TITLE
make the values file actually compatible with postgresl 12.1.5

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -153,7 +153,7 @@ postgresql:
   auth:
     database: hammerhead_production
     username: postgres
-    postgresPassword: retool
+    password: retool
   service:
     port: 5432
   # Use the offical docker image rather than bitnami/docker
@@ -164,10 +164,9 @@ postgresql:
     # see https://www.postgresql.org/support/versioning/
     tag: "11"
   postgresqlDataDir: "/data/pgdata"
-  primary:
-    persistence:
-      enabled: true
-      mountPath: "/data/"
+  persistence:
+    enabled: true
+    mountPath: "/data/"
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
it turns out when we packaged the last few versions we didn't update the dependencies first and so changed the values file variables with an outdated postgresql chart. This aligns the values file with the actual values for 12.1.5 :) 