### PR TITLE
add appProtocol and membership ports for istio proxy compatibility

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.2.0
+version: 6.2.1
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/charts/retool-temporal-services-helm/templates/server-deployment.yaml
+++ b/charts/retool/charts/retool-temporal-services-helm/templates/server-deployment.yaml
@@ -195,6 +195,9 @@ spec:
             - name: rpc
               containerPort: {{ include (printf "temporal.%s.grpcPort" $service) $ }}
               protocol: TCP
+            - name: membership
+              containerPort: {{ include (printf "temporal.%s.membershipPort" $service) $ }}
+              protocol: TCP
             - name: metrics
               containerPort: 9090
               protocol: TCP

--- a/charts/retool/charts/retool-temporal-services-helm/templates/server-service.yaml
+++ b/charts/retool/charts/retool-temporal-services-helm/templates/server-service.yaml
@@ -19,11 +19,22 @@ spec:
   ports:
     - port: {{ .Values.server.frontend.service.port }}
       targetPort: rpc
+{{- if semverCompare ">=1.20-0" $.Capabilities.KubeVersion.Version }}
+      appProtocol: TCP
+{{- end }}
       protocol: TCP
       name: grpc-rpc
       {{- if hasKey .Values.server.frontend.service "nodePort" }}
       nodePort: {{ .Values.server.frontend.service.nodePort }}
       {{- end }}
+    - port: {{ include "temporal.frontend.membershipPort" $ }}
+      targetPort: membership
+{{- if semverCompare ">=1.20-0" $.Capabilities.KubeVersion.Version }}
+      appProtocol: TCP
+{{- end }}
+      protocol: TCP
+      name: grpc-membership
+
   selector:
     app.kubernetes.io/name: {{ include "temporal.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -64,7 +75,17 @@ spec:
     - port: {{ $serviceValues.service.port }}
       targetPort: rpc
       protocol: TCP
+{{- if semverCompare ">=1.20-0" $.Capabilities.KubeVersion.Version }}
+      appProtocol: TCP
+{{- end }}
       name: grpc-rpc
+    - port: {{ include (printf "temporal.%s.membershipPort" $service) $ }}
+      targetPort: membership
+{{- if semverCompare ">=1.20-0" $.Capabilities.KubeVersion.Version }}
+      appProtocol: TCP
+{{- end }}
+      protocol: TCP
+      name: grpc-membership
     - port: 9090
       targetPort: metrics
       protocol: TCP


### PR DESCRIPTION
Adds support for self-hosted temporal with istio proxy by defining the ringpop ports and using `appProtocol: TCP`, since otherwise istio defaults to grpc which breaks networking.