### PR TITLE
Add readinessProb to jobs container

### DIFF
--- a/charts/retool/templates/deployment_jobs.yaml
+++ b/charts/retool/templates/deployment_jobs.yaml
@@ -174,6 +174,13 @@ spec:
           initialDelaySeconds: 120
           periodSeconds: 30
           timeoutSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /api/checkJobsRunnerHealth
+            port: 3003
+          initialDelaySeconds: 120
+          periodSeconds: 30
+          timeoutSeconds: 3
         {{- end }}
         {{- end }}
         volumeMounts:


### PR DESCRIPTION
My platform team has implemented an admission controller that requires a readinessProbe to be defined. Using the livelinessProbe as a model, this implements it for the jobs container.