### PR TITLE
set user for visibility db in VISIBILITY_DBUSER env var

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.1.1
+version: 6.1.3
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/charts/retool-temporal-services-helm/templates/server-deployment.yaml
+++ b/charts/retool/charts/retool-temporal-services-helm/templates/server-deployment.yaml
@@ -145,6 +145,10 @@ spec:
             - name: VISIBILITY_DBNAME
               value: "{{ $.Values.server.config.persistence.visibility.sql.database }}"
             {{- end }}
+            {{- if $.Values.server.config.persistence.visibility.sql.user }}
+            - name: VISIBILITY_DBUSER
+              value: "{{ $.Values.server.config.persistence.visibility.sql.user }}"
+            {{- end }}
             {{- if ($.Values.server.config.persistence.default.sql.tls).enabled }}
             - name: SQL_TLS_ENABLED
               value: "true"

--- a/charts/retool/charts/retool-temporal-services-helm/values.yaml
+++ b/charts/retool/charts/retool-temporal-services-helm/values.yaml
@@ -25,7 +25,7 @@ server:
   autosetup: true
   image:
     repository: tryretool/one-offs
-    tag: retool-temporal-1.1.3
+    tag: retool-temporal-1.1.5
     pullPolicy: IfNotPresent
 
   # Global default settings (can be overridden per service)
@@ -67,8 +67,7 @@ server:
       timerType: histogram
   podAnnotations: {}
   podLabels: {}
-  resources:
-    {}
+  resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -257,7 +256,6 @@ web:
       default_to_namespace: workflows # internal use only
       issue_report_link: https://github.com/temporalio/web/issues/new/choose # set this field if you need to direct people to internal support forums
 
-
   replicaCount: 1
 
   image:
@@ -351,49 +349,49 @@ grafana:
     dashboardproviders.yaml:
       apiVersion: 1
       providers:
-      - name: 'default'
-        orgId: 1
-        folder: ''
-        type: file
-        disableDeletion: false
-        editable: true
-        options:
-          path: /var/lib/grafana/dashboards/default
+        - name: "default"
+          orgId: 1
+          folder: ""
+          type: file
+          disableDeletion: false
+          editable: true
+          options:
+            path: /var/lib/grafana/dashboards/default
   datasources:
-   datasources.yaml:
-     apiVersion: 1
-     datasources:
-     - name: TemporalMetrics
-       type: prometheus
-       url: http://{{ .Release.Name }}-prometheus-server
-       access: proxy
-       isDefault: true
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+        - name: TemporalMetrics
+          type: prometheus
+          url: http://{{ .Release.Name }}-prometheus-server
+          access: proxy
+          isDefault: true
   dashboards:
-     default:
-       server-general-github:
-         url: https://raw.githubusercontent.com/temporalio/dashboards/helm/server/server-general.json
-         datasource: TemporalMetrics
-       sdk-general-github:
-         url: https://raw.githubusercontent.com/temporalio/dashboards/helm/sdk/sdk-general.json
-         datasource: TemporalMetrics
-       misc-advanced-visibility-specific-github:
-         url: https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/advanced-visibility-specific.json
-         datasource: TemporalMetrics
-       misc-clustermonitoring-kubernetes-github:
-         url: https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/clustermonitoring-kubernetes.json
-         datasource: TemporalMetrics
-       misc-frontend-service-specific-github:
-         url: https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/frontend-service-specific.json
-         datasource: TemporalMetrics
-       misc-history-service-specific-github:
-         url: https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/history-service-specific.json
-         datasource: TemporalMetrics
-       misc-matching-service-specific-github:
-         url: https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/matching-service-specific.json
-         datasource: TemporalMetrics
-       misc-worker-service-specific-github:
-         url: https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/worker-service-specific.json
-         datasource: TemporalMetrics
+    default:
+      server-general-github:
+        url: https://raw.githubusercontent.com/temporalio/dashboards/helm/server/server-general.json
+        datasource: TemporalMetrics
+      sdk-general-github:
+        url: https://raw.githubusercontent.com/temporalio/dashboards/helm/sdk/sdk-general.json
+        datasource: TemporalMetrics
+      misc-advanced-visibility-specific-github:
+        url: https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/advanced-visibility-specific.json
+        datasource: TemporalMetrics
+      misc-clustermonitoring-kubernetes-github:
+        url: https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/clustermonitoring-kubernetes.json
+        datasource: TemporalMetrics
+      misc-frontend-service-specific-github:
+        url: https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/frontend-service-specific.json
+        datasource: TemporalMetrics
+      misc-history-service-specific-github:
+        url: https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/history-service-specific.json
+        datasource: TemporalMetrics
+      misc-matching-service-specific-github:
+        url: https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/matching-service-specific.json
+        datasource: TemporalMetrics
+      misc-worker-service-specific-github:
+        url: https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/worker-service-specific.json
+        datasource: TemporalMetrics
 
 postgresql:
   enabled: false

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -459,7 +459,7 @@ retool-temporal-services-helm:
     # Defines image to be used for temporal server
     image:
       repository: tryretool/one-offs
-      tag: retool-temporal-1.1.3
+      tag: retool-temporal-1.1.5
       pullPolicy: IfNotPresent
     # this configures grpc_health_probe (https://github.com/grpc-ecosystem/grpc-health-probe)
     # for healthchecks instead of native k8s.

--- a/values.yaml
+++ b/values.yaml
@@ -459,7 +459,7 @@ retool-temporal-services-helm:
     # Defines image to be used for temporal server
     image:
       repository: tryretool/one-offs
-      tag: retool-temporal-1.1.3
+      tag: retool-temporal-1.1.5
       pullPolicy: IfNotPresent
     # this configures grpc_health_probe (https://github.com/grpc-ecosystem/grpc-health-probe)
     # for healthchecks instead of native k8s.


### PR DESCRIPTION
Support using different users, each scoped to the DB (default store, visibility store) they are expected to manage. in our auto set up scripts (https://github.com/tryretool/retool-temporal-docker-builds/pull/2) we assume the same user is used to set up schema for both these databases.

see issue here: https://retooled.slack.com/archives/C05TR7RRB0F/p1710327058225469

relates to https://github.com/tryretool/retool-temporal-docker-builds/pull/2
