### PR TITLE
Add startupProbe to backend deployment

### DIFF
--- a/templates/deployment_backend.yaml
+++ b/templates/deployment_backend.yaml
@@ -183,6 +183,16 @@ spec:
           successThreshold: {{ .Values.readinessProbe.successThreshold }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
 {{- end }}
+{{- if .Values.startupProbe.enabled }}
+        startupProbe:
+          httpGet:
+            path: {{ .Values.startupProbe.path }}
+            port: {{ .Values.service.internalPort }}
+          initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.startupProbe.successThreshold }}
+          periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+{{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:

--- a/values.yaml
+++ b/values.yaml
@@ -192,6 +192,15 @@ readinessProbe:
   periodSeconds: 10
   successThreshold: 5
 
+# To avoid increasing livenessProbe initialDelaySeconds the good practice is to use a startupProbe.
+startupProbe:
+  enabled: false
+  path: /api/checkHealth
+  initialDelaySeconds: 60
+  timeoutSeconds: 10
+  periodSeconds: 10
+  successThreshold: 5
+
 extraContainers: []
 
 extraVolumeMounts: []


### PR DESCRIPTION
Following [this conversation](https://github.com/tryretool/retool-helm/issues/91), it would be good to have `startupProbe` configuration on the backend deployment to avoid increasing `initialDelaySeconds` on the `livenessProbe` too much, that will defeat the purpose of `livenessProbes`. Following the [recommended practice](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes) from kubernetes for slow starting containers.