### PR TITLE
[chore] Java dbconnector enabled by default

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.2.8
+version: 6.2.9
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -75,21 +75,19 @@ spec:
           - name: NODE_ENV
             value: production
           {{- if include "retool.jobRunner.enabled" . }}
-          {{ if $.Values.dbconnector.java.enabled }}
-          - name: SERVICE_TYPE
-            value: MAIN_BACKEND,DB_CONNECTOR,DB_SSH_CONNECTOR,JAVA_DBCONNECTOR
-          {{ else }}
+          {{ if ( not $.Values.dbconnector.java.enabled ) }}
+          - name: DISABLE_JAVA_DBCONNECTOR
+            value: "true"
+          {{ end }}
           - name: SERVICE_TYPE
             value: MAIN_BACKEND,DB_CONNECTOR,DB_SSH_CONNECTOR
-          {{ end }}
           {{- else }}
-          {{ if $.Values.dbconnector.java.enabled }}
-          - name: SERVICE_TYPE
-            value: MAIN_BACKEND,DB_CONNECTOR,DB_SSH_CONNECTOR,JAVA_DBCONNECTOR,JOBS_RUNNER
-          {{ else }}
+          {{ if ( not $.Values.dbconnector.java.enabled ) }}
+          - name: DISABLE_JAVA_DBCONNECTOR
+            value: "true"
+          {{ end }}
           - name: SERVICE_TYPE
             value: MAIN_BACKEND,DB_CONNECTOR,DB_SSH_CONNECTOR,JOBS_RUNNER
-          {{ end }}
           {{- end }}
           - name: CLIENT_ID
             value: {{ default "" .Values.config.auth.google.clientId }}

--- a/charts/retool/templates/deployment_workflows.yaml
+++ b/charts/retool/templates/deployment_workflows.yaml
@@ -66,13 +66,12 @@ spec:
             value: {{ template "retool.deploymentTemplateVersion" . }}
           - name: NODE_ENV
             value: production
-          {{ if $.Values.dbconnector.java.enabled }}
-          - name: SERVICE_TYPE
-            value: WORKFLOW_BACKEND,DB_CONNECTOR,DB_SSH_CONNECTOR,JAVA_DBCONNECTOR
-          {{ else }}
+          {{ if ( not $.Values.dbconnector.java.enabled ) }}
+          - name: DISABLE_JAVA_DBCONNECTOR
+            value: "true"
+          {{ end }}
           - name: SERVICE_TYPE
             value: WORKFLOW_BACKEND,DB_CONNECTOR,DB_SSH_CONNECTOR
-          {{ end }}
           - name: DBCONNECTOR_POSTGRES_POOL_MAX_SIZE
             value: "100"
           - name: DBCONNECTOR_QUERY_TIMEOUT_MS

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -405,9 +405,8 @@ workflows:
 
 dbconnector:
   java:
-    # Enable this to use Retool's experimental next-gen dbconnector to connect to resources.
-    # This feature is not ready for production use; please check with the Retool team before enablement.
-    enabled: false
+    # Disable this to disable Retool's Java dbconnector.
+    enabled: true
 
 multiplayer:
   # Enable this to use Retool's experimental multiplayer editing feature.

--- a/values.yaml
+++ b/values.yaml
@@ -405,9 +405,8 @@ workflows:
 
 dbconnector:
   java:
-    # Enable this to use Retool's experimental next-gen dbconnector to connect to resources.
-    # This feature is not ready for production use; please check with the Retool team before enablement.
-    enabled: false
+    # Disable this to disable Retool's Java dbconnector.
+    enabled: true
 
 multiplayer:
   # Enable this to use Retool's experimental multiplayer editing feature.


### PR DESCRIPTION
We're making our Java dbconnector enabled by default so that it's much easier to enable. This service is currently available for a select few connectors, but it's much more stable for them. If you'd like to disable this functionality, you can use `DISABLE_JAVA_DBCONNECTOR` to stop it from starting up.