### PR TITLE
fix: add a missing `nodeSelector` field to the code-executor deployment

### DIFF
--- a/charts/retool/templates/deployment_code_executor.yaml
+++ b/charts/retool/templates/deployment_code_executor.yaml
@@ -131,6 +131,10 @@ spec:
       affinity:
 {{ toYaml .Values.codeExecutor.affinity | indent 8 }}
 {{- end }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This PR addresses the issue of a missing `nodeSelector` in the `code-executor` deployment, which causes problems when the cluster is based on mixed-architecture nodes. For example, in our case, the `code-executor` pod was provisioned on an `arm64` node.