### PR TITLE
Support granular UI annotations and labels

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.0.6
+version: 6.0.9
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -23,6 +23,9 @@ spec:
 {{- if .Values.backend.annotations }}
 {{ toYaml .Values.backend.annotations | indent 8 }}
 {{- end }}
+{{- if .Values.ui.annotations }}
+{{ toYaml .Values.ui.annotations | indent 8 }}
+{{- end }}
       labels:
 {{- include "retool.selectorLabels" . | nindent 8 }}
 {{- if .Values.podLabels }}
@@ -30,6 +33,9 @@ spec:
 {{- end }}
 {{- if .Values.backend.labels }}
 {{ toYaml .Values.backend.labels | indent 8 }}
+{{- end }}
+{{- if .Values.ui.labels }}
+{{ toYaml .Values.ui.labels | indent 8 }}
 {{- end }}
     spec:
       serviceAccountName: {{ template "retool.serviceAccountName" . }}

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -290,10 +290,17 @@ jobRunner:
   labels: {}
 
 backend:
-  # Annotations for backendpods
+  # Annotations for backend pods
   annotations: {}
 
   # Labels for backend pods
+  labels: {}
+
+ui:
+  # Annotations for ui pods
+  annotations: {}
+
+  # Labels for ui pods
   labels: {}
 
 workflows:

--- a/values.yaml
+++ b/values.yaml
@@ -290,10 +290,17 @@ jobRunner:
   labels: {}
 
 backend:
-  # Annotations for backendpods
+  # Annotations for backend pods
   annotations: {}
 
   # Labels for backend pods
+  labels: {}
+
+ui:
+  # Annotations for ui pods
+  annotations: {}
+
+  # Labels for ui pods
   labels: {}
 
 workflows:


### PR DESCRIPTION
This PR adds the ability to specifically target the UI pods with annotations. The current available annotations configurations apply to multiple deployments, including the UI pods. In order to expose the service via our service mesh, we need the ability to target the UI pods with annotations. This change allows us to inject and expose the UI pods only, without inadvertently annotated undesired pods. 

if you need me to make any changes like bumping versions or updating changelogs, etc, just let me know and I'm happy to do so. 