### PR TITLE
use the correct password for the postgresql subchart based on username

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 5.0.9
+version: 5.0.10
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/NOTES.txt
+++ b/charts/retool/templates/NOTES.txt
@@ -20,3 +20,13 @@
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
 {{- end }}
+
+{{- if and .Values.postgresql.enabled (and (not .Values.postgresql.auth.postgresPassword) (eq .Values.postgresql.auth.username "postgres")) }}
+***************************************************************************
+Warning: Using in-cluster postgresql setup. `.Values.postgresql.auth.username username` is set to the default admin username "postgres", but the admin password field `.Values.postgresql.auth.postgresPassword` is not set, so a random password is generated and used. This wouldn't affect your usage, but if you choose to uninstall and reinstall this helm chart, please make sure you remove the existing PersistentVolumeClaim backing the in-cluster postgresql by running:
+  kubectl --namespace {{ .Release.Namespace }} delete pvc/data-{{ include "retool.fullname" . }}-postgresql-0
+Alternatively, you can fetch the randomly generated password and set the value in `.Values.postgresql.auth.postgresPassword` to make sure it never changes unexpectedly:
+  echo $(kubectl --namespace {{ .Release.Namespace }} get secret/{{ include "retool.fullname" . }}-postgresql -o jsonpath='{.data.postgres-password}' | base64 -d)
+We highly recommend you do NOT use this subchart as is to run Postgres in a container for your production instance of Retool. It is only suitable for proof-of-concepts. Please use a managed Postgres, or self-host more permanantly.
+***************************************************************************
+{{- end }} 

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -113,7 +113,13 @@ spec:
               secretKeyRef:
           {{- if  .Values.postgresql.enabled }}
                 name: {{ template "retool.postgresql.fullname" . }}
+                # `postgres` is the default admin username for postgres in the subchart we use, so it needs the admin password
+                # if a different username is picked, then it needs the custom password instead.
+                {{- if eq .Values.postgresql.auth.username "postgres" }}
                 key: postgres-password
+                {{- else }}
+                key: password
+                {{- end }}
           {{- else }}
                 {{- if .Values.config.postgresql.passwordSecretName }}
                 name: {{ .Values.config.postgresql.passwordSecretName }}

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -154,6 +154,9 @@ postgresql:
     database: hammerhead_production
     username: postgres
     password: retool
+    # Uncomment this if setting `username` to `postgres`. If this field is not set, a random password
+    # will be generated and used. And you might run into password mismatch issues when re-installing the chart.
+    # postgresPassword: retool
   service:
     port: 5432
   # Use the offical docker image rather than bitnami/docker

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -154,8 +154,7 @@ postgresql:
     database: hammerhead_production
     username: postgres
     password: retool
-    # Uncomment this if setting `username` to `postgres`. If this field is not set, a random password
-    # will be generated and used. And you might run into password mismatch issues when re-installing the chart.
+    # IMPORTANT: When setting username to `postgres` a random password will be generated unless the postgresPassword field is uncommented
     # postgresPassword: retool
   service:
     port: 5432

--- a/values.yaml
+++ b/values.yaml
@@ -154,6 +154,9 @@ postgresql:
     database: hammerhead_production
     username: postgres
     password: retool
+    # Uncomment this if setting `username` to `postgres`. If this field is not set, a random password
+    # will be generated and used. And you might run into password mismatch issues when re-installing the chart.
+    # postgresPassword: retool
   service:
     port: 5432
   # Use the offical docker image rather than bitnami/docker

--- a/values.yaml
+++ b/values.yaml
@@ -154,8 +154,7 @@ postgresql:
     database: hammerhead_production
     username: postgres
     password: retool
-    # Uncomment this if setting `username` to `postgres`. If this field is not set, a random password
-    # will be generated and used. And you might run into password mismatch issues when re-installing the chart.
+    # IMPORTANT: When setting username to `postgres` a random password will be generated unless the postgresPassword field is uncommented
     # postgresPassword: retool
   service:
     port: 5432


### PR DESCRIPTION
Right now, by default, we have these values:
```
postgresql:
  # We highly recommend you do NOT use this subchart as is to run Postgres in a container
  # for your production instance of Retool; it is a default. Please use a managed Postgres,
  # or self-host more permanantly. Use enabled: false and set in config above to do so.
  enabled: true
  ssl_enabled: false
  auth:
    database: hammerhead_production
    username: postgres
    password: retool
```
`postgres` happens to be the username of the default admin user in the postgresql subchart, which means it needs the admin password `postgresPassword`. These defaults would work out of the box because retool will be initiated with the user `postgres` and the auto-generated admin password `postgresPassword` which we did not specify here.

however, if the user changes username to anything else other than `postgres`, the install would break unless the user sets a `postgresPassword` field that has the same value as the password field. This is because we only pass the value of `postgresPassword` to retool regardless of whether password is set, but by specifying a custom user that is not `postgres`, the pg subchart actually expects `password` to be used for the custom user, not `postgresPassword`.

This fixes this case by checking whether username == "postgres", if true, we’d use `postgresPassword` , otherwise we use `password`. Also added some comments to warn people about this situation

We can't just add a new default for `postgresPassword` because that would break anyone who has installed the chart with the username `postgres` but not have `postgresPassword` set by changing the password for them.

I tested:
1. pg username postgres , postgresPassword is used (pic1):
  a. new installation works
  b. upgrading to this new chart version doesn’t change anything
2. pg username retool , password is used (pic2)
  a. new installation works
  b. upgrading to this new chart version changes the secret key from postgres-password to password which doesn’t break anything - if anyone has username set to anything other than postgres right now, the only way they could’ve made it work is to set `postgresPassword to be the same value as password, so changing the secret reference doesnt change anything

pic1:
![image](https://github.com/tryretool/retool-helm/assets/7955711/51a638fa-0bce-4f15-9969-58f1fd056fec)
pic2:
![image](https://github.com/tryretool/retool-helm/assets/7955711/2447f2ed-c70e-4573-a134-5940e7f7ff23)
