### PR TITLE
add DEPLOYMENT_TEMPLATE_TYPE and VERSION to templates

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.0.15
+version: 6.0.16
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -30,6 +30,15 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+
+{{- define "retool.deploymentTemplateType" -}}
+{{- "k8s-helm" | quote -}}
+{{- end -}}
+
+{{- define "retool.deploymentTemplateVersion" -}}
+{{- .Chart.Version | quote -}}
+{{- end -}}
+
 {{/*
 Common labels
 */}}

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -65,6 +65,10 @@ spec:
 {{ toYaml .Values.commandline.args | indent 10 }}
         {{- end }}
         env:
+          - name: DEPLOYMENT_TEMPLATE_TYPE
+            value: {{ template "retool.deploymentTemplateType" . }}
+          - name: DEPLOYMENT_TEMPLATE_VERSION
+            value: {{ template "retool.deploymentTemplateVersion" . }}
           - name: NODE_ENV
             value: production
           {{- if include "retool.jobRunner.enabled" . }}

--- a/charts/retool/templates/deployment_code_executor.yaml
+++ b/charts/retool/templates/deployment_code_executor.yaml
@@ -55,6 +55,10 @@ spec:
         securityContext:
           privileged: true
         env:
+          - name: DEPLOYMENT_TEMPLATE_TYPE
+            value: {{ template "retool.deploymentTemplateType" . }}
+          - name: DEPLOYMENT_TEMPLATE_VERSION
+            value: {{ template "retool.deploymentTemplateVersion" . }}
           - name: NODE_ENV
             value: production
           - name: NODE_OPTIONS

--- a/charts/retool/templates/deployment_jobs.yaml
+++ b/charts/retool/templates/deployment_jobs.yaml
@@ -58,6 +58,10 @@ spec:
 {{ toYaml .Values.commandline.args | indent 10 }}
         {{- end }}
         env:
+          - name: DEPLOYMENT_TEMPLATE_TYPE
+            value: {{ template "retool.deploymentTemplateType" . }}
+          - name: DEPLOYMENT_TEMPLATE_VERSION
+            value: {{ template "retool.deploymentTemplateVersion" . }}
           - name: NODE_ENV
             value: production
           - name: SERVICE_TYPE

--- a/charts/retool/templates/deployment_workflows.yaml
+++ b/charts/retool/templates/deployment_workflows.yaml
@@ -57,6 +57,10 @@ spec:
 {{ toYaml .Values.commandline.args | indent 10 }}
         {{- end }}
         env:
+          - name: DEPLOYMENT_TEMPLATE_TYPE
+            value: {{ template "retool.deploymentTemplateType" . }}
+          - name: DEPLOYMENT_TEMPLATE_VERSION
+            value: {{ template "retool.deploymentTemplateVersion" . }}
           - name: NODE_ENV
             value: production
           {{ if $.Values.dbconnector.java.enabled }}

--- a/charts/retool/templates/deployment_workflows_worker.yaml
+++ b/charts/retool/templates/deployment_workflows_worker.yaml
@@ -63,6 +63,10 @@ spec:
 {{ toYaml .Values.commandline.args | indent 10 }}
         {{- end }}
         env:
+          - name: DEPLOYMENT_TEMPLATE_TYPE
+            value: {{ template "retool.deploymentTemplateType" . }}
+          - name: DEPLOYMENT_TEMPLATE_VERSION
+            value: {{ template "retool.deploymentTemplateVersion" . }}
           - name: NODE_ENV
             value: production
           - name: NODE_OPTIONS


### PR DESCRIPTION
```
helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="3.20.16"  --set replicaCount=2 | rg DEPLOYMENT_TEMPLATE_TYPE -C 3
          - -c
          - chmod -R +x ./docker_scripts; sync; ./docker_scripts/wait-for-it.sh -t 0 "foo-postgresql":"5432"; ./docker_scripts/start_api.sh
        env:
          - name: DEPLOYMENT_TEMPLATE_TYPE
            value: "k8s-helm"
          - name: DEPLOYMENT_TEMPLATE_VERSION
            value: "6.0.16"
--
        securityContext:
          privileged: true
        env:
          - name: DEPLOYMENT_TEMPLATE_TYPE
            value: "k8s-helm"
          - name: DEPLOYMENT_TEMPLATE_VERSION
            value: "6.0.16"
--
          - -c
          - chmod -R +x ./docker_scripts; sync; ./docker_scripts/wait-for-it.sh -t 0 "foo-postgresql":"5432"; ./docker_scripts/start_api.sh
        env:
          - name: DEPLOYMENT_TEMPLATE_TYPE
            value: "k8s-helm"
          - name: DEPLOYMENT_TEMPLATE_VERSION
            value: "6.0.16"
--
          - -c
          - chmod -R +x ./docker_scripts; sync; ./docker_scripts/wait-for-it.sh -t 0 "foo-postgresql":"5432"; ./docker_scripts/start_api.sh
        env:
          - name: DEPLOYMENT_TEMPLATE_TYPE
            value: "k8s-helm"
          - name: DEPLOYMENT_TEMPLATE_VERSION
            value: "6.0.16"
--
          - -c
          - chmod -R +x ./docker_scripts; sync; ./docker_scripts/wait-for-it.sh -t 0 "foo-postgresql":"5432"; ./docker_scripts/start_api.sh
        env:
          - name: DEPLOYMENT_TEMPLATE_TYPE
            value: "k8s-helm"
          - name: DEPLOYMENT_TEMPLATE_VERSION
            value: "6.0.16"
```

related to:
- https://github.com/tryretool/retool_development/pull/40510
- https://retooled.slack.com/archives/C01A0DPBWJ0/p1707762619167969