### PR TITLE
support 1 replica api backend with jobs runner

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.0.6
+version: 6.0.7
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -124,6 +124,18 @@ Set postgresql user
 {{- end -}}
 
 {{/*
+Set Jobs Runner enabled
+Usage: (include "retool.jobRunner.enabled" .)
+*/}}
+{{- define "retool.jobRunner.enabled" -}}
+{{- $output := "" -}}
+{{- if or (gt (int (toString (.Values.replicaCount))) 1) (eq .Values.jobRunner.enabled true) }}
+  {{- $output = "1" -}}
+{{- end -}}
+{{- $output -}}
+{{- end -}}
+
+{{/*
 Set Workflows enabled
 Usage: (include "retool.workflows.enabled" .)
 */}}

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -61,7 +61,7 @@ spec:
         env:
           - name: NODE_ENV
             value: production
-          {{- if gt (int (toString (.Values.replicaCount))) 1 }}
+          {{- if include "retool.jobRunner.enabled" . }}
           - name: SERVICE_TYPE
             value: MAIN_BACKEND,DB_CONNECTOR,DB_SSH_CONNECTOR
           {{- else }}

--- a/charts/retool/templates/deployment_jobs.yaml
+++ b/charts/retool/templates/deployment_jobs.yaml
@@ -1,4 +1,4 @@
-{{- if gt (int (toString (.Values.replicaCount))) 1 }}
+{{- if include "retool.jobRunner.enabled" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -32,7 +32,8 @@ config:
 
   # IMPORTANT: Incompatible with postgresql subchart
   # Please disable the subchart in order to use a managed or external postgres instance.
-  postgresql: {}
+  postgresql:
+    {}
     # Specify if postgresql subchart is disabled
     # host:
     # port:
@@ -58,7 +59,8 @@ env: {}
 
 # Optionally specify additional environment variables to be populated from Kubernetes secrets.
 # Useful for passing in SCIM_AUTH_TOKEN or other secret environment variables from Kubernetes secrets.
-environmentSecrets: []
+environmentSecrets:
+  []
   # - name: SCIM_AUTH_TOKEN
   #   secretKeyRef:
   #     name: retool-scim-auth-token
@@ -70,7 +72,8 @@ environmentSecrets: []
 
 # Optionally specify environmental variables. Useful for variables that are not key-value, as env: {} above requires.
 # Can also include environment secrets here instead of in environmentSecrets
-environmentVariables: []
+environmentVariables:
+  []
   #   - name: SCIM_AUTH_TOKEN
   #     valueFrom:
   #       secretKeyRef:
@@ -94,7 +97,8 @@ externalSecrets:
   enabled: false
   name: retool-config
   # Array of secrets to be use as env variables. (Optional)
-  secrets: []
+  secrets:
+    []
     # - name: retool-config
     # - name: retool-db
   # Support for External Secrets Operator: https://github.com/external-secrets/external-secrets
@@ -104,7 +108,8 @@ externalSecrets:
     # Default set to AWS Secrets Manager.
     backendType: secretsManager
     # Array of name/path key/value pairs to use for the External Secrets Objects.
-    secretRef: []
+    secretRef:
+      []
       # - name: retool-config
       #   path: global-retool-config
       # - name: retool-db
@@ -244,15 +249,15 @@ priorityClassName: ""
 affinity:
   podAntiAffinity:
     preferredDuringSchedulingIgnoredDuringExecution:
-    - weight: 100
-      podAffinityTerm:
-        labelSelector:
-          matchExpressions:
-          - key: "app.kubernetes.io/name"
-            operator: In
-            values:
-            - retool
-        topologyKey: "kubernetes.io/hostname"
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+              - key: "app.kubernetes.io/name"
+                operator: In
+                values:
+                  - retool
+          topologyKey: "kubernetes.io/hostname"
 
 # Tolerations for pod assignment
 # Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
@@ -265,9 +270,6 @@ nodeSelector: {}
 # Common annotations for all pods (backend and job runner).
 podAnnotations: {}
 
-# Increasing replica count will deploy a separate pod for backend and jobs
-# Example: with 3 replicas, you will end up with 3 backends + 1 jobs pod
-replicaCount: 2
 revisionHistoryLimit: 3
 
 # Optional pod disruption budget, for ensuring higher availability of the
@@ -282,7 +284,18 @@ revisionHistoryLimit: 3
 # Common labels for all pods (backend and job runner) for pod assignment
 podLabels: {}
 
+# Increasing replica count will deploy a separate pod for backend and jobs
+# Example 1: with 1 replicas, you will end up with 1 combined backend and jobs pod (unless jobRunner.enabled is true, see below)
+# Example 2: with 2 replicas, you will end up with 2 backends + 1 jobs pod
+# Example 3: with 3 replicas, you will end up with 3 backends + 1 jobs pod
+replicaCount: 2
+
 jobRunner:
+  # explicitly enable this pod if exactly 1 api backend container and
+  # 1 jobs runner container is desired. otherwise a replicaCount of 2
+  # will already launch a job runner pod
+  # enabled: true
+
   # Annotations for job runner pods
   annotations: {}
 

--- a/values.yaml
+++ b/values.yaml
@@ -32,7 +32,8 @@ config:
 
   # IMPORTANT: Incompatible with postgresql subchart
   # Please disable the subchart in order to use a managed or external postgres instance.
-  postgresql: {}
+  postgresql:
+    {}
     # Specify if postgresql subchart is disabled
     # host:
     # port:
@@ -58,7 +59,8 @@ env: {}
 
 # Optionally specify additional environment variables to be populated from Kubernetes secrets.
 # Useful for passing in SCIM_AUTH_TOKEN or other secret environment variables from Kubernetes secrets.
-environmentSecrets: []
+environmentSecrets:
+  []
   # - name: SCIM_AUTH_TOKEN
   #   secretKeyRef:
   #     name: retool-scim-auth-token
@@ -70,7 +72,8 @@ environmentSecrets: []
 
 # Optionally specify environmental variables. Useful for variables that are not key-value, as env: {} above requires.
 # Can also include environment secrets here instead of in environmentSecrets
-environmentVariables: []
+environmentVariables:
+  []
   #   - name: SCIM_AUTH_TOKEN
   #     valueFrom:
   #       secretKeyRef:
@@ -94,7 +97,8 @@ externalSecrets:
   enabled: false
   name: retool-config
   # Array of secrets to be use as env variables. (Optional)
-  secrets: []
+  secrets:
+    []
     # - name: retool-config
     # - name: retool-db
   # Support for External Secrets Operator: https://github.com/external-secrets/external-secrets
@@ -104,7 +108,8 @@ externalSecrets:
     # Default set to AWS Secrets Manager.
     backendType: secretsManager
     # Array of name/path key/value pairs to use for the External Secrets Objects.
-    secretRef: []
+    secretRef:
+      []
       # - name: retool-config
       #   path: global-retool-config
       # - name: retool-db
@@ -244,15 +249,15 @@ priorityClassName: ""
 affinity:
   podAntiAffinity:
     preferredDuringSchedulingIgnoredDuringExecution:
-    - weight: 100
-      podAffinityTerm:
-        labelSelector:
-          matchExpressions:
-          - key: "app.kubernetes.io/name"
-            operator: In
-            values:
-            - retool
-        topologyKey: "kubernetes.io/hostname"
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+              - key: "app.kubernetes.io/name"
+                operator: In
+                values:
+                  - retool
+          topologyKey: "kubernetes.io/hostname"
 
 # Tolerations for pod assignment
 # Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
@@ -265,9 +270,6 @@ nodeSelector: {}
 # Common annotations for all pods (backend and job runner).
 podAnnotations: {}
 
-# Increasing replica count will deploy a separate pod for backend and jobs
-# Example: with 3 replicas, you will end up with 3 backends + 1 jobs pod
-replicaCount: 2
 revisionHistoryLimit: 3
 
 # Optional pod disruption budget, for ensuring higher availability of the
@@ -282,7 +284,18 @@ revisionHistoryLimit: 3
 # Common labels for all pods (backend and job runner) for pod assignment
 podLabels: {}
 
+# Increasing replica count will deploy a separate pod for backend and jobs
+# Example 1: with 1 replicas, you will end up with 1 combined backend and jobs pod (unless jobRunner.enabled is true, see below)
+# Example 2: with 2 replicas, you will end up with 2 backends + 1 jobs pod
+# Example 3: with 3 replicas, you will end up with 3 backends + 1 jobs pod
+replicaCount: 2
+
 jobRunner:
+  # explicitly enable this pod if exactly 1 api backend container and
+  # 1 jobs runner container is desired. otherwise a replicaCount of 2
+  # will already launch a job runner pod
+  # enabled: true
+
   # Annotations for job runner pods
   annotations: {}
 


### PR DESCRIPTION
Support 1 replica api backend with 1 jobs runner pod. Previously replicaCount of 2 was required to separate jobs runner from api backend, which resulted in 2 api backends -- forcing the overall capacity to have this separation of services across pods.


**--set jobRunner.enabled=true --set replicaCount=1**
```
$ helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="5.6.10" --set jobRunner.enabled=true --set replicaCount=1  --debug | rg replicas -C 7
install.go:192: [debug] Original chart version: ""
install.go:209: [debug] CHART PATH: /Users/avimoondra/retool-helm/charts/retool

  name: foo-retool
  labels:
    helm.sh/chart: retool-6.0.7
    app.kubernetes.io/name: retool
    app.kubernetes.io/instance: foo
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: retool
      app.kubernetes.io/instance: foo
  revisionHistoryLimit: 3
  template:
    metadata:
--
  name: foo-retool-jobs-runner
  labels:
    helm.sh/chart: retool-6.0.7
    app.kubernetes.io/name: retool
    app.kubernetes.io/instance: foo
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: retool-jobs-runner
      app.kubernetes.io/instance: foo
  revisionHistoryLimit: 3
  template:
    metadata:
--
```

**--set jobRunner.enabled=true --set replicaCount=2**
```
$ helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="5.6.10" --set jobRunner.enabled=true --set replicaCount=2  --deb

install.go:192: [debug] Original chart version: ""
install.go:209: [debug] CHART PATH: /Users/avimoondra/retool-helm/charts/retool

  name: foo-retool
  labels:
    helm.sh/chart: retool-6.0.7
    app.kubernetes.io/name: retool
    app.kubernetes.io/instance: foo
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 2
  selector:
    matchLabels:
      app.kubernetes.io/name: retool
      app.kubernetes.io/instance: foo
  revisionHistoryLimit: 3
  template:
    metadata:
--
  name: foo-retool-jobs-runner
  labels:
    helm.sh/chart: retool-6.0.7
    app.kubernetes.io/name: retool
    app.kubernetes.io/instance: foo
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: retool-jobs-runner
      app.kubernetes.io/instance: foo
  revisionHistoryLimit: 3
  template:
    metadata:
--
```

**--set replicaCount=2**
```
$ helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="5.6.10" --set replicaCount=2  --debug | rg replicas -C 7

install.go:192: [debug] Original chart version: ""
install.go:209: [debug] CHART PATH: /Users/avimoondra/retool-helm/charts/retool

  name: foo-retool
  labels:
    helm.sh/chart: retool-6.0.7
    app.kubernetes.io/name: retool
    app.kubernetes.io/instance: foo
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 2
  selector:
    matchLabels:
      app.kubernetes.io/name: retool
      app.kubernetes.io/instance: foo
  revisionHistoryLimit: 3
  template:
    metadata:
--
  name: foo-retool-jobs-runner
  labels:
    helm.sh/chart: retool-6.0.7
    app.kubernetes.io/name: retool
    app.kubernetes.io/instance: foo
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: retool-jobs-runner
      app.kubernetes.io/instance: foo
  revisionHistoryLimit: 3
  template:
    metadata:
--
```

**--set replicaCount=1**
```
$helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="5.6.10" --set replicaCount=1  --debug | rg replicas -C 7

install.go:192: [debug] Original chart version: ""
install.go:209: [debug] CHART PATH: /Users/avimoondra/retool-helm/charts/retool

  name: foo-retool
  labels:
    helm.sh/chart: retool-6.0.7
    app.kubernetes.io/name: retool
    app.kubernetes.io/instance: foo
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: retool
      app.kubernetes.io/instance: foo
  revisionHistoryLimit: 3
  template:
    metadata:
--
```