### PR TITLE
allow name overrides in pods

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.0.13
+version: 6.0.14
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -24,6 +24,30 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Set service names
+*/}}
+{{- define "retool.codeExecutor.name" -}}
+  {{- default (printf "%s-code-executor" (include "retool.fullname" .)) .Values.codeExecutor.name -}}
+{{- end -}}
+
+{{- define "retool.backend.name" -}}
+  {{- default (include "retool.fullname" .) .Values.backend.name -}}
+{{- end -}}
+
+{{- define "retool.jobsRunner.name" -}}
+  {{- default (printf "%s-jobs-runner" (include "retool.fullname" .)) .Values.jobRunner.name -}}
+{{- end -}}
+
+{{- define "retool.workflowsWorker.name" -}}
+  {{- default (printf "%s-workflow-worker" (include "retool.fullname" .)) .Values.workflows.worker.name -}}
+{{- end -}}
+
+{{- define "retool.workflowsBackend.name" -}}
+  {{- default (printf "%s-workflow-backend" (include "retool.fullname" .)) .Values.workflows.backend.name -}}
+{{- end -}}
+
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "retool.chart" -}}
@@ -125,9 +149,9 @@ Set postgresql user
 
 {{/*
 Set Jobs Runner enabled
-Usage: (include "retool.jobRunner.enabled" .)
+Usage: (include "retool.jobsRunner.enabled" .)
 */}}
-{{- define "retool.jobRunner.enabled" -}}
+{{- define "retool.jobsRunner.enabled" -}}
 {{- $output := "" -}}
 {{- if or (gt (int (toString (.Values.replicaCount))) 1) (default false .Values.jobRunner.enabled) }}
   {{- $output = "1" -}}
@@ -197,9 +221,3 @@ Set Temporal namespace
 {{- end -}}
 {{- end -}}
 
-{{/*
-Set code executor service name
-*/}}
-{{- define "retool.codeExecutor.name" -}}
-{{ template "retool.fullname" . }}-code-executor
-{{- end -}}

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -149,14 +149,13 @@ Set postgresql user
 
 {{/*
 Set Jobs Runner enabled
-Usage: (include "retool.jobsRunner.enabled" .)
+Usage: (include "retool.jobRunner.enabled" .)
 */}}
-{{- define "retool.jobsRunner.enabled" -}}
+{{- define "retool.jobRunner.enabled" -}}
 {{- $output := "" -}}
 {{- if or (gt (int (toString (.Values.replicaCount))) 1) (default false .Values.jobRunner.enabled) }}
   {{- $output = "1" -}}
 {{- end -}}
-# {{ printf "retool.jobsRunner.enabled result: %s" $output | quote }}
 {{- $output -}}
 {{- end -}}
 

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -34,7 +34,7 @@ Set service names
   {{- default (include "retool.fullname" .) .Values.backend.name -}}
 {{- end -}}
 
-{{- define "retool.jobsRunner.name" -}}
+{{- define "retool.jobRunner.name" -}}
   {{- default (printf "%s-jobs-runner" (include "retool.fullname" .)) .Values.jobRunner.name -}}
 {{- end -}}
 
@@ -156,6 +156,7 @@ Usage: (include "retool.jobsRunner.enabled" .)
 {{- if or (gt (int (toString (.Values.replicaCount))) 1) (default false .Values.jobRunner.enabled) }}
   {{- $output = "1" -}}
 {{- end -}}
+# {{ printf "retool.jobsRunner.enabled result: %s" $output | quote }}
 {{- $output -}}
 {{- end -}}
 

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -127,7 +127,7 @@ spec:
                 name: {{ .Values.workflows.temporal.sslKeySecretName }}
                 key: {{ .Values.workflows.temporal.sslKeySecretKey | default "temporal-tls-key" }}
               {{- else }}
-                name: {{ template "retool.backend.name" . }}
+                name: {{ template "retool.fullname" . }}
                 key: "temporal-tls-key"
               {{- end }}
           {{- end }}
@@ -144,7 +144,7 @@ spec:
                 name: {{ .Values.config.licenseKeySecretName }}
                 key: {{ .Values.config.licenseKeySecretKey | default "license-key" }}
                 {{- else }}
-                name: {{ template "retool.backend.name" . }}
+                name: {{ template "retool.fullname" . }}
                 key: license-key
                 {{- end }}
           - name: JWT_SECRET
@@ -154,7 +154,7 @@ spec:
                 name: {{ .Values.config.jwtSecretSecretName }}
                 key: {{ .Values.config.jwtSecretSecretKey | default "jwt-secret" }}
                 {{- else }}
-                name: {{ template "retool.backend.name" . }}
+                name: {{ template "retool.fullname" . }}
                 key: jwt-secret
                 {{- end }}
           - name: ENCRYPTION_KEY
@@ -164,7 +164,7 @@ spec:
                 name: {{ .Values.config.encryptionKeySecretName }}
                 key: {{ .Values.config.encryptionKeySecretKey | default "encryption-key" }}
                 {{- else }}
-                name: {{ template "retool.backend.name" . }}
+                name: {{ template "retool.fullname" . }}
                 key: encryption-key
                 {{- end }}
           - name: POSTGRES_PASSWORD
@@ -184,7 +184,7 @@ spec:
                 name: {{ .Values.config.postgresql.passwordSecretName }}
                 key: {{ .Values.config.postgresql.passwordSecretKey | default "postgresql-password" }}
                 {{- else }}
-                name: {{ template "retool.backend.name" . }}
+                name: {{ template "retool.fullname" . }}
                 key: postgresql-password
                 {{- end }}
           {{- end }}
@@ -195,7 +195,7 @@ spec:
                 name: {{ .Values.config.auth.google.clientSecretSecretName }}
                 key: {{ .Values.config.auth.google.clientSecretSecretKey | default "google-client-secret" }}
                 {{- else }}
-                name: {{ template "retool.backend.name" . }}
+                name: {{ template "retool.fullname" . }}
                 key: google-client-secret
                 {{- end }}
           {{- end }}

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "retool.fullname" . }}
+  name: {{ template "retool.backend.name" . }}
   labels:
 {{- include "retool.labels" . | nindent 4 }}
 {{- if .Values.deployment.annotations }}
@@ -67,7 +67,7 @@ spec:
         env:
           - name: NODE_ENV
             value: production
-          {{- if include "retool.jobRunner.enabled" . }}
+          {{- if include "retool.jobsRunner.enabled" . }}
           {{ if $.Values.dbconnector.java.enabled }}
           - name: SERVICE_TYPE
             value: MAIN_BACKEND,DB_CONNECTOR,DB_SSH_CONNECTOR,JAVA_DBCONNECTOR
@@ -112,7 +112,7 @@ spec:
           {{- end }}
           {{- if include "retool.workflows.enabled" . }}
           - name: WORKFLOW_BACKEND_HOST
-            value: http://{{ template "retool.fullname" . }}-workflow-backend
+            value: http://{{ template "retool.workflowsBackend.name" . }}
           {{- end }}
           {{- if (.Values.workflows.temporal).sslEnabled }}
           - name: WORKFLOW_TEMPORAL_TLS_ENABLED
@@ -127,7 +127,7 @@ spec:
                 name: {{ .Values.workflows.temporal.sslKeySecretName }}
                 key: {{ .Values.workflows.temporal.sslKeySecretKey | default "temporal-tls-key" }}
               {{- else }}
-                name: {{ template "retool.fullname" . }}
+                name: {{ template "retool.backend.name" . }}
                 key: "temporal-tls-key"
               {{- end }}
           {{- end }}
@@ -144,7 +144,7 @@ spec:
                 name: {{ .Values.config.licenseKeySecretName }}
                 key: {{ .Values.config.licenseKeySecretKey | default "license-key" }}
                 {{- else }}
-                name: {{ template "retool.fullname" . }}
+                name: {{ template "retool.backend.name" . }}
                 key: license-key
                 {{- end }}
           - name: JWT_SECRET
@@ -154,7 +154,7 @@ spec:
                 name: {{ .Values.config.jwtSecretSecretName }}
                 key: {{ .Values.config.jwtSecretSecretKey | default "jwt-secret" }}
                 {{- else }}
-                name: {{ template "retool.fullname" . }}
+                name: {{ template "retool.backend.name" . }}
                 key: jwt-secret
                 {{- end }}
           - name: ENCRYPTION_KEY
@@ -164,7 +164,7 @@ spec:
                 name: {{ .Values.config.encryptionKeySecretName }}
                 key: {{ .Values.config.encryptionKeySecretKey | default "encryption-key" }}
                 {{- else }}
-                name: {{ template "retool.fullname" . }}
+                name: {{ template "retool.backend.name" . }}
                 key: encryption-key
                 {{- end }}
           - name: POSTGRES_PASSWORD
@@ -184,7 +184,7 @@ spec:
                 name: {{ .Values.config.postgresql.passwordSecretName }}
                 key: {{ .Values.config.postgresql.passwordSecretKey | default "postgresql-password" }}
                 {{- else }}
-                name: {{ template "retool.fullname" . }}
+                name: {{ template "retool.backend.name" . }}
                 key: postgresql-password
                 {{- end }}
           {{- end }}
@@ -195,7 +195,7 @@ spec:
                 name: {{ .Values.config.auth.google.clientSecretSecretName }}
                 key: {{ .Values.config.auth.google.clientSecretSecretKey | default "google-client-secret" }}
                 {{- else }}
-                name: {{ template "retool.fullname" . }}
+                name: {{ template "retool.backend.name" . }}
                 key: google-client-secret
                 {{- end }}
           {{- end }}
@@ -327,7 +327,7 @@ apiVersion: policy/v1beta1
 {{- end }}
 kind: PodDisruptionBudget
 metadata:
-  name: {{ template "retool.fullname" . }}
+  name: {{ template "retool.backend.name" . }}
 spec:
   {{ toYaml .Values.podDisruptionBudget }}
   selector:

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -67,7 +67,7 @@ spec:
         env:
           - name: NODE_ENV
             value: production
-          {{- if include "retool.jobsRunner.enabled" . }}
+          {{- if include "retool.jobRunner.enabled" . }}
           {{ if $.Values.dbconnector.java.enabled }}
           - name: SERVICE_TYPE
             value: MAIN_BACKEND,DB_CONNECTOR,DB_SSH_CONNECTOR,JAVA_DBCONNECTOR

--- a/charts/retool/templates/deployment_jobs.yaml
+++ b/charts/retool/templates/deployment_jobs.yaml
@@ -1,4 +1,4 @@
-{{- if include "retool.jobsRunner.enabled" . }}
+{{- if include "retool.jobRunner.enabled" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/retool/templates/deployment_jobs.yaml
+++ b/charts/retool/templates/deployment_jobs.yaml
@@ -1,8 +1,8 @@
-{{- if include "retool.jobRunner.enabled" . }}
+{{- if include "retool.jobsRunner.enabled" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "retool.fullname" . }}-jobs-runner
+  name: {{ template "retool.jobsRunner.name" . }}
   labels:
 {{- include "retool.labels" . | nindent 4 }}
 {{- if .Values.deployment.annotations }}
@@ -13,7 +13,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "retool.name" . }}-jobs-runner
+      app.kubernetes.io/name: {{ template "retool.jobsRunner.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   template:
@@ -26,7 +26,7 @@ spec:
 {{ toYaml .Values.jobRunner.annotations | indent 8 }}
 {{- end }}
       labels:
-        app.kubernetes.io/name: {{ include "retool.name" . }}-jobs-runner
+        app.kubernetes.io/name: {{ template "retool.jobsRunner.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8 }}

--- a/charts/retool/templates/deployment_jobs.yaml
+++ b/charts/retool/templates/deployment_jobs.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "retool.jobsRunner.name" . }}
+  name: {{ template "retool.jobRunner.name" . }}
   labels:
 {{- include "retool.labels" . | nindent 4 }}
 {{- if .Values.deployment.annotations }}
@@ -13,7 +13,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ template "retool.jobsRunner.name" . }}
+      app.kubernetes.io/name: {{ template "retool.jobRunner.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   template:
@@ -26,7 +26,7 @@ spec:
 {{ toYaml .Values.jobRunner.annotations | indent 8 }}
 {{- end }}
       labels:
-        app.kubernetes.io/name: {{ template "retool.jobsRunner.name" . }}
+        app.kubernetes.io/name: {{ template "retool.jobRunner.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8 }}

--- a/charts/retool/templates/deployment_workflows.yaml
+++ b/charts/retool/templates/deployment_workflows.yaml
@@ -2,9 +2,9 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "retool.fullname" . }}-workflow-backend
+  name: {{ template "retool.workflowsBackend.name" . }}
   labels:
-    retoolService: {{ template "retool.fullname" . }}-workflow-backend
+    retoolService: {{ template "retool.workflowsBackend.name" . }}
 {{- include "retool.labels" . | nindent 4 }}
 {{- if .Values.deployment.annotations }}
   annotations:
@@ -14,7 +14,7 @@ spec:
   replicas: {{ (.Values.workflows.backend).replicaCount | default 1 }}
   selector:
     matchLabels:
-      retoolService: {{ template "retool.fullname" . }}-workflow-backend
+      retoolService: {{ template "retool.workflowsBackend.name" . }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   template:
     metadata:
@@ -26,7 +26,7 @@ spec:
 {{ toYaml .Values.backend.annotations | indent 8 }}
 {{- end }}
       labels:
-        retoolService: {{ template "retool.fullname" . }}-workflow-backend
+        retoolService: {{ template "retool.workflowsBackend.name" . }}
 {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8 }}
 {{- end }}
@@ -119,7 +119,7 @@ spec:
           - name: POSTGRES_SSL_ENABLED
             value: {{ template "retool.postgresql.ssl_enabled" . }}
           - name: WORKFLOW_BACKEND_HOST
-            value: http://{{ template "retool.fullname" . }}-workflow-backend
+            value: http://{{ template "retool.workflowsBackend.name" . }}
           {{- if .Values.codeExecutor.enabled }}
           - name: CODE_EXECUTOR_INGRESS_DOMAIN
             value: http://{{ template "retool.codeExecutor.name" . }}
@@ -295,17 +295,17 @@ spec:
   {{ toYaml .Values.podDisruptionBudget }}
   selector:
     matchLabels:
-      retoolService: {{ template "retool.fullname" . }}-workflow-backend
+      retoolService: {{ template "retool.workflowsBackend.name" . }}
   {{- include "retool.selectorLabels" . | nindent 6 }}
 {{- end }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "retool.fullname" . }}-workflow-backend
+  name: {{ template "retool.workflowsBackend.name" . }}
 spec:
   selector:
-    retoolService: {{ template "retool.fullname" . }}-workflow-backend
+    retoolService: {{ template "retool.workflowsBackend.name" . }}
   ports:
   - protocol: TCP
     port: 80

--- a/charts/retool/templates/deployment_workflows_worker.yaml
+++ b/charts/retool/templates/deployment_workflows_worker.yaml
@@ -2,9 +2,9 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "retool.fullname" . }}-workflow-worker
+  name: {{ template "retool.workflowsWorker.name" . }}
   labels:
-    retoolService: {{ template "retool.fullname" . }}-workflow-worker
+    retoolService: {{ template "retool.workflowsWorker.name" . }}
 {{- include "retool.labels" . | nindent 4 }}
 {{- if .Values.deployment.annotations }}
   annotations:
@@ -14,12 +14,12 @@ spec:
   replicas: {{ (.Values.workflows.worker).replicaCount | default (.Values.workflows.replicaCount | default 1) }}
   selector:
     matchLabels:
-      retoolService: {{ template "retool.fullname" . }}-workflow-worker
+      retoolService: {{ template "retool.workflowsWorker.name" . }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   template:
     metadata:
       annotations:
-        prometheus.io/job: {{ template "retool.fullname" . }}-workflow-worker
+        prometheus.io/job: {{ template "retool.workflowsWorker.name" . }}
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9090'
 {{- if .Values.podAnnotations }}
@@ -32,7 +32,7 @@ spec:
 {{ toYaml .Values.workflows.annotations | indent 8 }}
 {{- end }}
       labels:
-        retoolService: {{ template "retool.fullname" . }}-workflow-worker
+        retoolService: {{ template "retool.workflowsWorker.name" . }}
 {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8 }}
 {{- end }}
@@ -110,7 +110,7 @@ spec:
           - name: WORKFLOW_WORKER_HEALTHCHECK_PORT
             value: "3005"
           - name: WORKFLOW_BACKEND_HOST
-            value: http://{{ template "retool.fullname" . }}-workflow-backend
+            value: http://{{ template "retool.workflowsBackend.name" . }}
           - name: CLIENT_ID
             value: {{ default "" .Values.config.auth.google.clientId }}
           - name: COOKIE_INSECURE
@@ -324,10 +324,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "retool.fullname" . }}-workflow-worker
+  name: {{ template "retool.workflowsWorker.name" . }}
 spec:
   selector:
-    retoolService: {{ template "retool.fullname" . }}-workflow-worker
+    retoolService: {{ template "retool.workflowsWorker.name" . }}
   ports:
   - protocol: TCP
     port: 3005


### PR DESCRIPTION
Enable internal Retool to align service names with Cloud Prod, for DD dashboards shared across env

----- 

## before the change

without custom names:

```
helm template -f ~/retool-helm/charts/retool/values.yaml retool ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="5.6.10" --set codeExecutor.image.tag="5.6.10" --set codeExecutor.enabled=true | rg retool- -C 2
```

```
kind: Secret
metadata:
  name: retool-postgresql
  namespace: "default"
  labels:
--
  name: retool
  labels:
    helm.sh/chart: retool-6.0.13
    app.kubernetes.io/name: retool
    app.kubernetes.io/instance: retool
--
kind: Service
metadata:
  name: retool-postgresql-hl
  namespace: "default"
  labels:
--
kind: Service
metadata:
  name: retool-postgresql
  namespace: "default"
  labels:
--
kind: Service
metadata:
  name: retool-code-executor
spec:
  selector:
    retoolService: retool-code-executor
  ports:
  - protocol: TCP
--
kind: Service
metadata:
  name: retool-workflow-backend
spec:
  selector:
    retoolService: retool-workflow-backend
  ports:
  - protocol: TCP
--
kind: Service
metadata:
  name: retool-workflow-worker
spec:
  selector:
    retoolService: retool-workflow-worker
  ports:
  - protocol: TCP
--
metadata:
  labels:
    helm.sh/chart: retool-6.0.13
    app.kubernetes.io/name: retool
    app.kubernetes.io/instance: retool
--
  name: retool
  labels:
    helm.sh/chart: retool-6.0.13
    app.kubernetes.io/name: retool
    app.kubernetes.io/instance: retool
--
          - bash
          - -c
          - chmod -R +x ./docker_scripts; sync; ./docker_scripts/wait-for-it.sh -t 0 "retool-postgresql":"5432"; ./docker_scripts/start_api.sh
        env:
          - name: NODE_ENV
--
            value: "false"
          - name: POSTGRES_HOST
            value: "retool-postgresql"
          - name: POSTGRES_PORT
            value: "5432"
--
            value: "false"
          - name: WORKFLOW_BACKEND_HOST
            value: http://retool-workflow-backend
          - name: CODE_EXECUTOR_INGRESS_DOMAIN
            value: http://retool-code-executor
          - name: LICENSE_KEY
            valueFrom:
--
            valueFrom:
              secretKeyRef:
                name: retool-postgresql
                # `postgres` is the default admin username for postgres in the subchart we use, so it needs the admin password
                # if a different username is picked, then it needs the custom password instead.
--
kind: Deployment
metadata:
  name: retool-code-executor
  labels:
    retoolService: retool-code-executor
    helm.sh/chart: retool-6.0.13
    app.kubernetes.io/name: retool
    app.kubernetes.io/instance: retool
--
  selector:
    matchLabels:
      retoolService: retool-code-executor
  revisionHistoryLimit: 3
  template:
    metadata:
      annotations:
        prometheus.io/job: retool-code-executor
        prometheus.io/scrape: 'true'
        prometheus.io/port: '9090'
      labels:
        retoolService: retool-code-executor
    spec:
      serviceAccountName: retool
--
kind: Deployment
metadata:
  name: retool-jobs-runner
  labels:
    helm.sh/chart: retool-6.0.13
    app.kubernetes.io/name: retool
    app.kubernetes.io/instance: retool
--
  selector:
    matchLabels:
      app.kubernetes.io/name: retool-jobs-runner
      app.kubernetes.io/instance: retool
  revisionHistoryLimit: 3
--
      annotations:
      labels:
        app.kubernetes.io/name: retool-jobs-runner
        app.kubernetes.io/instance: retool
    spec:
--
          - bash
          - -c
          - chmod -R +x ./docker_scripts; sync; ./docker_scripts/wait-for-it.sh -t 0 "retool-postgresql":"5432"; ./docker_scripts/start_api.sh
        env:
          - name: NODE_ENV
--
            value: "false"
          - name: POSTGRES_HOST
            value: "retool-postgresql"
          - name: POSTGRES_PORT
            value: "5432"
--
            valueFrom:
              secretKeyRef:
                name: retool-postgresql
                key: postgres-password
          - name: CLIENT_SECRET
--
kind: Deployment
metadata:
  name: retool-workflow-backend
  labels:
    retoolService: retool-workflow-backend
    helm.sh/chart: retool-6.0.13
    app.kubernetes.io/name: retool
    app.kubernetes.io/instance: retool
--
  selector:
    matchLabels:
      retoolService: retool-workflow-backend
  revisionHistoryLimit: 3
  template:
--
      annotations:
      labels:
        retoolService: retool-workflow-backend
    spec:
      serviceAccountName: retool
--
          - bash
          - -c
          - chmod -R +x ./docker_scripts; sync; ./docker_scripts/wait-for-it.sh -t 0 "retool-postgresql":"5432"; ./docker_scripts/start_api.sh
        env:
          - name: NODE_ENV
--
            value: "false"
          - name: POSTGRES_HOST
            value: "retool-postgresql"
          - name: POSTGRES_PORT
            value: "5432"
--
            value: "false"
          - name: WORKFLOW_BACKEND_HOST
            value: http://retool-workflow-backend
          - name: CODE_EXECUTOR_INGRESS_DOMAIN
            value: http://retool-code-executor
          - name: LICENSE_KEY
            valueFrom:
--
            valueFrom:
              secretKeyRef:
                name: retool-postgresql
                key: postgres-password
          - name: CLIENT_SECRET
--
kind: Deployment
metadata:
  name: retool-workflow-worker
  labels:
    retoolService: retool-workflow-worker
    helm.sh/chart: retool-6.0.13
    app.kubernetes.io/name: retool
    app.kubernetes.io/instance: retool
--
  selector:
    matchLabels:
      retoolService: retool-workflow-worker
  revisionHistoryLimit: 3
  template:
    metadata:
      annotations:
        prometheus.io/job: retool-workflow-worker
        prometheus.io/scrape: 'true'
        prometheus.io/port: '9090'
      labels:
        retoolService: retool-workflow-worker
    spec:
      serviceAccountName: retool
--
          - bash
          - -c
          - chmod -R +x ./docker_scripts; sync; ./docker_scripts/wait-for-it.sh -t 0 "retool-postgresql":"5432"; ./docker_scripts/start_api.sh
        env:
          - name: NODE_ENV
--
            value: "3005"
          - name: WORKFLOW_BACKEND_HOST
            value: http://retool-workflow-backend
          - name: CLIENT_ID
            value:
--
            value: "false"
          - name: POSTGRES_HOST
            value: "retool-postgresql"
          - name: POSTGRES_PORT
            value: "5432"
--
            value: "false"
          - name: CODE_EXECUTOR_INGRESS_DOMAIN
            value: http://retool-code-executor
          - name: LICENSE_KEY
            valueFrom:
--
            valueFrom:
              secretKeyRef:
                name: retool-postgresql
                key: postgres-password
          - name: CLIENT_SECRET
--
kind: StatefulSet
metadata:
  name: retool-postgresql
  namespace: "default"
  labels:
--
spec:
  replicas: 1
  serviceName: retool-postgresql-hl
  updateStrategy:
    rollingUpdate: {}
--
  template:
    metadata:
      name: retool-postgresql
      labels:
        app.kubernetes.io/name: postgresql
--
              valueFrom:
                secretKeyRef:
                  name: retool-postgresql
                  key: postgres-password
            - name: POSTGRES_DB
--
metadata:
  labels:
    helm.sh/chart: retool-6.0.13
    app.kubernetes.io/name: retool
    app.kubernetes.io/instance: retool
```

## after the change

without custom names (no difference):

```
helm template -f ~/retool-helm/charts/retool/values.yaml retool ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="5.6.10" --set codeExecutor.image.tag="5.6.10" --set codeExecutor.enabled=true | rg retool- -C 2
```

```
kind: Secret
metadata:
  name: retool-postgresql
  namespace: "default"
  labels:
--
  name: retool
  labels:
    helm.sh/chart: retool-6.0.14
    app.kubernetes.io/name: retool
    app.kubernetes.io/instance: retool
--
kind: Service
metadata:
  name: retool-postgresql-hl
  namespace: "default"
  labels:
--
kind: Service
metadata:
  name: retool-postgresql
  namespace: "default"
  labels:
--
kind: Service
metadata:
  name: retool-code-executor
spec:
  selector:
    retoolService: retool-code-executor
  ports:
  - protocol: TCP
--
kind: Service
metadata:
  name: retool-workflow-backend
spec:
  selector:
    retoolService: retool-workflow-backend
  ports:
  - protocol: TCP
--
kind: Service
metadata:
  name: retool-workflow-worker
spec:
  selector:
    retoolService: retool-workflow-worker
  ports:
  - protocol: TCP
--
metadata:
  labels:
    helm.sh/chart: retool-6.0.14
    app.kubernetes.io/name: retool
    app.kubernetes.io/instance: retool
--
  name: retool
  labels:
    helm.sh/chart: retool-6.0.14
    app.kubernetes.io/name: retool
    app.kubernetes.io/instance: retool
--
          - bash
          - -c
          - chmod -R +x ./docker_scripts; sync; ./docker_scripts/wait-for-it.sh -t 0 "retool-postgresql":"5432"; ./docker_scripts/start_api.sh
        env:
          - name: NODE_ENV
--
            value: "false"
          - name: POSTGRES_HOST
            value: "retool-postgresql"
          - name: POSTGRES_PORT
            value: "5432"
--
            value: "false"
          - name: WORKFLOW_BACKEND_HOST
            value: http://retool-workflow-backend
          - name: CODE_EXECUTOR_INGRESS_DOMAIN
            value: http://retool-code-executor
          - name: LICENSE_KEY
            valueFrom:
--
            valueFrom:
              secretKeyRef:
                name: retool-postgresql
                # `postgres` is the default admin username for postgres in the subchart we use, so it needs the admin password
                # if a different username is picked, then it needs the custom password instead.
--
kind: Deployment
metadata:
  name: retool-code-executor
  labels:
    retoolService: retool-code-executor
    helm.sh/chart: retool-6.0.14
    app.kubernetes.io/name: retool
    app.kubernetes.io/instance: retool
--
  selector:
    matchLabels:
      retoolService: retool-code-executor
  revisionHistoryLimit: 3
  template:
    metadata:
      annotations:
        prometheus.io/job: retool-code-executor
        prometheus.io/scrape: 'true'
        prometheus.io/port: '9090'
      labels:
        retoolService: retool-code-executor
    spec:
      serviceAccountName: retool
--
kind: Deployment
metadata:
  name: retool-jobs-runner
  labels:
    helm.sh/chart: retool-6.0.14
    app.kubernetes.io/name: retool
    app.kubernetes.io/instance: retool
--
  selector:
    matchLabels:
      app.kubernetes.io/name: retool-jobs-runner
      app.kubernetes.io/instance: retool
  revisionHistoryLimit: 3
--
      annotations:
      labels:
        app.kubernetes.io/name: retool-jobs-runner
        app.kubernetes.io/instance: retool
    spec:
--
          - bash
          - -c
          - chmod -R +x ./docker_scripts; sync; ./docker_scripts/wait-for-it.sh -t 0 "retool-postgresql":"5432"; ./docker_scripts/start_api.sh
        env:
          - name: NODE_ENV
--
            value: "false"
          - name: POSTGRES_HOST
            value: "retool-postgresql"
          - name: POSTGRES_PORT
            value: "5432"
--
            valueFrom:
              secretKeyRef:
                name: retool-postgresql
                key: postgres-password
          - name: CLIENT_SECRET
--
kind: Deployment
metadata:
  name: retool-workflow-backend
  labels:
    retoolService: retool-workflow-backend
    helm.sh/chart: retool-6.0.14
    app.kubernetes.io/name: retool
    app.kubernetes.io/instance: retool
--
  selector:
    matchLabels:
      retoolService: retool-workflow-backend
  revisionHistoryLimit: 3
  template:
--
      annotations:
      labels:
        retoolService: retool-workflow-backend
    spec:
      serviceAccountName: retool
--
          - bash
          - -c
          - chmod -R +x ./docker_scripts; sync; ./docker_scripts/wait-for-it.sh -t 0 "retool-postgresql":"5432"; ./docker_scripts/start_api.sh
        env:
          - name: NODE_ENV
--
            value: "false"
          - name: POSTGRES_HOST
            value: "retool-postgresql"
          - name: POSTGRES_PORT
            value: "5432"
--
            value: "false"
          - name: WORKFLOW_BACKEND_HOST
            value: http://retool-workflow-backend
          - name: CODE_EXECUTOR_INGRESS_DOMAIN
            value: http://retool-code-executor
          - name: LICENSE_KEY
            valueFrom:
--
            valueFrom:
              secretKeyRef:
                name: retool-postgresql
                key: postgres-password
          - name: CLIENT_SECRET
--
kind: Deployment
metadata:
  name: retool-workflow-worker
  labels:
    retoolService: retool-workflow-worker
    helm.sh/chart: retool-6.0.14
    app.kubernetes.io/name: retool
    app.kubernetes.io/instance: retool
--
  selector:
    matchLabels:
      retoolService: retool-workflow-worker
  revisionHistoryLimit: 3
  template:
    metadata:
      annotations:
        prometheus.io/job: retool-workflow-worker
        prometheus.io/scrape: 'true'
        prometheus.io/port: '9090'
      labels:
        retoolService: retool-workflow-worker
    spec:
      serviceAccountName: retool
--
          - bash
          - -c
          - chmod -R +x ./docker_scripts; sync; ./docker_scripts/wait-for-it.sh -t 0 "retool-postgresql":"5432"; ./docker_scripts/start_api.sh
        env:
          - name: NODE_ENV
--
            value: "3005"
          - name: WORKFLOW_BACKEND_HOST
            value: http://retool-workflow-backend
          - name: CLIENT_ID
            value:
--
            value: "false"
          - name: POSTGRES_HOST
            value: "retool-postgresql"
          - name: POSTGRES_PORT
            value: "5432"
--
            value: "false"
          - name: CODE_EXECUTOR_INGRESS_DOMAIN
            value: http://retool-code-executor
          - name: LICENSE_KEY
            valueFrom:
--
            valueFrom:
              secretKeyRef:
                name: retool-postgresql
                key: postgres-password
          - name: CLIENT_SECRET
--
kind: StatefulSet
metadata:
  name: retool-postgresql
  namespace: "default"
  labels:
--
spec:
  replicas: 1
  serviceName: retool-postgresql-hl
  updateStrategy:
    rollingUpdate: {}
--
  template:
    metadata:
      name: retool-postgresql
      labels:
        app.kubernetes.io/name: postgresql
--
              valueFrom:
                secretKeyRef:
                  name: retool-postgresql
                  key: postgres-password
            - name: POSTGRES_DB
--
metadata:
  labels:
    helm.sh/chart: retool-6.0.14
    app.kubernetes.io/name: retool
    app.kubernetes.io/instance: retool
```


with custom names: 
```
helm template -f ~/retool-helm/charts/retool/values.yaml retool ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="5.6.10" --set codeExecutor.image.tag="5.6.10" --set codeExecutor.enabled=true --set codeExecutor.name=customName1 --set jobRunner.name=customName2 --set backend.name=customName3 --set workflows.worker.name=customName4 --set workflows.backend.name=customName5 | rg custom -C 3
```

```
apiVersion: v1
kind: Service
metadata:
  name: customName1
spec:
  selector:
    retoolService: customName1
  ports:
  - protocol: TCP
    port: 80
--
apiVersion: v1
kind: Service
metadata:
  name: customName5
spec:
  selector:
    retoolService: customName5
  ports:
  - protocol: TCP
    port: 80
--
apiVersion: v1
kind: Service
metadata:
  name: customName4
spec:
  selector:
    retoolService: customName4
  ports:
  - protocol: TCP
    port: 3005
--
apiVersion: apps/v1
kind: Deployment
metadata:
  name: customName3
  labels:
    helm.sh/chart: retool-6.0.14
    app.kubernetes.io/name: retool
--
          - name: POSTGRES_SSL_ENABLED
            value: "false"
          - name: WORKFLOW_BACKEND_HOST
            value: http://customName5
          - name: CODE_EXECUTOR_INGRESS_DOMAIN
            value: http://customName1
          - name: LICENSE_KEY
            valueFrom:
              secretKeyRef:
                name: customName3
                key: license-key
          - name: JWT_SECRET
            valueFrom:
              secretKeyRef:
                name: customName3
                key: jwt-secret
          - name: ENCRYPTION_KEY
            valueFrom:
              secretKeyRef:
                name: customName3
                key: encryption-key
          - name: POSTGRES_PASSWORD
            valueFrom:
              secretKeyRef:
                name: retool-postgresql
                # `postgres` is the default admin username for postgres in the subchart we use, so it needs the admin password
                # if a different username is picked, then it needs the custom password instead.
                key: postgres-password
          - name: CLIENT_SECRET
            valueFrom:
              secretKeyRef:
                name: customName3
                key: google-client-secret
        ports:
        - containerPort: 3000
--
apiVersion: apps/v1
kind: Deployment
metadata:
  name: customName1
  labels:
    retoolService: customName1
    helm.sh/chart: retool-6.0.14
    app.kubernetes.io/name: retool
    app.kubernetes.io/instance: retool
--
  replicas: 1
  selector:
    matchLabels:
      retoolService: customName1
  revisionHistoryLimit: 3
  template:
    metadata:
      annotations:
        prometheus.io/job: customName1
        prometheus.io/scrape: 'true'
        prometheus.io/port: '9090'
      labels:
        retoolService: customName1
    spec:
      serviceAccountName: retool
      containers:
--
apiVersion: apps/v1
kind: Deployment
metadata:
  name: customName2
  labels:
    helm.sh/chart: retool-6.0.14
    app.kubernetes.io/name: retool
--
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: customName2
      app.kubernetes.io/instance: retool
  revisionHistoryLimit: 3
  template:
    metadata:
      annotations:
      labels:
        app.kubernetes.io/name: customName2
        app.kubernetes.io/instance: retool
    spec:
      serviceAccountName: retool
--
apiVersion: apps/v1
kind: Deployment
metadata:
  name: customName5
  labels:
    retoolService: customName5
    helm.sh/chart: retool-6.0.14
    app.kubernetes.io/name: retool
    app.kubernetes.io/instance: retool
--
  replicas: 1
  selector:
    matchLabels:
      retoolService: customName5
  revisionHistoryLimit: 3
  template:
    metadata:
      annotations:
      labels:
        retoolService: customName5
    spec:
      serviceAccountName: retool
      containers:
--
          - name: POSTGRES_SSL_ENABLED
            value: "false"
          - name: WORKFLOW_BACKEND_HOST
            value: http://customName5
          - name: CODE_EXECUTOR_INGRESS_DOMAIN
            value: http://customName1
          - name: LICENSE_KEY
            valueFrom:
              secretKeyRef:
--
apiVersion: apps/v1
kind: Deployment
metadata:
  name: customName4
  labels:
    retoolService: customName4
    helm.sh/chart: retool-6.0.14
    app.kubernetes.io/name: retool
    app.kubernetes.io/instance: retool
--
  replicas: 1
  selector:
    matchLabels:
      retoolService: customName4
  revisionHistoryLimit: 3
  template:
    metadata:
      annotations:
        prometheus.io/job: customName4
        prometheus.io/scrape: 'true'
        prometheus.io/port: '9090'
      labels:
        retoolService: customName4
    spec:
      serviceAccountName: retool
      containers:
--
          - name: WORKFLOW_WORKER_HEALTHCHECK_PORT
            value: "3005"
          - name: WORKFLOW_BACKEND_HOST
            value: http://customName5
          - name: CLIENT_ID
            value:
          - name: COOKIE_INSECURE
--
          - name: POSTGRES_SSL_ENABLED
            value: "false"
          - name: CODE_EXECUTOR_INGRESS_DOMAIN
            value: http://customName1
          - name: LICENSE_KEY
            valueFrom:
              secretKeyRef:
```