### PR TITLE
add support for additional volumes and volume mounts on code executor

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.0.11
+version: 6.0.12
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/deployment_code_executor.yaml
+++ b/charts/retool/templates/deployment_code_executor.yaml
@@ -101,6 +101,14 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.codeExecutor.resources | indent 10 }}
+        volumeMounts:
+{{- if .Values.codeExecutor.volumeMounts }}
+{{ toYaml .Values.codeExecutor.volumeMounts | indent 10 }}
+{{- end }}
+      volumes:
+{{- if .Values.codeExecutor.volumes }}
+{{ toYaml .Values.codeExecutor.volumes | indent 8 }}
+{{- end }}
 {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.image.pullSecrets | indent 8 }}

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -423,6 +423,8 @@ codeExecutor:
   # config: {
   #   nodeOptions: --max_old_space_size=1024
   # }
+  volumes: {}
+  volumeMounts: {}
 
   # Resources for the code executor. Most common issues will be seen with CPU usage as this will
   # most likely be CPU bound. Adjust the CPU if latency increases under load.

--- a/values.yaml
+++ b/values.yaml
@@ -423,6 +423,8 @@ codeExecutor:
   # config: {
   #   nodeOptions: --max_old_space_size=1024
   # }
+  volumes: {}
+  volumeMounts: {}
 
   # Resources for the code executor. Most common issues will be seen with CPU usage as this will
   # most likely be CPU bound. Adjust the CPU if latency increases under load.


### PR DESCRIPTION
command:
```
helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="5.6.10" --set codeExecutor.image.tag="5.6.10" --set codeExecutor.enabled=true
```

values:
```
codeExecutor:
  # Enable this for Python support and running code more securely within a separate
  # sandboxed environment
  enabled: false

  replicaCount: 1

  # Annotations for code executor pods
  annotations: {}

  # Labels for code executor pods
  labels: {}

  # Config for code executor. Node heap size limits can be overridden here
  config: {}
  # config: {
  #   nodeOptions: --max_old_space_size=1024
  # }
  volumes:
    - name: dsdsocket
      hostPath:
        path: /var/run/datadog/
  volumeMounts:
    - name: dsdsocket
      mountPath: /var/run/datadog
```

output
```
# Source: retool/templates/deployment_code_executor.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: foo-retool-code-executor
  labels:
    retoolService: foo-retool-code-executor
    helm.sh/chart: retool-6.0.12
    app.kubernetes.io/name: retool
    app.kubernetes.io/instance: foo
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      retoolService: foo-retool-code-executor
  revisionHistoryLimit: 3
  template:
    metadata:
      annotations:
        prometheus.io/job: foo-retool-code-executor
        prometheus.io/scrape: 'true'
        prometheus.io/port: '9090'
      labels:
        retoolService: foo-retool-code-executor
    spec:
      serviceAccountName: foo-retool
      containers:
      - name: retool
        image: "tryretool/code-executor-service:5.6.10"
        imagePullPolicy: IfNotPresent
        securityContext:
          privileged: true
        env:
          - name: NODE_ENV
            value: production
          - name: NODE_OPTIONS
            value: --max_old_space_size=1024
        ports:
        - containerPort: 3004
          name: retool
          protocol: TCP
        - containerPort: 9090
          name: metrics
          protocol: TCP
        livenessProbe:
          httpGet:
            path: /api/checkHealth
            port: 3004
          initialDelaySeconds: 30
          timeoutSeconds: 10
          failureThreshold:  3
        readinessProbe:
          httpGet:
            path: /api/checkHealth
            port: 3004
          initialDelaySeconds: 30
          timeoutSeconds: 10
          successThreshold: 5
          periodSeconds: 10
        resources:
          limits:
            cpu: 2000m
            memory: 2048Mi
          requests:
            cpu: 1000m
            memory: 1024Mi
        volumeMounts:
          - mountPath: /var/run/datadog
            name: dsdsocket
      volumes:
        - hostPath:
            path: /var/run/datadog/
          name: dsdsocket
```