### PR TITLE
add default image tag for code executor

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.0.14
+version: 6.0.15
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -177,6 +177,8 @@ Usage: (include "retool.codeExecutor.enabled" .)
   {{- else -}}
     {{- $output = "" -}}
   {{- end -}}
+{{- else if empty (include "retool.codeExecutor.image.tag" .) -}}
+  {{- $output = "" -}}
 {{- else if semverCompare ">= 3.20.15" (include "retool.codeExecutor.image.tag" .) -}}
   {{- $output = "1" -}}
 {{- else -}}
@@ -234,8 +236,10 @@ Usage: (template "retool.codeExecutor.image.tag" .)
 {{- if .Values.codeExecutor.image.tag -}}
   {{- .Values.codeExecutor.image.tag -}}
 {{- else if .Values.image.tag  -}}
-  {{- if eq .Values.image.tag "latest" -}}
-    {{- fail "If using image.tag=latest (not recommended), explicitly set codeExecutor.image.tag" }}
+  {{- if and (eq .Values.image.tag "latest") (eq (toString .Values.codeExecutor.enabled) "true") -}}
+    {{- fail "If using image.tag=latest (not recommended, select an explicit tag instead) and enabling codeExecutor, explicitly set codeExecutor.image.tag" }}
+  {{- else if (eq .Values.image.tag "latest") -}}
+    {{- "" -}}
   {{- else if semverCompare ">= 3.20.15" .Values.image.tag -}}
     {{- .Values.image.tag -}}
   {{- else -}}

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -177,15 +177,14 @@ Usage: (include "retool.codeExecutor.enabled" .)
   {{- else -}}
     {{- $output = "" -}}
   {{- end -}}
-{{- else if empty .Values.codeExecutor.image.tag -}}
-  {{- $output = "" -}}
-{{- else if semverCompare ">= 3.20.15" .Values.codeExecutor.image.tag -}}
+{{- else if semverCompare ">= 3.20.15" (include "retool.codeExecutor.image.tag" .) -}}
   {{- $output = "1" -}}
 {{- else -}}
   {{- $output = "" -}}
 {{- end -}}
 {{- $output -}}
 {{- end -}}
+
 
 {{/*
 Set Temporal frontend host
@@ -225,4 +224,24 @@ Set code executor service name
 */}}
 {{- define "retool.codeExecutor.name" -}}
 {{ template "retool.fullname" . }}-code-executor
+{{- end -}}
+
+{{/*
+Set code executor image tag
+Usage: (template "retool.codeExecutor.image.tag" .)
+*/}}
+{{- define "retool.codeExecutor.image.tag" -}}
+{{- if .Values.codeExecutor.image.tag -}}
+  {{- .Values.codeExecutor.image.tag -}}
+{{- else if .Values.image.tag  -}}
+  {{- if eq .Values.image.tag "latest" -}}
+    {{- fail "If using image.tag=latest (not recommended), explicitly set codeExecutor.image.tag" }}
+  {{- else if semverCompare ">= 3.20.15" .Values.image.tag -}}
+    {{- .Values.image.tag -}}
+  {{- else -}}
+    {{- "1.1.0" -}}
+  {{- end -}}
+{{- else -}}
+  {{- fail "Please set a value for .Values.image.tag" }}
+{{- end -}}
 {{- end -}}

--- a/charts/retool/templates/deployment_code_executor.yaml
+++ b/charts/retool/templates/deployment_code_executor.yaml
@@ -50,7 +50,7 @@ spec:
 {{- end }}
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.codeExecutor.image.repository }}:{{ required "Please set a value for .Values.codeExecutor.image.tag" .Values.codeExecutor.image.tag }}"
+        image: "{{ .Values.codeExecutor.image.repository }}:{{ include "retool.codeExecutor.image.tag" . }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:
           privileged: true

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -439,7 +439,8 @@ codeExecutor:
 
   image:
     repository: tryretool/code-executor-service
-    tag:
+    # defaults to image.tag if >= 3.20.15, otherwise defaults to 1.1.0; explicitly set to override.
+    # tag:
     pullPolicy: IfNotPresent
 
 retool-temporal-services-helm:

--- a/values.yaml
+++ b/values.yaml
@@ -439,7 +439,8 @@ codeExecutor:
 
   image:
     repository: tryretool/code-executor-service
-    tag:
+    # defaults to image.tag if >= 3.20.15, otherwise defaults to 1.1.0; explicitly set to override.
+    # tag:
     pullPolicy: IfNotPresent
 
 retool-temporal-services-helm:


### PR DESCRIPTION
Follow up from https://github.com/tryretool/retool-helm/pull/145

Adds default image tag for code executor that's based on backend's image tag (after 3.20.15)

## Tests

###  Inputs

```
echo "\n\n\n ====== Running tests for code-executor (helm) ======";
helm version

echo "TEST: (no tag)"
helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" | grep code-executor;
echo "No CE";
echo "\n";

echo "TEST: --set image.tag=3.20.16"
helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="3.20.16" | grep code-executor;
echo "Expecting CE (3.20.16)";
echo "\n";

echo "TEST: --set image.tag=3.20.16 --set codeExecutor.enabled=true"
helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="3.20.16" --set codeExecutor.enabled=true | grep code-executor;
echo "Expecting CE (3.20.16)";
echo "\n";

echo "TEST: --set image.tag=3.20.14"
helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="3.20.14" | grep code-executor;
echo "No CE";
echo "\n";

echo "TEST: --set image.tag=3.20.14 --set codeExecutor.image.tag=3.20.14"
helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="3.20.14" --set codeExecutor.image.tag="3.20.14" | grep code-executor;
echo "No CE";
echo "\n";

echo "TEST: --set image.tag=3.20.14 --set codeExecutor.enabled=true"
helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="3.20.14" --set codeExecutor.enabled=true | grep code-executor;
echo "Expecting CE (1.1.0)";
echo "\n";

echo "TEST: --set image.tag=3.20.14 --set codeExecutor.image.tag=2.2.0 --set codeExecutor.enabled=true"
helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="3.20.14" --set codeExecutor.image.tag="2.2.0" --set codeExecutor.enabled=true | grep code-executor;
echo "Expecting CE (2.2.0)";
echo "\n";

echo "TEST: --set image.tag=latest"
helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="latest" | grep code-executor;
echo "No CE";
echo "\n";

echo "TEST: --set image.tag=latest --set codeExecutor.enabled=true"
helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="latest" --set codeExecutor.enabled=true | grep code-executor;
echo "No CE";
echo "\n";

```

###  Outputs

```
 ====== Running tests for code-executor (helm) ======
version.BuildInfo{Version:"v3.10.3", GitCommit:"835b7334cfe2e5e27870ab3ed4135f136eecc704", GitTreeState:"clean", GoVersion:"go1.19.4"}
TEST: (no tag)
Error: execution error at (retool/templates/deployment_jobs.yaml:51:50): Please set a value for .Values.image.tag

Use --debug flag to render out invalid YAML
No CE


TEST: --set image.tag=3.20.16
  name: foo-retool-code-executor
    retoolService: foo-retool-code-executor
            value: http://foo-retool-code-executor
  name: foo-retool-code-executor
    retoolService: foo-retool-code-executor
      retoolService: foo-retool-code-executor
        prometheus.io/job: foo-retool-code-executor
        retoolService: foo-retool-code-executor
        image: "tryretool/code-executor-service:3.20.16"
            value: http://foo-retool-code-executor
Expecting CE (3.20.16)


TEST: --set image.tag=3.20.16 --set codeExecutor.enabled=true
  name: foo-retool-code-executor
    retoolService: foo-retool-code-executor
            value: http://foo-retool-code-executor
  name: foo-retool-code-executor
    retoolService: foo-retool-code-executor
      retoolService: foo-retool-code-executor
        prometheus.io/job: foo-retool-code-executor
        retoolService: foo-retool-code-executor
        image: "tryretool/code-executor-service:3.20.16"
            value: http://foo-retool-code-executor
            value: http://foo-retool-code-executor
Expecting CE (3.20.16)


TEST: --set image.tag=3.20.14
No CE


TEST: --set image.tag=3.20.14 --set codeExecutor.image.tag=3.20.14
No CE


TEST: --set image.tag=3.20.14 --set codeExecutor.enabled=true
  name: foo-retool-code-executor
    retoolService: foo-retool-code-executor
            value: http://foo-retool-code-executor
  name: foo-retool-code-executor
    retoolService: foo-retool-code-executor
      retoolService: foo-retool-code-executor
        prometheus.io/job: foo-retool-code-executor
        retoolService: foo-retool-code-executor
        image: "tryretool/code-executor-service:1.1.0"
            value: http://foo-retool-code-executor
            value: http://foo-retool-code-executor
Expecting CE (1.1.0)


TEST: --set image.tag=3.20.14 --set codeExecutor.image.tag=2.2.0 --set codeExecutor.enabled=true
  name: foo-retool-code-executor
    retoolService: foo-retool-code-executor
            value: http://foo-retool-code-executor
  name: foo-retool-code-executor
    retoolService: foo-retool-code-executor
      retoolService: foo-retool-code-executor
        prometheus.io/job: foo-retool-code-executor
        retoolService: foo-retool-code-executor
        image: "tryretool/code-executor-service:2.2.0"
            value: http://foo-retool-code-executor
            value: http://foo-retool-code-executor
Expecting CE (2.2.0)


TEST: --set image.tag=latest
No CE


TEST: --set image.tag=latest --set codeExecutor.enabled=true
Error: execution error at (retool/templates/deployment_code_executor.yaml:53:63): If using image.tag=latest (not recommended, select an explicit tag instead) and enabling codeExecutor, explicitly set codeExecutor.image.tag

Use --debug flag to render out invalid YAML
No CE

```

Also tested w/ Helm 3.7 👍 ✅ 