### PR TITLE
Add instance label to serviceaccount

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.2.7
+version: 6.2.8
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/serviceaccount.yaml
+++ b/charts/retool/templates/serviceaccount.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "retool.serviceAccountName" . }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Values.serviceAccount.annotations }}
   annotations:
 {{ toYaml .Values.serviceAccount.annotations | indent 4 }}

--- a/charts/retool/templates/serviceaccount.yaml
+++ b/charts/retool/templates/serviceaccount.yaml
@@ -3,8 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "retool.serviceAccountName" . }}
-  labels:
-    app.kubernetes.io/instance: {{ .Release.Name }}
+  labels: {{- include "retool.labels" . | nindent 4 }}
 {{- if .Values.serviceAccount.annotations }}
   annotations:
 {{ toYaml .Values.serviceAccount.annotations | indent 4 }}


### PR DESCRIPTION
This is needed for automatic uninstallation on GCP to behave correctly.