### PR TITLE
enable code executor by default for image tags >=3.20.15

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.0.13
+version: 6.0.14
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -141,11 +141,11 @@ Usage: (include "retool.workflows.enabled" .)
 */}}
 {{- define "retool.workflows.enabled" -}}
 {{- $output := "" -}}
-{{- if or 
+{{- if or
     (eq (toString (default "" .Values.workflows.enabled)) "true")
-    (eq .Values.workflows.enabled true) 
-    (eq (toString (default "" .Values.workflows.enabled)) "false") 
-    (eq .Values.workflows.enabled false) 
+    (eq .Values.workflows.enabled true)
+    (eq (toString (default "" .Values.workflows.enabled)) "false")
+    (eq .Values.workflows.enabled false)
 -}}
   {{- if eq .Values.workflows.enabled true -}}
     {{- $output = "1" -}}
@@ -157,6 +157,35 @@ Usage: (include "retool.workflows.enabled" .)
 {{- else if eq .Values.image.tag "latest" -}}
   {{- $output = "1" -}}
 {{- else if semverCompare ">= 3.6.11" .Values.image.tag -}}
+  {{- $output = "1" -}}
+{{- else -}}
+  {{- $output = "" -}}
+{{- end -}}
+{{- $output -}}
+{{- end -}}
+
+{{/*
+Set Code Executor enabled
+Usage: (include "retool.codeExecutor.enabled" .)
+*/}}
+{{- define "retool.codeExecutor.enabled" -}}
+{{- $output := "" -}}
+{{- if or
+    (eq (toString (default "" .Values.codeExecutor.enabled)) "true")
+    (eq .Values.codeExecutor.enabled true)
+    (eq (toString (default "" .Values.codeExecutor.enabled)) "false")
+    (eq .Values.codeExecutor.enabled false)
+-}}
+  {{- if
+    (eq .Values.codeExecutor.enabled true)
+  -}}
+    {{- $output = "1" -}}
+  {{- else -}}
+    {{- $output = "" -}}
+  {{- end -}}
+{{- else if empty .Values.codeExecutor.image.tag -}}
+  {{- $output = "" -}}
+{{- else if semverCompare ">= 3.20.15" .Values.codeExecutor.image.tag -}}
   {{- $output = "1" -}}
 {{- else -}}
   {{- $output = "" -}}

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -142,12 +142,10 @@ Usage: (include "retool.workflows.enabled" .)
 {{- define "retool.workflows.enabled" -}}
 {{- $output := "" -}}
 {{- if or
-    (eq (toString (default "" .Values.workflows.enabled)) "true")
-    (eq .Values.workflows.enabled true)
-    (eq (toString (default "" .Values.workflows.enabled)) "false")
-    (eq .Values.workflows.enabled false)
+    (eq (toString .Values.workflows.enabled) "true")
+    (eq (toString .Values.workflows.enabled) "false")
 -}}
-  {{- if eq .Values.workflows.enabled true -}}
+  {{- if (eq (toString .Values.workflows.enabled) "true") -}}
     {{- $output = "1" -}}
   {{- else -}}
     {{- $output = "" -}}
@@ -171,14 +169,10 @@ Usage: (include "retool.codeExecutor.enabled" .)
 {{- define "retool.codeExecutor.enabled" -}}
 {{- $output := "" -}}
 {{- if or
-    (eq (toString (default "" .Values.codeExecutor.enabled)) "true")
-    (eq .Values.codeExecutor.enabled true)
-    (eq (toString (default "" .Values.codeExecutor.enabled)) "false")
-    (eq .Values.codeExecutor.enabled false)
+    (eq (toString .Values.codeExecutor.enabled) "true")
+    (eq (toString .Values.codeExecutor.enabled) "false")
 -}}
-  {{- if
-    (eq .Values.codeExecutor.enabled true)
-  -}}
+  {{- if (eq (toString .Values.codeExecutor.enabled) "true") -}}
     {{- $output = "1" -}}
   {{- else -}}
     {{- $output = "" -}}

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -132,7 +132,7 @@ spec:
               {{- end }}
           {{- end }}
           {{- end }}
-          {{- if .Values.codeExecutor.enabled }}
+          {{- if include "retool.codeExecutor.enabled" . }}
           - name: CODE_EXECUTOR_INGRESS_DOMAIN
             value: http://{{ template "retool.codeExecutor.name" . }}
           {{- end }}

--- a/charts/retool/templates/deployment_code_executor.yaml
+++ b/charts/retool/templates/deployment_code_executor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.codeExecutor.enabled }}
+{{- if include "retool.codeExecutor.enabled" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/retool/templates/deployment_workflows_worker.yaml
+++ b/charts/retool/templates/deployment_workflows_worker.yaml
@@ -125,7 +125,7 @@ spec:
             value: {{ template "retool.postgresql.user" . }}
           - name: POSTGRES_SSL_ENABLED
             value: {{ template "retool.postgresql.ssl_enabled" . }}
-          {{- if .Values.codeExecutor.enabled }}
+          {{- if include "retool.codeExecutor.enabled" . }}
           - name: CODE_EXECUTOR_INGRESS_DOMAIN
             value: http://{{ template "retool.codeExecutor.name" . }}
           {{- end }}

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -406,9 +406,10 @@ dbconnector:
     enabled: false
 
 codeExecutor:
-  # Enable this for Python support and running code more securely within a separate
-  # sandboxed environment
-  enabled: false
+  # enabled by default from Chart version 6.0.15 and Retool image 3.20.15 onwards
+  # explicitly set other fields as needed
+
+  # enabled: true
 
   replicaCount: 1
 

--- a/values.yaml
+++ b/values.yaml
@@ -406,9 +406,10 @@ dbconnector:
     enabled: false
 
 codeExecutor:
-  # Enable this for Python support and running code more securely within a separate
-  # sandboxed environment
-  enabled: false
+  # enabled by default from Chart version 6.0.15 and Retool image 3.20.15 onwards
+  # explicitly set other fields as needed
+
+  # enabled: true
 
   replicaCount: 1
 


### PR DESCRIPTION
- Enables code executor by default for image tags >=3.20.15 (where we started publishing matching tags for CE consistently)
- Corresponds to docs changes here: https://github.com/tryretool/docs/pull/568
- Corresponds to other docs changes here: https://github.com/tryretool/docs/pull/572 that request 3.7+ https://docs.retool.com/self-hosted/quickstarts/kubernetes/helm#requirements. I tried with 3.3... template is broken.

## Tests

### Helm 3.7 
we've had issues with this before: https://retooled.slack.com/archives/C03THV8QH0S/p1702051476282189

#### Inputs

```
echo "\n\n\n ====== Running tests for code-executor (helm 3.7) ======";
echo helm-3-7 version

echo "TEST: --set codeExecutor.enabled=true --set codeExecutor.image.tag=1.1.0";
helm-3-7 template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="5.6.10" --set codeExecutor.enabled=true --set codeExecutor.image.tag=1.1.0 | grep code-executor;
echo "expecting CE";
echo "\n";

echo "TEST: --set codeExecutor.enabled='true' --set codeExecutor.image.tag=1.1.0";
helm-3-7 template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="5.6.10" --set codeExecutor.enabled="true" --set codeExecutor.image.tag=1.1.0 | grep code-executor;
echo "expecting CE";
echo "\n";

echo "TEST: --set codeExecutor.enabled=false";
helm-3-7 template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="5.6.10" --set codeExecutor.enabled=false | grep code-executor;
echo "No CE";
echo "\n";

echo "TEST: --set codeExecutor.enabled='false'";
helm-3-7 template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="5.6.10" --set codeExecutor.enabled="false" | grep code-executor;
echo "No CE";
echo "\n";

echo "TEST: --set codeExecutor.image.tag=3.20.15";
helm-3-7 template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="5.6.10" --set codeExecutor.image.tag=3.20.15 | grep code-executor;
echo "expecting CE";
echo "\n";

echo "TEST: --set codeExecutor.image.tag=3.21.1";
helm-3-7 template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="5.6.10" --set codeExecutor.image.tag=3.21.1 | grep code-executor;
echo "expecting CE";
echo "\n";

echo "TEST: --set codeExecutor.image.tag=1.1.0";
helm-3-7 template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="5.6.10" --set codeExecutor.image.tag=1.1.0 | grep code-executor;
echo "No CE";
echo "\n";


echo "\n\n\n ====== Running tests for workflows (helm 3.7) ======";

echo "TEST: --set workflows.enabled=true ";
helm-3-7 template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="5.6.10" --set workflows.enabled=true  | grep worker;
echo "expecting worker";
echo "\n";

echo "TEST: --set workflows.enabled='true'";
helm-3-7 template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="5.6.10" --set workflows.enabled="true"  | grep worker;
echo "expecting worker";
echo "\n";

echo "TEST: --set workflows.enabled=false";
helm-3-7 template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="5.6.10" --set workflows.enabled=false | grep worker;
echo "No worker";
echo "\n";

echo "TEST: --set workflows.enabled='false'";
helm-3-7 template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="5.6.10" --set workflows.enabled="false" | grep worker;
echo "No worker";
echo "\n";

echo "TEST: --set image.tag=3.6.11";
helm-3-7 template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo"  --set image.tag=3.6.11 | grep worker;
echo "expecting worker";
echo "\n";

echo "TEST: --set image.tag=3.21.1";
helm-3-7 template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag=3.21.1 | grep worker;
echo "expecting worker";
echo "\n";

echo "TEST: --set image.tag=3.4.14";
helm-3-7 template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="3.4.14" | grep worker;
echo "No worker";
echo "\n";

echo "\n\n\n ====== Running tests for workflows w/ code executor (default) (helm 3.7) ======";

echo "TEST: --set image.tag=3.4.14 --set codeExecutor.image.tag=3.20.15";
helm-3-7 template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="3.20.16" --set codeExecutor.image.tag="3.20.16" | grep 'worker\|code-executor';
echo "worker AND code executor";
echo "\n";
```

#### Outputs

```
 ====== Running tests for code-executor (helm 3.7) ======
helm-3-7 version
TEST: --set codeExecutor.enabled=true --set codeExecutor.image.tag=1.1.0
  name: foo-retool-code-executor
    retoolService: foo-retool-code-executor
            value: http://foo-retool-code-executor
  name: foo-retool-code-executor
    retoolService: foo-retool-code-executor
      retoolService: foo-retool-code-executor
        prometheus.io/job: foo-retool-code-executor
        retoolService: foo-retool-code-executor
        image: "tryretool/code-executor-service:1.1.0"
            value: http://foo-retool-code-executor
            value: http://foo-retool-code-executor
expecting CE


TEST: --set codeExecutor.enabled='true' --set codeExecutor.image.tag=1.1.0
  name: foo-retool-code-executor
    retoolService: foo-retool-code-executor
            value: http://foo-retool-code-executor
  name: foo-retool-code-executor
    retoolService: foo-retool-code-executor
      retoolService: foo-retool-code-executor
        prometheus.io/job: foo-retool-code-executor
        retoolService: foo-retool-code-executor
        image: "tryretool/code-executor-service:1.1.0"
            value: http://foo-retool-code-executor
            value: http://foo-retool-code-executor
expecting CE


TEST: --set codeExecutor.enabled=false
No CE


TEST: --set codeExecutor.enabled='false'
No CE


TEST: --set codeExecutor.image.tag=3.20.15
  name: foo-retool-code-executor
    retoolService: foo-retool-code-executor
            value: http://foo-retool-code-executor
  name: foo-retool-code-executor
    retoolService: foo-retool-code-executor
      retoolService: foo-retool-code-executor
        prometheus.io/job: foo-retool-code-executor
        retoolService: foo-retool-code-executor
        image: "tryretool/code-executor-service:3.20.15"
            value: http://foo-retool-code-executor
expecting CE


TEST: --set codeExecutor.image.tag=3.21.1
  name: foo-retool-code-executor
    retoolService: foo-retool-code-executor
            value: http://foo-retool-code-executor
  name: foo-retool-code-executor
    retoolService: foo-retool-code-executor
      retoolService: foo-retool-code-executor
        prometheus.io/job: foo-retool-code-executor
        retoolService: foo-retool-code-executor
        image: "tryretool/code-executor-service:3.21.1"
            value: http://foo-retool-code-executor
expecting CE


TEST: --set codeExecutor.image.tag=1.1.0
No CE





 ====== Running tests for workflows (helm 3.7) ======
TEST: --set workflows.enabled=true
# Source: retool/templates/deployment_workflows_worker.yaml
  name: foo-retool-workflow-worker
    retoolService: foo-retool-workflow-worker
# Source: retool/templates/deployment_workflows_worker.yaml
  name: foo-retool-workflow-worker
    retoolService: foo-retool-workflow-worker
      retoolService: foo-retool-workflow-worker
        prometheus.io/job: foo-retool-workflow-worker
        retoolService: foo-retool-workflow-worker
expecting worker


TEST: --set workflows.enabled='true'
# Source: retool/templates/deployment_workflows_worker.yaml
  name: foo-retool-workflow-worker
    retoolService: foo-retool-workflow-worker
# Source: retool/templates/deployment_workflows_worker.yaml
  name: foo-retool-workflow-worker
    retoolService: foo-retool-workflow-worker
      retoolService: foo-retool-workflow-worker
        prometheus.io/job: foo-retool-workflow-worker
        retoolService: foo-retool-workflow-worker
expecting worker


TEST: --set workflows.enabled=false
No worker


TEST: --set workflows.enabled='false'
No worker


TEST: --set image.tag=3.6.11
# Source: retool/templates/deployment_workflows_worker.yaml
  name: foo-retool-workflow-worker
    retoolService: foo-retool-workflow-worker
# Source: retool/templates/deployment_workflows_worker.yaml
  name: foo-retool-workflow-worker
    retoolService: foo-retool-workflow-worker
      retoolService: foo-retool-workflow-worker
        prometheus.io/job: foo-retool-workflow-worker
        retoolService: foo-retool-workflow-worker
expecting worker


TEST: --set image.tag=3.21.1
# Source: retool/templates/deployment_workflows_worker.yaml
  name: foo-retool-workflow-worker
    retoolService: foo-retool-workflow-worker
# Source: retool/templates/deployment_workflows_worker.yaml
  name: foo-retool-workflow-worker
    retoolService: foo-retool-workflow-worker
      retoolService: foo-retool-workflow-worker
        prometheus.io/job: foo-retool-workflow-worker
        retoolService: foo-retool-workflow-worker
expecting worker


TEST: --set image.tag=3.4.14
No worker





 ====== Running tests for workflows w/ code executor (default) (helm 3.7) ======
TEST: --set image.tag=3.4.14 --set codeExecutor.image.tag=3.20.15
  name: foo-retool-code-executor
    retoolService: foo-retool-code-executor
# Source: retool/templates/deployment_workflows_worker.yaml
  name: foo-retool-workflow-worker
    retoolService: foo-retool-workflow-worker
            value: http://foo-retool-code-executor
  name: foo-retool-code-executor
    retoolService: foo-retool-code-executor
      retoolService: foo-retool-code-executor
        prometheus.io/job: foo-retool-code-executor
        retoolService: foo-retool-code-executor
        image: "tryretool/code-executor-service:3.20.16"
# Source: retool/templates/deployment_workflows_worker.yaml
  name: foo-retool-workflow-worker
    retoolService: foo-retool-workflow-worker
      retoolService: foo-retool-workflow-worker
        prometheus.io/job: foo-retool-workflow-worker
        retoolService: foo-retool-workflow-worker
            value: http://foo-retool-code-executor
worker AND code executor
```

### Helm 3.10  

#### Inputs

```
echo "\n\n\n ====== Running tests for code-executor (helm) ======";
helm version

echo "TEST: --set codeExecutor.enabled=true --set codeExecutor.image.tag=1.1.0";
helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="5.6.10" --set codeExecutor.enabled=true --set codeExecutor.image.tag=1.1.0 | grep code-executor;
echo "expecting CE";
echo "\n";

echo "TEST: --set codeExecutor.enabled='true' --set codeExecutor.image.tag=1.1.0";
helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="5.6.10" --set codeExecutor.enabled="true" --set codeExecutor.image.tag=1.1.0 | grep code-executor;
echo "expecting CE";
echo "\n";

echo "TEST: --set codeExecutor.enabled=false";
helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="5.6.10" --set codeExecutor.enabled=false | grep code-executor;
echo "No CE";
echo "\n";

echo "TEST: --set codeExecutor.enabled='false'";
helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="5.6.10" --set codeExecutor.enabled="false" | grep code-executor;
echo "No CE";
echo "\n";

echo "TEST: --set codeExecutor.image.tag=3.20.15";
helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="5.6.10" --set codeExecutor.image.tag=3.20.15 | grep code-executor;
echo "expecting CE";
echo "\n";

echo "TEST: --set codeExecutor.image.tag=3.21.1";
helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="5.6.10" --set codeExecutor.image.tag=3.21.1 | grep code-executor;
echo "expecting CE";
echo "\n";

echo "TEST: --set codeExecutor.image.tag=1.1.0";
helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="5.6.10" --set codeExecutor.image.tag=1.1.0 | grep code-executor;
echo "No CE";
echo "\n";


echo "\n\n\n ====== Running tests for workflows (helm) ======";

echo "TEST: --set workflows.enabled=true ";
helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="5.6.10" --set workflows.enabled=true  | grep worker;
echo "expecting worker";
echo "\n";

echo "TEST: --set workflows.enabled='true'";
helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="5.6.10" --set workflows.enabled="true"  | grep worker;
echo "expecting worker";
echo "\n";

echo "TEST: --set workflows.enabled=false";
helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="5.6.10" --set workflows.enabled=false | grep worker;
echo "No worker";
echo "\n";

echo "TEST: --set workflows.enabled='false'";
helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="5.6.10" --set workflows.enabled="false" | grep worker;
echo "No worker";
echo "\n";

echo "TEST: --set image.tag=3.6.11";
helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo"  --set image.tag=3.6.11 | grep worker;
echo "expecting worker";
echo "\n";

echo "TEST: --set image.tag=3.21.1";
helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag=3.21.1 | grep worker;
echo "expecting worker";
echo "\n";

echo "TEST: --set image.tag=3.4.14";
helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="3.4.14" | grep worker;
echo "No worker";
echo "\n";

echo "\n\n\n ====== Running tests for workflows w/ code executor (default) (helm) ======";

echo "TEST: --set image.tag=3.4.14 --set codeExecutor.image.tag=3.20.15";
helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="3.20.16" --set codeExecutor.image.tag="3.20.16" | grep 'worker\|code-executor';
echo "worker AND code executor";
echo "\n";

```


#### Outputs

```
 ====== Running tests for code-executor (helm) ======
version.BuildInfo{Version:"v3.10.3", GitCommit:"835b7334cfe2e5e27870ab3ed4135f136eecc704", GitTreeState:"clean", GoVersion:"go1.19.4"}
TEST: --set codeExecutor.enabled=true --set codeExecutor.image.tag=1.1.0
  name: foo-retool-code-executor
    retoolService: foo-retool-code-executor
            value: http://foo-retool-code-executor
  name: foo-retool-code-executor
    retoolService: foo-retool-code-executor
      retoolService: foo-retool-code-executor
        prometheus.io/job: foo-retool-code-executor
        retoolService: foo-retool-code-executor
        image: "tryretool/code-executor-service:1.1.0"
            value: http://foo-retool-code-executor
            value: http://foo-retool-code-executor
expecting CE


TEST: --set codeExecutor.enabled='true' --set codeExecutor.image.tag=1.1.0
  name: foo-retool-code-executor
    retoolService: foo-retool-code-executor
            value: http://foo-retool-code-executor
  name: foo-retool-code-executor
    retoolService: foo-retool-code-executor
      retoolService: foo-retool-code-executor
        prometheus.io/job: foo-retool-code-executor
        retoolService: foo-retool-code-executor
        image: "tryretool/code-executor-service:1.1.0"
            value: http://foo-retool-code-executor
            value: http://foo-retool-code-executor
expecting CE


TEST: --set codeExecutor.enabled=false
No CE


TEST: --set codeExecutor.enabled='false'
No CE


TEST: --set codeExecutor.image.tag=3.20.15
  name: foo-retool-code-executor
    retoolService: foo-retool-code-executor
            value: http://foo-retool-code-executor
  name: foo-retool-code-executor
    retoolService: foo-retool-code-executor
      retoolService: foo-retool-code-executor
        prometheus.io/job: foo-retool-code-executor
        retoolService: foo-retool-code-executor
        image: "tryretool/code-executor-service:3.20.15"
            value: http://foo-retool-code-executor
expecting CE


TEST: --set codeExecutor.image.tag=3.21.1
  name: foo-retool-code-executor
    retoolService: foo-retool-code-executor
            value: http://foo-retool-code-executor
  name: foo-retool-code-executor
    retoolService: foo-retool-code-executor
      retoolService: foo-retool-code-executor
        prometheus.io/job: foo-retool-code-executor
        retoolService: foo-retool-code-executor
        image: "tryretool/code-executor-service:3.21.1"
            value: http://foo-retool-code-executor
expecting CE


TEST: --set codeExecutor.image.tag=1.1.0
No CE





 ====== Running tests for workflows (helm) ======
TEST: --set workflows.enabled=true
# Source: retool/templates/deployment_workflows_worker.yaml
  name: foo-retool-workflow-worker
    retoolService: foo-retool-workflow-worker
# Source: retool/templates/deployment_workflows_worker.yaml
  name: foo-retool-workflow-worker
    retoolService: foo-retool-workflow-worker
      retoolService: foo-retool-workflow-worker
        prometheus.io/job: foo-retool-workflow-worker
        retoolService: foo-retool-workflow-worker
expecting worker


TEST: --set workflows.enabled='true'
# Source: retool/templates/deployment_workflows_worker.yaml
  name: foo-retool-workflow-worker
    retoolService: foo-retool-workflow-worker
# Source: retool/templates/deployment_workflows_worker.yaml
  name: foo-retool-workflow-worker
    retoolService: foo-retool-workflow-worker
      retoolService: foo-retool-workflow-worker
        prometheus.io/job: foo-retool-workflow-worker
        retoolService: foo-retool-workflow-worker
expecting worker


TEST: --set workflows.enabled=false
No worker


TEST: --set workflows.enabled='false'
No worker


TEST: --set image.tag=3.6.11
# Source: retool/templates/deployment_workflows_worker.yaml
  name: foo-retool-workflow-worker
    retoolService: foo-retool-workflow-worker
# Source: retool/templates/deployment_workflows_worker.yaml
  name: foo-retool-workflow-worker
    retoolService: foo-retool-workflow-worker
      retoolService: foo-retool-workflow-worker
        prometheus.io/job: foo-retool-workflow-worker
        retoolService: foo-retool-workflow-worker
expecting worker


TEST: --set image.tag=3.21.1
# Source: retool/templates/deployment_workflows_worker.yaml
  name: foo-retool-workflow-worker
    retoolService: foo-retool-workflow-worker
# Source: retool/templates/deployment_workflows_worker.yaml
  name: foo-retool-workflow-worker
    retoolService: foo-retool-workflow-worker
      retoolService: foo-retool-workflow-worker
        prometheus.io/job: foo-retool-workflow-worker
        retoolService: foo-retool-workflow-worker
expecting worker


TEST: --set image.tag=3.4.14
No worker


 ====== Running tests for workflows w/ code executor (default) (helm) ======
TEST: --set image.tag=3.4.14 --set codeExecutor.image.tag=3.20.15
  name: foo-retool-code-executor
    retoolService: foo-retool-code-executor
# Source: retool/templates/deployment_workflows_worker.yaml
  name: foo-retool-workflow-worker
    retoolService: foo-retool-workflow-worker
            value: http://foo-retool-code-executor
  name: foo-retool-code-executor
    retoolService: foo-retool-code-executor
      retoolService: foo-retool-code-executor
        prometheus.io/job: foo-retool-code-executor
        retoolService: foo-retool-code-executor
        image: "tryretool/code-executor-service:3.20.16"
# Source: retool/templates/deployment_workflows_worker.yaml
  name: foo-retool-workflow-worker
    retoolService: foo-retool-workflow-worker
      retoolService: foo-retool-workflow-worker
        prometheus.io/job: foo-retool-workflow-worker
        retoolService: foo-retool-workflow-worker
            value: http://foo-retool-code-executor
worker AND code executor
```


