### PR TITLE
Add allowPrivilegeEscalation to the securityContexts

### DIFF
--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -241,6 +241,7 @@ spec:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
         allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
 {{- end }}
       volumes:
 {{- range .Values.extraConfigMapMounts }}

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -240,6 +240,7 @@ spec:
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
+        allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
 {{- end }}
       volumes:
 {{- range .Values.extraConfigMapMounts }}

--- a/charts/retool/templates/deployment_jobs.yaml
+++ b/charts/retool/templates/deployment_jobs.yaml
@@ -213,6 +213,7 @@ spec:
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
+        allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
 {{- end }}
       volumes:
 {{- range .Values.extraConfigMapMounts }}

--- a/charts/retool/templates/deployment_jobs.yaml
+++ b/charts/retool/templates/deployment_jobs.yaml
@@ -214,6 +214,7 @@ spec:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
         allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
 {{- end }}
       volumes:
 {{- range .Values.extraConfigMapMounts }}

--- a/values.yaml
+++ b/values.yaml
@@ -303,6 +303,7 @@ securityContext:
   allowPrivilegeEscalation: false
   runAsUser: 1000
   fsGroup: 2000
+  runAsNonRoot: false
 
 extraConfigMapMounts: []
 


### PR DESCRIPTION
It's mentioned in `values.yaml` but not actually reflected in the code,
but enable configuring the PodSecurity policy option for
`allowPrivilegeEscalation` to the chart.
