### PR TITLE
update port names for Services for istio compliance

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.2.0
+version: 6.2.2
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/charts/retool-temporal-services-helm/templates/server-deployment.yaml
+++ b/charts/retool/charts/retool-temporal-services-helm/templates/server-deployment.yaml
@@ -195,7 +195,7 @@ spec:
             - name: rpc
               containerPort: {{ include (printf "temporal.%s.grpcPort" $service) $ }}
               protocol: TCP
-            - name: metrics
+            - name: tcp-metrics
               containerPort: 9090
               protocol: TCP
           {{- if and (ne $service "worker") $.Values.server.useLegacyHealthProbe }}

--- a/charts/retool/charts/retool-temporal-services-helm/templates/server-deployment.yaml
+++ b/charts/retool/charts/retool-temporal-services-helm/templates/server-deployment.yaml
@@ -195,7 +195,7 @@ spec:
             - name: rpc
               containerPort: {{ include (printf "temporal.%s.grpcPort" $service) $ }}
               protocol: TCP
-            - name: tcp-metrics
+            - name: http-metrics
               containerPort: 9090
               protocol: TCP
           {{- if and (ne $service "worker") $.Values.server.useLegacyHealthProbe }}

--- a/charts/retool/charts/retool-temporal-services-helm/templates/server-service-monitor.yaml
+++ b/charts/retool/charts/retool-temporal-services-helm/templates/server-service-monitor.yaml
@@ -19,7 +19,7 @@ metadata:
     {{- end }}
 spec:
   endpoints:
-  - port: tcp-metrics
+  - port: http-metrics
     interval: {{ default $.Values.server.metrics.serviceMonitor.interval $serviceValues.metrics.serviceMonitor.interval }}
     {{- with (default $.Values.server.metrics.serviceMonitor.metricRelabelings $serviceValues.metrics.serviceMonitor.metricRelabelings) }}
     metricRelabelings:

--- a/charts/retool/charts/retool-temporal-services-helm/templates/server-service-monitor.yaml
+++ b/charts/retool/charts/retool-temporal-services-helm/templates/server-service-monitor.yaml
@@ -19,7 +19,7 @@ metadata:
     {{- end }}
 spec:
   endpoints:
-  - port: metrics
+  - port: tcp-metrics
     interval: {{ default $.Values.server.metrics.serviceMonitor.interval $serviceValues.metrics.serviceMonitor.interval }}
     {{- with (default $.Values.server.metrics.serviceMonitor.metricRelabelings $serviceValues.metrics.serviceMonitor.metricRelabelings) }}
     metricRelabelings:

--- a/charts/retool/charts/retool-temporal-services-helm/templates/server-service.yaml
+++ b/charts/retool/charts/retool-temporal-services-helm/templates/server-service.yaml
@@ -66,9 +66,9 @@ spec:
       protocol: TCP
       name: grpc-rpc
     - port: 9090
-      targetPort: tcp-metrics
+      targetPort: http-metrics
       protocol: TCP
-      name: tcp-metrics
+      name: http-metrics
   selector:
     app.kubernetes.io/name: {{ include "temporal.name" $ }}
     app.kubernetes.io/instance: {{ $.Release.Name }}

--- a/charts/retool/charts/retool-temporal-services-helm/templates/server-service.yaml
+++ b/charts/retool/charts/retool-temporal-services-helm/templates/server-service.yaml
@@ -66,9 +66,9 @@ spec:
       protocol: TCP
       name: grpc-rpc
     - port: 9090
-      targetPort: metrics
+      targetPort: tcp-metrics
       protocol: TCP
-      name: metrics
+      name: tcp-metrics
   selector:
     app.kubernetes.io/name: {{ include "temporal.name" $ }}
     app.kubernetes.io/instance: {{ $.Release.Name }}

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -306,6 +306,14 @@ Set code executor service name
 {{- end -}}
 
 {{/*
+Set multiplayer service name
+*/}}
+{{- define "retool.multiplayer.name" -}}
+{{ template "retool.fullname" . }}-multiplayer-ws
+{{- end -}}
+
+
+{{/*
 Set code executor image tag
 Usage: (template "retool.codeExecutor.image.tag" .)
 */}}

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -345,16 +345,3 @@ spec:
     matchLabels:
   {{- include "retool.selectorLabels" . | nindent 6 }}
 {{- end }}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ template "retool.fullname" . }}
-spec:
-  selector:
-    {{- include "retool.selectorLabels" . | nindent 4 }}
-  ports:
-  - protocol: TCP
-    port: 80
-    targetPort: {{ .Values.service.internalPort }}
-    name: http-server

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -241,7 +241,7 @@ spec:
         {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
-          name: {{ template "retool.name" . }}
+          name: tcp-{{ template "retool.fullname" . }}
           protocol: TCP
 {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
@@ -345,3 +345,16 @@ spec:
     matchLabels:
   {{- include "retool.selectorLabels" . | nindent 6 }}
 {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "retool.fullname" . }}
+spec:
+  selector:
+    {{- include "retool.selectorLabels" . | nindent 4 }}
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: {{ .Values.service.internalPort }}
+    name: tcp-{{ template "retool.fullname" . }}

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -241,7 +241,7 @@ spec:
         {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
-          name: tcp-{{ template "retool.fullname" . }}
+          name: http-server
           protocol: TCP
 {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
@@ -357,4 +357,4 @@ spec:
   - protocol: TCP
     port: 80
     targetPort: {{ .Values.service.internalPort }}
-    name: tcp-{{ template "retool.fullname" . }}
+    name: http-server

--- a/charts/retool/templates/deployment_code_executor.yaml
+++ b/charts/retool/templates/deployment_code_executor.yaml
@@ -86,7 +86,7 @@ spec:
           {{- end }}
         ports:
         - containerPort: 3004
-          name: tcp-{{ template "retool.codeExecutor.name" . }}
+          name: http-server
           protocol: TCP
 {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
@@ -137,5 +137,5 @@ spec:
   - protocol: TCP
     port: 80
     targetPort: 3004
-    name: tcp-{{ template "retool.codeExecutor.name" . }}
+    name: http-server
 {{- end }}

--- a/charts/retool/templates/deployment_code_executor.yaml
+++ b/charts/retool/templates/deployment_code_executor.yaml
@@ -20,9 +20,6 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/job: {{ template "retool.codeExecutor.name" . }}
-        prometheus.io/scrape: 'true'
-        prometheus.io/port: '9090'
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
@@ -89,10 +86,7 @@ spec:
           {{- end }}
         ports:
         - containerPort: 3004
-          name: {{ template "retool.name" . }}
-          protocol: TCP
-        - containerPort: 9090
-          name: metrics
+          name: tcp-{{ template "retool.codeExecutor.name" . }}
           protocol: TCP
 {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
@@ -143,9 +137,5 @@ spec:
   - protocol: TCP
     port: 80
     targetPort: 3004
-    name: {{ template "retool.name" . }}
-  - protocol: TCP
-    port: 9090
-    targetPort: metrics
-    name: metrics
+    name: tcp-{{ template "retool.codeExecutor.name" . }}
 {{- end }}

--- a/charts/retool/templates/deployment_multiplayer_ws.yaml
+++ b/charts/retool/templates/deployment_multiplayer_ws.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "retool.fullname" . }}-multiplayer-ws
+  name: {{ template "retool.multiplayer.name" . }}
 spec:
   selector:
-    retoolService: {{ template "retool.fullname" . }}-multiplayer-ws
+    retoolService: {{ template "retool.multiplayer.name" . }}
   ports:
-  - name: ws
+  - name: tcp-{{ template "retool.multiplayer.name" . }}
     protocol: TCP
     port: 80
     targetPort: 3001
@@ -15,7 +15,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "retool.fullname" . }}-multiplayer-ws
+  name: {{ template "retool.multiplayer.name" . }}
   labels:
 {{- include "retool.labels" . | nindent 4 }}
 {{- if .Values.deployment.annotations }}
@@ -128,6 +128,10 @@ spec:
         - name: "{{ $key }}"
           value: "{{ $value }}"
         {{- end }}
+        ports:
+          - containerPort: 3001
+            name: tcp-{{ template "retool.multiplayer.name" . }}
+            protocol: TCP
         resources:
 {{ toYaml .Values.multiplayer.resources | indent 10 }}
         readinessProbe:

--- a/charts/retool/templates/deployment_multiplayer_ws.yaml
+++ b/charts/retool/templates/deployment_multiplayer_ws.yaml
@@ -7,7 +7,7 @@ spec:
   selector:
     retoolService: {{ template "retool.multiplayer.name" . }}
   ports:
-  - name: tcp-{{ template "retool.multiplayer.name" . }}
+  - name: http-server
     protocol: TCP
     port: 80
     targetPort: 3001
@@ -130,7 +130,7 @@ spec:
         {{- end }}
         ports:
           - containerPort: 3001
-            name: tcp-{{ template "retool.multiplayer.name" . }}
+            name: http-server
             protocol: TCP
         resources:
 {{ toYaml .Values.multiplayer.resources | indent 10 }}

--- a/charts/retool/templates/deployment_telemetry.yaml
+++ b/charts/retool/templates/deployment_telemetry.yaml
@@ -127,7 +127,7 @@ spec:
           {{- end }}
         ports:
           - containerPort: 9125
-            name: statsd-udp
+            name: udp-statsd
             protocol: UDP
           {{- if .Values.telemetry.extraPorts }}
           {{- .Values.telemetry.extraPorts | toYaml | nindent 10 }}
@@ -175,7 +175,7 @@ metadata:
     {{- include "retool.telemetry.labels" . | nindent 4 }}
 spec:
   ports:
-    - name: statsd-udp
+    - name: udp-statsd
       port: 9125
       protocol: UDP
   selector:

--- a/charts/retool/templates/deployment_workflows.yaml
+++ b/charts/retool/templates/deployment_workflows.yaml
@@ -223,7 +223,7 @@ spec:
         {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
-          name: {{ template "retool.name" . }}
+          name: tcp-{{ template "retool.workflowBackend.name" . }}
           protocol: TCP
 {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
@@ -319,4 +319,5 @@ spec:
   - protocol: TCP
     port: 80
     targetPort: {{ .Values.service.internalPort }}
+    name: tcp-{{ template "retool.workflowBackend.name" . }}
 {{- end }}

--- a/charts/retool/templates/deployment_workflows.yaml
+++ b/charts/retool/templates/deployment_workflows.yaml
@@ -223,7 +223,7 @@ spec:
         {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
-          name: tcp-{{ template "retool.workflowBackend.name" . }}
+          name: http-server
           protocol: TCP
 {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
@@ -319,5 +319,5 @@ spec:
   - protocol: TCP
     port: 80
     targetPort: {{ .Values.service.internalPort }}
-    name: tcp-{{ template "retool.workflowBackend.name" . }}
+    name: http-server
 {{- end }}

--- a/charts/retool/templates/deployment_workflows_worker.yaml
+++ b/charts/retool/templates/deployment_workflows_worker.yaml
@@ -242,10 +242,10 @@ spec:
         {{- end }}
         ports:
         - containerPort: 3005
-          name: {{ template "retool.name" . }}
+          name: tcp-{{ template "retool.workflowWorker.name" . }}
           protocol: TCP
         - containerPort: 9090
-          name: metrics
+          name: tcp-metrics
           protocol: TCP
 
 {{- if .Values.livenessProbe.enabled }}
@@ -342,9 +342,9 @@ spec:
   - protocol: TCP
     port: 3005
     targetPort: 3005
-    name: {{ template "retool.name" . }}
+    name: tcp-{{ template "retool.workflowWorker.name" . }}
   - protocol: TCP
     port: 9090
-    targetPort: metrics
-    name: metrics
+    targetPort: tcp-metrics
+    name: tcp-metrics
 {{- end }}

--- a/charts/retool/templates/deployment_workflows_worker.yaml
+++ b/charts/retool/templates/deployment_workflows_worker.yaml
@@ -242,10 +242,10 @@ spec:
         {{- end }}
         ports:
         - containerPort: 3005
-          name: tcp-{{ template "retool.workflowWorker.name" . }}
+          name: http-server
           protocol: TCP
         - containerPort: 9090
-          name: tcp-metrics
+          name: http-metrics
           protocol: TCP
 
 {{- if .Values.livenessProbe.enabled }}
@@ -342,9 +342,9 @@ spec:
   - protocol: TCP
     port: 3005
     targetPort: 3005
-    name: tcp-{{ template "retool.workflowWorker.name" . }}
+    name: http-server
   - protocol: TCP
     port: 9090
-    targetPort: tcp-metrics
-    name: tcp-metrics
+    targetPort: http-metrics
+    name: http-metrics
 {{- end }}


### PR DESCRIPTION
Addresses https://github.com/tryretool/retool-helm/issues/144, alternate to https://github.com/tryretool/retool-helm/pull/151

Addresses: https://github.com/tryretool/retool-helm/issues/155, alternate to https://github.com/tryretool/retool-helm/pull/156

Lighter weight approach than https://github.com/tryretool/retool-helm/pull/154

https://istio.io/v1.0/docs/setup/kubernetes/spec-requirements/

> Named ports: Service ports must be named. The port names must be of the form <protocol>[-<suffix>] with http, http2, grpc, mongo, or redis as the <protocol> in order to take advantage of Istio's routing features. For example, name: http2-foo or name: http are valid port names, but name: http2foo is not. If the port name does not begin with a recognized prefix or if the port is unnamed, traffic on the port will be treated as plain TCP traffic (unless the port [explicitly](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service) uses Protocol: UDP to signify a UDP port).

https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/, could also use appProtocol if prefix in names is not desirable.

Tested in internal (balloon) instances.

(also fixes https://github.com/tryretool/retool-helm/issues/155)