### PR TITLE
Support experimental multiplayer deployment.

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.1.1
+version: 6.1.2
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/deployment_multiplayer_ws.yaml
+++ b/charts/retool/templates/deployment_multiplayer_ws.yaml
@@ -1,0 +1,200 @@
+{{- if .Values.multiplayer.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "retool.fullname" . }}-multiplayer-ws
+spec:
+  selector:
+    retoolService: {{ template "retool.fullname" . }}-multiplayer-ws
+  ports:
+  - name: ws
+    protocol: TCP
+    port: 80
+    targetPort: 3001
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "retool.fullname" . }}-multiplayer-ws
+  labels:
+{{- include "retool.labels" . | nindent 4 }}
+{{- if .Values.deployment.annotations }}
+  annotations:
+{{ toYaml .Values.deployment.annotations | indent 4 }}
+{{- end }}
+spec:
+  replicas: {{ .Values.multiplayer.replicaCount }}
+  selector:
+    matchLabels:
+      retoolService: {{ include "retool.name" . }}-multiplayer-ws
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  template:
+    metadata:
+      annotations:
+{{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
+{{- if .Values.multiplayer.annotations }}
+{{ toYaml .Values.multiplayer.annotations | indent 8 }}
+{{- end }}
+      labels:
+        retoolService: {{ include "retool.name" . }}-multiplayer-ws
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
+{{- if .Values.multiplayer.labels }}
+{{ toYaml .Values.multiplayer.labels | indent 8 }}
+{{- end }}
+    spec:
+      serviceAccountName: {{ template "retool.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
+{{- if .Values.initContainers }}
+      initContainers:
+{{- range $key, $value := .Values.initContainers }}
+      - name: "{{ $key }}"
+{{ toYaml $value | indent 8 }}
+{{- end }}
+{{- end }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ required "Please set a value for .Values.image.tag" .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+          - bash
+          - -c
+          - chmod -R +x ./docker_scripts; sync; ./docker_scripts/wait-for-it.sh -t 0 {{ template "retool.postgresql.host" . }}:{{ template "retool.postgresql.port" . }}; ./docker_scripts/start_api.sh
+        {{- if .Values.commandline.args }}
+{{ toYaml .Values.commandline.args | indent 10 }}
+        {{- end }}
+        env:
+        - name: DEPLOYMENT_TEMPLATE_TYPE
+          value: {{ template "retool.deploymentTemplateType" . }}
+        - name: DEPLOYMENT_TEMPLATE_VERSION
+          value: {{ template "retool.deploymentTemplateVersion" . }}
+        - name: SERVICE_TYPE
+          value: MULTIPLAYER_SERVICE
+        - name: MULTIPLAYER_SERVER_PORT
+          value: "3001"
+        - name: COOKIE_INSECURE
+          value: {{ .Values.config.useInsecureCookies | quote }}
+        - name: POSTGRES_HOST
+          value: {{ template "retool.postgresql.host" . }}
+        - name: POSTGRES_PORT
+          value: {{ template "retool.postgresql.port" . }}
+        - name: POSTGRES_DB
+          value: {{ template "retool.postgresql.database" . }}
+        - name: POSTGRES_USER
+          value: {{ template "retool.postgresql.user" . }}
+        - name: POSTGRES_SSL_ENABLED
+          value: {{ template "retool.postgresql.ssl_enabled" . }}
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+        {{- if  .Values.postgresql.enabled }}
+              name: {{ template "retool.postgresql.fullname" . }}
+              key: postgres-password
+        {{- else }}
+              {{- if .Values.config.postgresql.passwordSecretName }}
+              name: {{ .Values.config.postgresql.passwordSecretName }}
+              key: {{ .Values.config.postgresql.passwordSecretKey | default "postgresql-password" }}
+              {{- else }}
+              name: {{ template "retool.fullname" . }}
+              key: postgresql-password
+              {{- end }}
+        {{- end }}
+        - name: ENCRYPTION_KEY
+          valueFrom:
+            secretKeyRef:
+              {{- if .Values.config.encryptionKeySecretName }}
+              name: {{ .Values.config.encryptionKeySecretName }}
+              key: {{ .Values.config.encryptionKeySecretKey | default "encryption-key" }}
+              {{- else }}
+              name: {{ template "retool.fullname" . }}
+              key: encryption-key
+              {{- end }}
+        - name: JWT_SECRET
+          valueFrom:
+            secretKeyRef:
+              {{- if .Values.config.jwtSecretSecretName }}
+              name: {{ .Values.config.jwtSecretSecretName }}
+              key: {{ .Values.config.jwtSecretSecretKey | default "jwt-secret" }}
+              {{- else }}
+              name: {{ template "retool.fullname" . }}
+              key: jwt-secret
+              {{- end }}
+        {{- range $key, $value := .Values.multiplayer.environmentVariables }}
+        - name: "{{ $key }}"
+          value: "{{ $value }}"
+        {{- end }}
+        resources:
+{{ toYaml .Values.multiplayer.resources | indent 10 }}
+        readinessProbe:
+          httpGet:
+            path: /api/checkHealth
+            port: 3001
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /api/checkHealth
+            port: 3001
+          initialDelaySeconds: 100
+          failureThreshold: 10
+          timeoutSeconds: 10
+          periodSeconds: 20
+        volumeMounts:
+        {{- range $configFile := (keys .Values.files) }}
+        - name: {{ template "retool.name" $ }}
+          mountPath: "/usr/share/retool/config/{{ $configFile }}"
+          subPath: {{ $configFile }}
+        {{- end }}
+        {{if and .Values.persistentVolumeClaim.enabled .Values.persistentVolumeClaim.mountPath }}
+        - name: retool-pv
+          mountPath: {{ .Values.persistentVolumeClaim.mountPath }}
+        {{- end }}
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 8 }}
+{{- end }}
+{{- with .Values.extraContainers }}
+{{ tpl . $ | indent 6 }}
+{{- end }}
+{{- range .Values.extraConfigMapMounts }}
+        - name: {{ .name }}
+          mountPath: {{ .mountPath }}
+          subPath: {{ .subPath }}
+{{- end }}
+    {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.image.pullSecrets | indent 8 }}
+    {{- end }}
+    {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+    {{- end }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+{{- if .Values.securityContext.enabled }}
+      securityContext:
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+{{- end }}
+      volumes:
+{{- range .Values.extraConfigMapMounts }}
+        - name: {{ .name }}
+          configMap:
+            name: {{ .configMap }}
+{{- end }}
+      {{- if .Values.persistentVolumeClaim.enabled }}
+        - name: retool-pv
+          persistentVolumeClaim:
+            claimName: {{ default (include "retool.fullname" .) .Values.persistentVolumeClaim.existingClaim }}
+      {{- end }}
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 8 }}
+{{- end }}
+{{- end }}

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -267,7 +267,7 @@ tolerations: []
 # Ref: https://kubernetes.io/docs/user-guide/node-selection/
 nodeSelector: {}
 
-# Common annotations for all pods (backend and job runner).
+# Common annotations for all pods.
 podAnnotations: {}
 
 revisionHistoryLimit: 3
@@ -404,6 +404,32 @@ dbconnector:
     # Enable this to use Retool's experimental next-gen dbconnector to connect to resources.
     # This feature is not ready for production use; please check with the Retool team before enablement.
     enabled: false
+
+multiplayer:
+  # Enable this to use Retool's experimental multiplayer editing feature.
+  # This feature is not ready for production use; please check with the Retool team before enablement.
+  enabled: false
+
+  replicaCount: 1
+
+  # Resources for multiplayer pods
+  resources:
+    requests:
+      cpu: "200m"
+      memory: "256Mi"
+    limits:
+      memory: "2048Mi"
+
+  # Set environment variables for multiplayer pods, e.g. defining which origin to use
+  # environmentVariables:
+  #   - name: MAIN_DOMAIN
+  #     value: retool.foo.com
+
+  # Annotations for multiplayer pods
+  annotations: {}
+
+  # Labels for multiplayer pods
+  labels: {}
 
 codeExecutor:
   # enabled by default from Chart version 6.0.15 and Retool image 3.20.15 onwards

--- a/values.yaml
+++ b/values.yaml
@@ -267,7 +267,7 @@ tolerations: []
 # Ref: https://kubernetes.io/docs/user-guide/node-selection/
 nodeSelector: {}
 
-# Common annotations for all pods (backend and job runner).
+# Common annotations for all pods.
 podAnnotations: {}
 
 revisionHistoryLimit: 3
@@ -404,6 +404,32 @@ dbconnector:
     # Enable this to use Retool's experimental next-gen dbconnector to connect to resources.
     # This feature is not ready for production use; please check with the Retool team before enablement.
     enabled: false
+
+multiplayer:
+  # Enable this to use Retool's experimental multiplayer editing feature.
+  # This feature is not ready for production use; please check with the Retool team before enablement.
+  enabled: false
+
+  replicaCount: 1
+
+  # Resources for multiplayer pods
+  resources:
+    requests:
+      cpu: "200m"
+      memory: "256Mi"
+    limits:
+      memory: "2048Mi"
+
+  # Set environment variables for multiplayer pods, e.g. defining which origin to use
+  # environmentVariables:
+  #   - name: MAIN_DOMAIN
+  #     value: retool.foo.com
+
+  # Annotations for multiplayer pods
+  annotations: {}
+
+  # Labels for multiplayer pods
+  labels: {}
 
 codeExecutor:
   # enabled by default from Chart version 6.0.15 and Retool image 3.20.15 onwards


### PR DESCRIPTION
This allows our admin instance to dogfood the multiplayer behavior and upgrade the image seamlessly. We're not far from official launch so it was deemed safe to include an experimental toggle.