### PR TITLE
Remove prom scrape annotations from code-executor, which does not have metrics

### DIFF
--- a/charts/retool/templates/deployment_code_executor.yaml
+++ b/charts/retool/templates/deployment_code_executor.yaml
@@ -19,9 +19,6 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/job: {{ template "retool.codeExecutor.name" . }}
-        prometheus.io/scrape: 'true'
-        prometheus.io/port: '9090'
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}


### PR DESCRIPTION
This prevents error-spam from failures to scrape metrics.

Resolves #155 