### PR TITLE
do not create secrets if loaded from file

### DIFF
--- a/charts/retool/templates/secret.yaml
+++ b/charts/retool/templates/secret.yaml
@@ -14,8 +14,12 @@ type: Opaque
 {{- $secret := lookup "v1" "Secret" .Release.Namespace $secretName | default dict }}
 {{- $secretData := (get $secret "data") | default dict }}
 data:
+  {{ if (and .Values.env.RETOOL_LOAD_FILE_SECRETS .Values.env.LICENSE_KEY_FILE) }}
   license-key: {{ .Values.config.licenseKey | default "" | b64enc | quote }}
+  {{ end }}
 
+
+  {{ if not (and .Values.env.RETOOL_LOAD_FILE_SECRETS .Values.env.JWT_SECRET_FILE) }}
   {{ if not .Values.config.jwtSecretSecretName }}
   {{ if .Values.config.jwtSecret }}
   jwt-secret: {{ .Values.config.jwtSecret | b64enc | quote }}
@@ -25,7 +29,9 @@ data:
   jwt-secret: {{ randAlphaNum 20 | b64enc | quote }}
   {{ end }}
   {{ end }}
+  {{ end }}
 
+  {{ if not (and .Values.env.RETOOL_LOAD_FILE_SECRETS .Values.env.ENCRYPTION_KEY_FILE) }}
   {{ if not .Values.config.encryptionKeySecretName }}
   {{ if .Values.config.encryptionKey }}
   encryption-key: {{ .Values.config.encryptionKey | b64enc | quote }}
@@ -35,14 +41,19 @@ data:
   encryption-key: {{ required "Please set a value for .Values.config.encryptionKey" .Values.config.encryptionKey }}
   {{ end }}
   {{ end }}
+  {{ end }}
 
+  {{ if not (and .Values.env.RETOOL_LOAD_FILE_SECRETS .Values.env.GOOGLE_CLIENT_SECRET_FILE) }}
   {{ if .Values.config.auth.google.clientSecret }}
   google-client-secret: {{ .Values.config.auth.google.clientSecret | b64enc | quote }}
   {{ else  }}
   google-client-secret: ""
   {{ end }}
+  {{ end }}
 
   {{ if not .Values.postgresql.enabled }}
+  {{ if not (and .Values.env.RETOOL_LOAD_FILE_SECRETS .Values.env.POSTGRES_PASSWORD_FILE) }}
   postgresql-password: {{ .Values.config.postgresql.password | default "" | b64enc | quote }}
+  {{ end }}
   {{ end }}
 {{- end }}


### PR DESCRIPTION
If `RETOOL_LOAD_FILE_SECRETS` is `true`, and the associated secret file is defined, do not create the related secret.