### PR TITLE
update postgresql container to use 13 and update persistence field

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -164,9 +164,10 @@ postgresql:
     # see https://www.postgresql.org/support/versioning/
     tag: "11"
   postgresqlDataDir: "/data/pgdata"
-  persistence:
-    enabled: true
-    mountPath: "/data/"
+  primary: 
+    persistence:
+      enabled: true
+      mountPath: "/data/"
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/values.yaml
+++ b/values.yaml
@@ -160,9 +160,7 @@ postgresql:
   # since Retool depends on the uuid-ossp extension
   image:
     repository: "postgres"
-    # 11 is a default, please use 13.4+
-    # see https://www.postgresql.org/support/versioning/
-    tag: "11"
+    tag: "13"
   postgresqlDataDir: "/data/pgdata"
   primary: 
     persistence:


### PR DESCRIPTION
update the default postgresql container to use v13, also sets the primary key which is required now