### PR TITLE
[fix] code executor image tag reference for internal tags

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.1.0
+version: 6.1.1
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -178,7 +178,6 @@ Set Code Executor enabled
 Usage: (include "retool.codeExecutor.enabled" .)
 */}}
 {{- define "retool.codeExecutor.enabled" -}}
-{{- $codeExecutorVersion := (include "retool.codeExecutor.image.tag" .) -}}
 {{- $output := "" -}}
 {{- if or
     (eq (toString .Values.codeExecutor.enabled) "true")
@@ -189,11 +188,11 @@ Usage: (include "retool.codeExecutor.enabled" .)
   {{- else -}}
     {{- $output = "" -}}
   {{- end -}}
-{{- else if empty $codeExecutorVersion -}}
+{{- else if empty (include "retool.codeExecutor.image.tag" .) -}}
   {{- $output = "" -}}
-{{- else if (or (contains "stable" $codeExecutorVersion) (contains "edge" $codeExecutorVersion)) -}}
+{{- else if (or (contains "stable" (include "retool.codeExecutor.image.tag" .)) (contains "edge" (include "retool.codeExecutor.image.tag" .))) -}}
   {{- $output = "1" -}}
-{{- else if semverCompare ">= 3.20.15" $codeExecutorVersion -}}
+{{- else if semverCompare ">= 3.20.15" (include "retool.codeExecutor.image.tag" .) -}}
   {{- $output = "1" -}}
 {{- else -}}
   {{- $output = "" -}}


### PR DESCRIPTION
```
helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="release-3.39.0-a0b2a86" --set codeExecutor.enabled="false" --set workflows.enabled="false" | rg "kind: Deployment" -C 2

# Source: retool/templates/deployment_backend.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: foo-retool
--
# Source: retool/templates/deployment_jobs.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: foo-retool-jobs-runner
```

```
helm template -f ~/retool-helm/charts/retool/values.yaml foo ~/retool-helm/charts/retool --set config.encryptionKey="foo" --set image.tag="release-3.39.0-a0b2a86" --set codeExecutor.enabled="false" --set workflows.enabled="true" | rg "kind: Deployment" -C 2

# Source: retool/templates/deployment_backend.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: foo-retool
--
# Source: retool/templates/deployment_jobs.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: foo-retool-jobs-runner
--
# Source: retool/templates/deployment_workflows.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: foo-retool-workflow-backend
--
# Source: retool/templates/deployment_workflows_worker.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: foo-retool-workflow-worker
```