### PR TITLE
FEAT - add deploymentLabels option to the deployment jobs and backend chart

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.2.9
+version: 6.2.10
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -6,7 +6,6 @@ metadata:
     {{- include "retool.labels" . | nindent 4 }}
     {{- include "retool.selectorLabels" . | nindent 4 }}
 {{- if .Values.deployment.labels }}
-  labels:
 {{ toYaml .Values.deployment.labels | indent 4 }}
 {{- end }}
 {{- if .Values.deployment.annotations }}

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     {{- include "retool.labels" . | nindent 4 }}
     {{- include "retool.selectorLabels" . | nindent 4 }}
+{{- if .Values.deploymentLabels }}
+{{ toYaml .Values.deploymentLabels | indent 4 }}
+{{- end }}
 {{- if .Values.deployment.annotations }}
   annotations:
 {{ toYaml .Values.deployment.annotations | indent 4 }}

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "retool.labels" . | nindent 4 }}
     {{- include "retool.selectorLabels" . | nindent 4 }}
 {{- if .Values.deployment.labels }}
+  labels:
 {{ toYaml .Values.deployment.labels | indent 4 }}
 {{- end }}
 {{- if .Values.deployment.annotations }}

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -5,8 +5,8 @@ metadata:
   labels:
     {{- include "retool.labels" . | nindent 4 }}
     {{- include "retool.selectorLabels" . | nindent 4 }}
-{{- if .Values.deploymentLabels }}
-{{ toYaml .Values.deploymentLabels | indent 4 }}
+{{- if .Values.deployment.labels }}
+{{ toYaml .Values.deployment.labels | indent 4 }}
 {{- end }}
 {{- if .Values.deployment.annotations }}
   annotations:

--- a/charts/retool/templates/deployment_jobs.yaml
+++ b/charts/retool/templates/deployment_jobs.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     telemetry.retool.com/service-name: jobs-runner
 {{- if .Values.deployment.labels }}
-  labels:
 {{ toYaml .Values.deployment.labels | indent 4 }}
 {{- end }}
 {{- if .Values.deployment.annotations }}

--- a/charts/retool/templates/deployment_jobs.yaml
+++ b/charts/retool/templates/deployment_jobs.yaml
@@ -8,8 +8,8 @@ metadata:
     app.kubernetes.io/name: {{ include "retool.name" . }}-jobs-runner
     app.kubernetes.io/instance: {{ .Release.Name }}
     telemetry.retool.com/service-name: jobs-runner
-{{- if .Values.deploymentLabels }}
-{{ toYaml .Values.deploymentLabels | indent 4 }}
+{{- if .Values.deployment.labels }}
+{{ toYaml .Values.deployment.labels | indent 4 }}
 {{- end }}
 {{- if .Values.deployment.annotations }}
   annotations:

--- a/charts/retool/templates/deployment_jobs.yaml
+++ b/charts/retool/templates/deployment_jobs.yaml
@@ -8,6 +8,9 @@ metadata:
     app.kubernetes.io/name: {{ include "retool.name" . }}-jobs-runner
     app.kubernetes.io/instance: {{ .Release.Name }}
     telemetry.retool.com/service-name: jobs-runner
+{{- if .Values.deploymentLabels }}
+{{ toYaml .Values.deploymentLabels | indent 4 }}
+{{- end }}
 {{- if .Values.deployment.annotations }}
   annotations:
 {{ toYaml .Values.deployment.annotations | indent 4 }}

--- a/charts/retool/templates/deployment_jobs.yaml
+++ b/charts/retool/templates/deployment_jobs.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     telemetry.retool.com/service-name: jobs-runner
 {{- if .Values.deployment.labels }}
+  labels:
 {{ toYaml .Values.deployment.labels | indent 4 }}
 {{- end }}
 {{- if .Values.deployment.annotations }}

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -118,6 +118,7 @@ externalSecrets:
 files: {}
 
 deployment:
+  labels: {}
   annotations: {}
 
 service:

--- a/values.yaml
+++ b/values.yaml
@@ -118,6 +118,7 @@ externalSecrets:
 files: {}
 
 deployment:
+  labels: {}
   annotations: {}
 
 service:


### PR DESCRIPTION
Enable end user to add custom labels at the deployment object for use by tooling downstream. 