### PR TITLE
require 3.6.11 to automatically spin up workflow services (worker, backend)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ charts/**/*.tgz
 .prettierignore
 
 kubeconform
+
+.DS_Store

--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.0.1
+version: 6.0.2
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -132,20 +132,20 @@ Usage: (include "retool.workflows.enabled" .)
 {{- if or (eq .Values.workflows.enabled true) (eq .Values.workflows.enabled false) -}}
   {{- if eq .Values.workflows.enabled true -}}
     {{- $output = "1" -}}
-  {{- else }}
+  {{- else -}}
     {{- $output = "" -}}
   {{- end -}}
-{{- else if empty .Values.image.tag }}
+{{- else if empty .Values.image.tag -}}
   {{- $output = "" -}}
-{{- else if eq .Values.image.tag "latest" }}
+{{- else if eq .Values.image.tag "latest" -}}
   {{- $output = "1" -}}
-{{- else if semverCompare ">= 3.6.11" .Values.image.tag }}
+{{- else if semverCompare ">= 3.6.11" .Values.image.tag -}}
   {{- $output = "1" -}}
-{{- else }}
+{{- else -}}
   {{- $output = "" -}}
-{{- end }}
-{{ $output }}
-{{- end }}
+{{- end -}}
+{{- $output -}}
+{{- end -}}
 
 {{/*
 Set Temporal frontend host

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -124,6 +124,29 @@ Set postgresql user
 {{- end -}}
 
 {{/*
+Set Workflows enabled
+*/}}
+{{- define "retool.workflows.enabled" -}}
+{{- if or (.Values.workflows.enabled true) (eq .Values.workflows.enabled false) -}}
+  {{- .Values.workflows.enabled | default false }}
+{{- else }}
+  {{- semverCompare ">= 3.6.11" .Values.image.tag }}
+{{- end }}
+{{- end }}
+
+{{/*
+Custom template function to cast a string to a boolean.
+Usage: {{ toBool .SomeString }}
+*/}}
+{{- define "strToBool" -}}
+    {{- $output := "" -}}
+    {{- if (eq . "true") -}}
+        {{- $output = "1" -}}
+    {{- end -}}
+    {{ $output }}
+{{- end -}}
+
+{{/*
 Set Temporal frontend host
 */}}
 {{- define "retool.temporal.host" -}}

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -127,7 +127,7 @@ Set postgresql user
 Set Workflows enabled
 */}}
 {{- define "retool.workflows.enabled" -}}
-{{- if or (.Values.workflows.enabled true) (eq .Values.workflows.enabled false) -}}
+{{- if or (eq .Values.workflows.enabled true) (eq .Values.workflows.enabled false) -}}
   {{- .Values.workflows.enabled | default false }}
 {{- else }}
   {{- semverCompare ">= 3.6.11" .Values.image.tag }}

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -125,30 +125,27 @@ Set postgresql user
 
 {{/*
 Set Workflows enabled
+Usage: (include "retool.workflows.enabled" .)
 */}}
 {{- define "retool.workflows.enabled" -}}
+{{- $output := "" -}}
 {{- if or (eq .Values.workflows.enabled true) (eq .Values.workflows.enabled false) -}}
-  {{- .Values.workflows.enabled | default false }}
+  {{- if eq .Values.workflows.enabled true -}}
+    {{- $output = "1" -}}
+  {{- else }}
+    {{- $output = "" -}}
+  {{- end -}}
 {{- else if empty .Values.image.tag }}
-  {{- false }}
+  {{- $output = "" -}}
 {{- else if eq .Values.image.tag "latest" }}
-  {{- true }}
+  {{- $output = "1" -}}
+{{- else if semverCompare ">= 3.6.11" .Values.image.tag }}
+  {{- $output = "1" -}}
 {{- else }}
-  {{- semverCompare ">= 3.6.11" .Values.image.tag }}
+  {{- $output = "" -}}
 {{- end }}
+{{ $output }}
 {{- end }}
-
-{{/*
-Custom template function to cast a string to a boolean.
-Usage: {{ toBool .SomeString }}
-*/}}
-{{- define "strToBool" -}}
-    {{- $output := "" -}}
-    {{- if (eq . "true") -}}
-        {{- $output = "1" -}}
-    {{- end -}}
-    {{ $output }}
-{{- end -}}
 
 {{/*
 Set Temporal frontend host

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -129,6 +129,10 @@ Set Workflows enabled
 {{- define "retool.workflows.enabled" -}}
 {{- if or (eq .Values.workflows.enabled true) (eq .Values.workflows.enabled false) -}}
   {{- .Values.workflows.enabled | default false }}
+{{- else if empty .Values.image.tag }}
+  {{- false }}
+{{- else if eq .Values.image.tag "latest" }}
+  {{- true }}
 {{- else }}
   {{- semverCompare ">= 3.6.11" .Values.image.tag }}
 {{- end }}

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -82,7 +82,7 @@ spec:
           - name: DBCONNECTOR_QUERY_TIMEOUT_MS	
             value: {{ .Values.config.dbConnectorTimeout | quote }}	
           {{- end }}
-          {{- if and ((include "retool.workflows.enabled" .) | include "strToBool") (or (index .Values "retool-temporal-services-helm" "enabled") (.Values.workflows.temporal.enabled)) }}
+          {{- if and (include "retool.workflows.enabled" .) (or (index .Values "retool-temporal-services-helm" "enabled") (.Values.workflows.temporal.enabled)) }}
           - name: WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_HOST	
             value: {{ template "retool.temporal.host" . }}	
           - name: WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_PORT	
@@ -90,7 +90,7 @@ spec:
           - name: WORKFLOW_TEMPORAL_CLUSTER_NAMESPACE	
             value: {{ template "retool.temporal.namespace" . }}	
           {{- end }}	
-          {{- if ((include "retool.workflows.enabled" .) | include "strToBool") }}
+          {{- if include "retool.workflows.enabled" . }}
           - name: WORKFLOW_BACKEND_HOST	
             value: http://{{ template "retool.fullname" . }}-workflow-backend	
           {{- end }}	

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -82,7 +82,7 @@ spec:
           - name: DBCONNECTOR_QUERY_TIMEOUT_MS	
             value: {{ .Values.config.dbConnectorTimeout | quote }}	
           {{- end }}
-          {{- if and (.Values.workflows.enabled) (or (index .Values "retool-temporal-services-helm" "enabled") (.Values.workflows.temporal.enabled)) }}	
+          {{- if and ((include "retool.workflows.enabled" .) | include "strToBool") (or (index .Values "retool-temporal-services-helm" "enabled") (.Values.workflows.temporal.enabled)) }}
           - name: WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_HOST	
             value: {{ template "retool.temporal.host" . }}	
           - name: WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_PORT	
@@ -90,7 +90,7 @@ spec:
           - name: WORKFLOW_TEMPORAL_CLUSTER_NAMESPACE	
             value: {{ template "retool.temporal.namespace" . }}	
           {{- end }}	
-          {{- if (.Values.workflows.enabled) }}	
+          {{- if ((include "retool.workflows.enabled" .) | include "strToBool") }}
           - name: WORKFLOW_BACKEND_HOST	
             value: http://{{ template "retool.fullname" . }}-workflow-backend	
           {{- end }}	

--- a/charts/retool/templates/deployment_workflows.yaml
+++ b/charts/retool/templates/deployment_workflows.yaml
@@ -1,4 +1,4 @@
-{{- if ((include "retool.workflows.enabled" .) | include "strToBool") }}
+{{- if include "retool.workflows.enabled" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/retool/templates/deployment_workflows.yaml
+++ b/charts/retool/templates/deployment_workflows.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.workflows.enabled }}
+{{- if ((include "retool.workflows.enabled" .) | include "strToBool") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/retool/templates/deployment_workflows_worker.yaml
+++ b/charts/retool/templates/deployment_workflows_worker.yaml
@@ -1,4 +1,4 @@
-{{- if ((include "retool.workflows.enabled" .) | include "strToBool") }}
+{{- if include "retool.workflows.enabled" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/retool/templates/deployment_workflows_worker.yaml
+++ b/charts/retool/templates/deployment_workflows_worker.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.workflows.enabled }}
+{{- if ((include "retool.workflows.enabled" .) | include "strToBool") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/retool/templates/secret.yaml
+++ b/charts/retool/templates/secret.yaml
@@ -46,8 +46,7 @@ data:
   postgresql-password: {{ .Values.config.postgresql.password | default "" | b64enc | quote }}
   {{ end }}
 
-  {{ if .Values.workflows.temporal.sslKey }}
+  {{ if (.Values.workflows.temporal).sslKey }}
   temporal-tls-key: {{ .Values.workflows.temporal.sslKey | default "" | b64enc | quote }}
   {{ end }}
-
 {{- end }}

--- a/charts/retool/templates/secret.yaml
+++ b/charts/retool/templates/secret.yaml
@@ -45,8 +45,9 @@ data:
   {{ if not .Values.postgresql.enabled }}
   postgresql-password: {{ .Values.config.postgresql.password | default "" | b64enc | quote }}
   {{ end }}
-
-  {{ if (.Values.workflows.temporal).sslKey }}
+  
+  {{ if and ((include "retool.workflows.enabled" .) | include "strToBool" ) .Values.workflows.temporal.sslKey }}
   temporal-tls-key: {{ .Values.workflows.temporal.sslKey | default "" | b64enc | quote }}
   {{ end }}
+
 {{- end }}

--- a/charts/retool/templates/secret.yaml
+++ b/charts/retool/templates/secret.yaml
@@ -46,7 +46,7 @@ data:
   postgresql-password: {{ .Values.config.postgresql.password | default "" | b64enc | quote }}
   {{ end }}
 
-  {{ if and ((include "retool.workflows.enabled" .) | include "strToBool" ) .Values.workflows.temporal.sslKey }}
+  {{ if .Values.workflows.temporal.sslKey }}
   temporal-tls-key: {{ .Values.workflows.temporal.sslKey | default "" | b64enc | quote }}
   {{ end }}
 

--- a/charts/retool/templates/secret.yaml
+++ b/charts/retool/templates/secret.yaml
@@ -45,7 +45,7 @@ data:
   {{ if not .Values.postgresql.enabled }}
   postgresql-password: {{ .Values.config.postgresql.password | default "" | b64enc | quote }}
   {{ end }}
-  
+
   {{ if and ((include "retool.workflows.enabled" .) | include "strToBool" ) .Values.workflows.temporal.sslKey }}
   temporal-tls-key: {{ .Values.workflows.temporal.sslKey | default "" | b64enc | quote }}
   {{ end }}

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -297,8 +297,10 @@ backend:
   labels: {}
 
 workflows:
-  enabled: true
+  # enabled by default from Chart version 6.0.2 and Retool image 3.6.11 onwards
+  # explicitly set other fields as needed
 
+  # enabled: true
   # A replicaCount of 1 will launch 6 pods -- 1 workflow backend, 1 workflow worker, and 4 pods that make up the executor temporal cluster
   # Scaling this number will increase the number of workflow workers, e.g. a replicaCount of 4
   # will launch 9 pods -- 1 workflow backend, 4 workflow workers, and 4 for temporal cluster

--- a/values.yaml
+++ b/values.yaml
@@ -297,8 +297,10 @@ backend:
   labels: {}
 
 workflows:
-  enabled: true
+  # enabled by default from Chart version 6.0.2 and Retool image 3.6.11 onwards
+  # explicitly set other fields as needed
 
+  # enabled: true
   # A replicaCount of 1 will launch 6 pods -- 1 workflow backend, 1 workflow worker, and 4 pods that make up the executor temporal cluster
   # Scaling this number will increase the number of workflow workers, e.g. a replicaCount of 4
   # will launch 9 pods -- 1 workflow backend, 4 workflow workers, and 4 for temporal cluster


### PR DESCRIPTION
Baseline

```
➜  retool git:(main) ✗ helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="5.6.10" --set workflows.enabled=false --debug | grep _worker.yaml
install.go:192: [debug] Original chart version: ""
install.go:209: [debug] CHART PATH: /Users/avimoondra/retool-helm/charts/retool

➜  retool git:(main) ✗ helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="5.6.10" --set workflows.enabled=true --debug | grep _worker.yaml
install.go:192: [debug] Original chart version: ""
install.go:209: [debug] CHART PATH: /Users/avimoondra/retool-helm/charts/retool

# Source: retool/templates/deployment_workflows_worker.yaml
# Source: retool/templates/deployment_workflows_worker.yaml
```

Migration/upgrade scenarios:

**1) using a `retool-workflows-helm`, moving to `retool-helm` 6.0.2 ... pre Retool image 3.6.11**
- `workflows: enabled` would have been set; if it's not set for some reason, we won't spin up workers as expected.
- we continue to respect any other fields related to workflows as is (codeExecutor, retool-temporal-services-helm)

**2) using a `retool-workflows-helm`, moving to `retool-helm` 6.0.2 ... post Retool image 3.6.11** 
- `workflows: enabled` would have been set; if it's not set for some reason, we will spin up workers + backend (but worker will not CrashLoopBackOff)
- we continue to respect any other fields related to workflows as is (codeExecutor, retool-temporal-services-helm)

**3) using `retool-helm` <= 5.0.10, moving to `retool-helm` 6.0.2 ... pre Retool image 3.6.11**
- if you wanted workflows, you MUST set explicitly since these workers will CrashLoopBackOff without temporal config (connecting to external cluster) OR retool-temporal-services helm spinning up a local cluster.
- if you don't want workflows, you can set nothing -- and we will not spin up workflows.
- we continue to respect any other fields related to workflows as is (codeExecutor, retool-temporal-services-helm)

```
➜  retool git:(avimoondra/set-min-versions-for-workflow-startup) ✗ helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="3.6.10" --debug | grep _worker.yaml
install.go:192: [debug] Original chart version: ""
install.go:209: [debug] CHART PATH: /Users/avimoondra/retool-helm/charts/retool
```

```
➜  retool git:(avimoondra/set-min-versions-for-workflow-startup) ✗ helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="3.6.10" --set workflows.enabled=false  --debug | grep _worker.yaml
install.go:192: [debug] Original chart version: ""
install.go:209: [debug] CHART PATH: /Users/avimoondra/retool-helm/charts/retool
```

```
➜  retool git:(avimoondra/set-min-versions-for-workflow-startup) ✗ helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="3.6.10" --set workflows.enabled=true --debug | grep _worker.yaml
install.go:192: [debug] Original chart version: ""
install.go:209: [debug] CHART PATH: /Users/avimoondra/retool-helm/charts/retool

# Source: retool/templates/deployment_workflows_worker.yaml
# Source: retool/templates/deployment_workflows_worker.yaml
```

**4) using `retool-helm` <= 5.0.10, moving to `retool-helm` 6.0.2 ... post Retool image 3.6.11**
- if you wanted workflows, you can either set nothing OR set explicitly, we will spin up backend +  worker, and worker will not CrashLoopBackOff
- if you don't want workflows, you must explicitly set `workflows: enabled` to `false`
- we continue to respect any other fields related to workflows as is (codeExecutor, retool-temporal-services-helm)

```
➜  retool git:(avimoondra/set-min-versions-for-workflow-startup) ✗ helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="3.6.12" --debug | grep _worker.yaml
install.go:192: [debug] Original chart version: ""
install.go:209: [debug] CHART PATH: /Users/avimoondra/retool-helm/charts/retool

# Source: retool/templates/deployment_workflows_worker.yaml
# Source: retool/templates/deployment_workflows_worker.yaml
```

```
➜  retool git:(avimoondra/set-min-versions-for-workflow-startup) ✗ helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="3.6.12" --set workflows.enabled=true --debug | grep _worker.yaml
install.go:192: [debug] Original chart version: ""
install.go:209: [debug] CHART PATH: /Users/avimoondra/retool-helm/charts/retool

# Source: retool/templates/deployment_workflows_worker.yaml
# Source: retool/templates/deployment_workflows_worker.yaml
```

```
➜  retool git:(avimoondra/set-min-versions-for-workflow-startup) ✗ helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="3.6.12" --set workflows.enabled=false --debug | grep _worker.yaml
install.go:192: [debug] Original chart version: ""
install.go:209: [debug] CHART PATH: /Users/avimoondra/retool-helm/charts/retool
```

