### PR TITLE
Add hostalias to backend deployment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,12 +82,12 @@ jobs:
         # When changing versions here, check that the version exists at:
         # https://github.com/yannh/kubernetes-json-schema
         k8s:
+          - v1.28.2
+          - v1.27.6
           - v1.26.5
           - v1.25.2
           - v1.24.2
           - v1.22.9
-          - v1.18.20
-          - v1.16.15
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.0.3
+version: 6.0.4
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -43,6 +43,16 @@ spec:
 {{ toYaml $value | indent 8 }}
 {{- end }}
 {{- end }}
+{{- if (hasKey .Values.hostAliases)}}
+      hostAliases:
+      {{- range .Values.hostAliases -}}
+        - ip: {{ .ip }}
+          hostnames:
+          {{- range .hostnames}}
+           - {{ . }}
+          {{- end }}
+      {{- end }}
+{{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ required "Please set a value for .Values.image.tag" .Values.image.tag }}"

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -36,22 +36,16 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
+      {{- with .Values.hostAliases }}
+      hostAliases:
+{{ toYaml . | indent 8 }}
+      {{- end }} 
 {{- if .Values.initContainers }}
       initContainers:
 {{- range $key, $value := .Values.initContainers }}
       - name: "{{ $key }}"
 {{ toYaml $value | indent 8 }}
 {{- end }}
-{{- end }}
-{{- if (hasKey .Values.hostAliases)}}
-      hostAliases:
-      {{- range .Values.hostAliases -}}
-        - ip: {{ .ip }}
-          hostnames:
-          {{- range .hostnames}}
-           - {{ . }}
-          {{- end }}
-      {{- end }}
 {{- end }}
       containers:
       - name: {{ .Chart.Name }}

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -38,7 +38,7 @@ spec:
       {{- end }}
       {{- with .Values.hostAliases }}
       hostAliases:
-{{ toYaml . | indent 8 }}
+      {{ toYaml . | indent 8 }}
       {{- end }} 
 {{- if .Values.initContainers }}
       initContainers:

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -38,7 +38,7 @@ spec:
       {{- end }}
       {{- with .Values.hostAliases }}
       hostAliases:
-      {{ toYaml . | indent 8 }}
+{{ toYaml . | indent 8 }}
       {{- end }} 
 {{- if .Values.initContainers }}
       initContainers:

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -564,4 +564,4 @@ hostAliases: {}
 #   - ip: 1.1.1.1
 #     hostnames:
 #     - test.com
-#     - anothertest.com  
+#     - anothertest.com

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -557,3 +557,10 @@ extraManifests: []
 securityGroupPolicy:
   enabled: false
   groupIds: []
+
+# Override any host aliases here if needed
+# hostAliases:
+#   - ip: 1.1.1.1
+#   hostnames:
+#   - example.com
+#   - exampletwo.com

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -559,6 +559,7 @@ securityGroupPolicy:
   groupIds: []
 
 hostAliases: {}
+# Support hostAliases on the backend deployment
 # hostAliases:
 #   - ip: 1.1.1.1
 #     hostnames:

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -558,9 +558,9 @@ securityGroupPolicy:
   enabled: false
   groupIds: []
 
-# Override any host aliases here if needed
+hostAliases: {}
 # hostAliases:
 #   - ip: 1.1.1.1
-#   hostnames:
-#   - example.com
-#   - exampletwo.com
+#     hostnames:
+#     - test.com
+#     - anothertest.com  

--- a/values.yaml
+++ b/values.yaml
@@ -557,3 +557,11 @@ extraManifests: []
 securityGroupPolicy:
   enabled: false
   groupIds: []
+
+hostAliases: {}
+# Support hostAliases on the backend deployment
+# hostAliases:
+#   - ip: 1.1.1.1
+#     hostnames:
+#     - test.com
+#     - anothertest.com


### PR DESCRIPTION
Tested with managed-self-hosted test instance. 

```
 spec:
      serviceAccountName: default
      hostAliases:
        - hostnames:
          - [REDACTED]
          - [REDACTED]
          ip: 1.1.1.1
```