### PR TITLE
Scale Jobs-runner resources separately from main_backend 

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.2.9
+version: 6.3.0
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/deployment_jobs.yaml
+++ b/charts/retool/templates/deployment_jobs.yaml
@@ -176,7 +176,11 @@ spec:
         {{- end }}
         {{- end }}
         resources:
+{{- if .Values.jobRunner.resources }}
+{{ toYaml .Values.jobRunner.resources | indent 10 }}
+{{- else }}
 {{ toYaml .Values.resources | indent 10 }}
+{{- end }}
         {{- if regexMatch "^([0-9]+)\\.([0-9]+)\\.([0-9]+)" .Values.image.tag }}
         {{- if semverCompare ">=2.110.0-0" .Values.image.tag }}
         livenessProbe:

--- a/charts/retool/templates/deployment_workflows.yaml
+++ b/charts/retool/templates/deployment_workflows.yaml
@@ -244,7 +244,11 @@ spec:
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
 {{- end }}
         resources:
+{{- if .Values.workflows.backend.resources }}
+{{ toYaml .Values.workflows.backend.resources | indent 10 }}
+{{- else }}
 {{ toYaml .Values.resources | indent 10 }}
+{{- end }}
         volumeMounts:
         {{- range $configFile := (keys .Values.files) }}
         - name: {{ template "retool.name" $ }}

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -348,7 +348,7 @@ workflows:
     # will launch 9 pods -- 4 workflow backend, 1 workflow workers, and 4 for temporal cluster
     replicaCount: 1
 
-      # If necessary, specify the resources to provision the workflows-backend pod separately from the main backend pods.
+    # If necessary, specify the resources to provision the workflows-backend pod separately from the main backend pods.
     # resources:
     #   limits:
     #     cpu: 4096m

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -650,7 +650,6 @@ hostAliases: {}
 #     - anothertest.com
 
 telemetry:
-
   # When enabled, will collect metrics and logs from the other pods in the
   # chart. These will be forwarded to Retool for proactive monitoring and bug
   # identification when `telemetry.sendToRetool.enabled = true`, and can also
@@ -659,7 +658,6 @@ telemetry:
   enabled: false
 
   sendToRetool:
-
     # Only relevant when `telemetry.enabled = true`. When enabled, telemetry
     # from pods in this chart will be forwarded to Retool for proactive
     # monitoring and bug identification.
@@ -669,13 +667,12 @@ telemetry:
     address: "https://telemetry.retool.com:443"
 
   image:
-
     repository: "tryretool/telemetry"
 
     # Default to same as top level `image.tag`.
     tag: null
 
-    pullPolicy: 'IfNotPresent'
+    pullPolicy: "IfNotPresent"
 
   resources:
     requests:

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -299,7 +299,7 @@ jobRunner:
   # will already launch a job runner pod
   # enabled: true
 
-  # These resource specifications apply specific to the jobs runner pod. Set the resources to scale jobs runner pod separately from main backend pods.
+  # These resource specifications apply specific to the jobs-runner pod. Set the resources to scale jobs-runner pod separately from main-backend pods.
   # resources:
   #   limits:
   #     cpu: 4096m

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -299,6 +299,15 @@ jobRunner:
   # will already launch a job runner pod
   # enabled: true
 
+  # These resource specifications apply specific to the jobs runner pod. Set the resources to scale jobs runner pod separately from main backend pods.
+  # resources:
+  #   limits:
+  #     cpu: 4096m
+  #     memory: 8192Mi
+  #   requests:
+  #     cpu: 2048m
+  #     memory: 4096Mi
+
   # Annotations for job runner pods
   annotations: {}
 
@@ -641,6 +650,7 @@ hostAliases: {}
 #     - anothertest.com
 
 telemetry:
+
   # When enabled, will collect metrics and logs from the other pods in the
   # chart. These will be forwarded to Retool for proactive monitoring and bug
   # identification when `telemetry.sendToRetool.enabled = true`, and can also
@@ -649,6 +659,7 @@ telemetry:
   enabled: false
 
   sendToRetool:
+
     # Only relevant when `telemetry.enabled = true`. When enabled, telemetry
     # from pods in this chart will be forwarded to Retool for proactive
     # monitoring and bug identification.
@@ -658,12 +669,13 @@ telemetry:
     address: "https://telemetry.retool.com:443"
 
   image:
+
     repository: "tryretool/telemetry"
 
     # Default to same as top level `image.tag`.
     tag: null
 
-    pullPolicy: "IfNotPresent"
+    pullPolicy: 'IfNotPresent'
 
   resources:
     requests:

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -299,7 +299,7 @@ jobRunner:
   # will already launch a job runner pod
   # enabled: true
 
-  # These resource specifications apply specific to the jobs-runner pod. Set the resources to scale jobs-runner pod separately from main-backend pods.
+  # These resource apply only to the jobs-runner pod. Set the resources to scale jobs-runner pod separately from main-backend pods.
   # resources:
   #   limits:
   #     cpu: 4096m

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -231,7 +231,7 @@ extraVolumeMounts: []
 
 extraVolumes: []
 
-# These resource specifications apply to the main backend and workflows backend pods.
+# These resource specifications will apply to the main backend, jobs-runner, db-connector, and workflows backend pods(unless if container specific resources are set)
 resources:
   # If you have more than 1 replica, the minimum recommended resources configuration is as follows:
   # - cpu: 2048m

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -348,6 +348,15 @@ workflows:
     # will launch 9 pods -- 4 workflow backend, 1 workflow workers, and 4 for temporal cluster
     replicaCount: 1
 
+      # If necessary, specify the resources to provision the workflows-backend pod separately from the main backend pods.
+    # resources:
+    #   limits:
+    #     cpu: 4096m
+    #     memory: 8192Mi
+    #   requests:
+    #     cpu: 2048m
+    #     memory: 4096Mi
+    
   # Timeout for queries, in ms. This will set the timeout for workflows-related pods only
   # If this value is not set but config.dbConnectorTimeout is, we will set workflows pod timeouts
   # to .Values.config.dbConnectorTimeout

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -231,7 +231,7 @@ extraVolumeMounts: []
 
 extraVolumes: []
 
-# These resource specifications will apply to the main backend, jobs-runner, db-connector, and workflows backend pods(unless if container specific resources are set)
+# These resource specifications will apply to the main backend, jobs-runner, dbconnector, and workflows-backend pods unless container specific resources are set.
 resources:
   # If you have more than 1 replica, the minimum recommended resources configuration is as follows:
   # - cpu: 2048m
@@ -299,7 +299,7 @@ jobRunner:
   # will already launch a job runner pod
   # enabled: true
 
-  # These resource apply only to the jobs-runner pod. Set the resources to scale jobs-runner pod separately from main-backend pods.
+  # If necessary, specify the resources to provision the jobRunner pod separately from the main backend pods.
   # resources:
   #   limits:
   #     cpu: 4096m

--- a/values.yaml
+++ b/values.yaml
@@ -231,7 +231,7 @@ extraVolumeMounts: []
 
 extraVolumes: []
 
-# These resource specifications apply to the main backend, jobs-runner, db-connector, and workflows backend pods(unless if container specific resources are set)
+# These resource specifications will apply to the main backend, jobs-runner, db-connector, and workflows backend pods(unless if container specific resources are set)
 resources:
   # If you have more than 1 replica, the minimum recommended resources configuration is as follows:
   # - cpu: 2048m

--- a/values.yaml
+++ b/values.yaml
@@ -299,7 +299,7 @@ jobRunner:
   # will already launch a job runner pod
   # enabled: true
 
-  # These resource specifications apply specific to the jobs-runner pod. Set the resources to scale jobs-runner pod separately from main-backend pods.
+  # These resource specifications apply only to the jobs-runner pod. Set the resources to scale jobs-runner pod separately from main-backend pods.
   # resources:
   #   limits:
   #     cpu: 4096m
@@ -307,7 +307,7 @@ jobRunner:
   #   requests:
   #     cpu: 2048m
   #     memory: 4096Mi
-  
+
   # Annotations for job runner pods
   annotations: {}
 

--- a/values.yaml
+++ b/values.yaml
@@ -347,6 +347,15 @@ workflows:
     # Scaling this number will increase the number of workflow backends, e.g. a replicaCount of 4
     # will launch 9 pods -- 4 workflow backend, 1 workflow workers, and 4 for temporal cluster
     replicaCount: 1
+    
+    # If necessary, specify the resources to provision the workflows-backend pod separately from the main backend pods.
+    # resources:
+    #   limits:
+    #     cpu: 4096m
+    #     memory: 8192Mi
+    #   requests:
+    #     cpu: 2048m
+    #     memory: 4096Mi
 
   # Timeout for queries, in ms. This will set the timeout for workflows-related pods only
   # If this value is not set but config.dbConnectorTimeout is, we will set workflows pod timeouts

--- a/values.yaml
+++ b/values.yaml
@@ -231,7 +231,7 @@ extraVolumeMounts: []
 
 extraVolumes: []
 
-# These resource specifications apply to the main backend and workflows backend pods.
+# These resource specifications apply to the main backend, jobs-runner, db-connector, and workflows backend pods(unless if container specific resources are set)
 resources:
   # If you have more than 1 replica, the minimum recommended resources configuration is as follows:
   # - cpu: 2048m
@@ -299,7 +299,7 @@ jobRunner:
   # will already launch a job runner pod
   # enabled: true
 
-  # These resource specifications apply only to the jobs-runner pod. Set the resources to scale jobs-runner pod separately from main-backend pods.
+  # These resource apply only to the jobs-runner pod. Set the resources to scale jobs-runner pod separately from main-backend pods.
   # resources:
   #   limits:
   #     cpu: 4096m

--- a/values.yaml
+++ b/values.yaml
@@ -299,6 +299,15 @@ jobRunner:
   # will already launch a job runner pod
   # enabled: true
 
+  # These resource specifications apply specific to the jobs-runner pod. Set the resources to scale jobs-runner pod separately from main-backend pods.
+  # resources:
+  #   limits:
+  #     cpu: 4096m
+  #     memory: 8192Mi
+  #   requests:
+  #     cpu: 2048m
+  #     memory: 4096Mi
+  
   # Annotations for job runner pods
   annotations: {}
 

--- a/values.yaml
+++ b/values.yaml
@@ -231,7 +231,7 @@ extraVolumeMounts: []
 
 extraVolumes: []
 
-# These resource specifications will apply to the main backend, jobs-runner, db-connector, and workflows backend pods(unless if container specific resources are set)
+# These resource specifications will apply to the main backend, jobs-runner, dbconnector, and workflows-backend pods unless container specific resources are set.
 resources:
   # If you have more than 1 replica, the minimum recommended resources configuration is as follows:
   # - cpu: 2048m
@@ -299,7 +299,7 @@ jobRunner:
   # will already launch a job runner pod
   # enabled: true
 
-  # These resource apply only to the jobs-runner pod. Set the resources to scale jobs-runner pod separately from main-backend pods.
+  # If necessary, specify the resources to provision the jobRunner pod separately from the main backend pods.
   # resources:
   #   limits:
   #     cpu: 4096m


### PR DESCRIPTION
Added option to set resource.request/limit for jobs-runner and workflows-backend container, separating it from same resources used in for main-backend container