### PR TITLE
Add nodeSelector to code-executor as well

### DIFF
--- a/charts/retool/templates/deployment_code_executor.yaml
+++ b/charts/retool/templates/deployment_code_executor.yaml
@@ -41,6 +41,10 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
 {{- if .Values.initContainers }}
       initContainers:
 {{- range $key, $value := .Values.initContainers }}


### PR DESCRIPTION
Because retool images are not built for ARM64, a nodeSelector `kubernetes.io/arch: amd64` needs to be added to all mixed architecture clusters.

Note that a reasonable change, in my mind, is to make `kubernetes.io/arch: amd64` a default node selector. That should work on almost all clusters and will prevent crashes on mixed architecture clusters.