### PR TITLE
remove unused google domain value

### DIFF
--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -18,7 +18,6 @@ config:
       # clientSecretSecretName:
       # clientSecretSecretKey is the key in the k8s secret, default: google-client-secret
       # clientSecretSecretKey:
-      domain:
   encryptionKey:
   # encryptionKeySecretName is the name of the secret where the encryption key is stored (can be used instead of encryptionKey)
   # encryptionKeySecretName:

--- a/values.yaml
+++ b/values.yaml
@@ -18,7 +18,6 @@ config:
       # clientSecretSecretName:
       # clientSecretSecretKey is the key in the k8s secret, default: google-client-secret
       # clientSecretSecretKey:
-      domain:
   encryptionKey:
   # encryptionKeySecretName is the name of the secret where the encryption key is stored (can be used instead of encryptionKey)
   # encryptionKeySecretName:


### PR DESCRIPTION
I search for uses of google domain in the templase and couldn't find.

Check by yourself with `rg '\.Values\.config\.auth\.google\.domain'`
