### PR TITLE
Add `WORKFLOW_BACKEND_HOST` to code-executor deployment

### DIFF
--- a/charts/retool/templates/deployment_code_executor.yaml
+++ b/charts/retool/templates/deployment_code_executor.yaml
@@ -67,6 +67,10 @@ spec:
             value: production
           - name: NODE_OPTIONS
             value: {{(.Values.codeExecutor.config).nodeOptions | default "--max_old_space_size=1024" }}
+          {{- if include "retool.workflows.enabled" . }}
+          - name: WORKFLOW_BACKEND_HOST
+            value: http://{{ template "retool.fullname" . }}-workflow-backend
+          {{- end }}
           {{- range $key, $value := .Values.env }}
           - name: "{{ $key }}"
             value: "{{ $value }}"


### PR DESCRIPTION
If retool workflows are enabled, `code-executor` deployments need to know which workflow backend to talk to. Before this update, users of the chart would have to inject this env var manually.

With this PR, I am proposing to add the (conditional) environment variable `WORKFLOW_BACKEND_HOST` to the `code-executor` deployment in the same way that it is being added in the other deployment manifests.