### PR TITLE
add a default nodeselector for AMD since retool docker image is amd64 only

### DIFF
--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -260,7 +260,8 @@ tolerations: []
 
 # Node labels for pod assignment
 # Ref: https://kubernetes.io/docs/user-guide/node-selection/
-nodeSelector: {}
+nodeSelector:
+  kubernetes.io/arch: amd64
 
 # Common annotations for all pods (backend and job runner).
 podAnnotations: {}


### PR DESCRIPTION
Hello!

  Our retool on-prem installation crashed recently because our AWS Karpenter autoscaler provisioned an ARM64 machine for our retool instances!

  Because the [tryretool/backend image is AMD64](https://hub.docker.com/r/tryretool/backend/tags?page=1) only, the helm chart should set a default nodeSelector for AMD.

Thanks!