### PR TITLE
[fix] Add default multiplayer ingress rule

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.3.5
+version: 6.3.6
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/ingress.yaml
+++ b/charts/retool/templates/ingress.yaml
@@ -30,6 +30,20 @@ spec:
     - host: {{ .Values.ingress.hostName | quote }}
       http:
         paths:
+          # The multiplayer paths must be added before the main path to avoid less specific paths being matched first.
+          {{- if ( and .Values.multiplayer.enabled .Values.multiplayer.ingress.enabled ) }}
+          {{- range .Values.multiplayer.ingress.paths }}
+          - path: {{ .path }}
+            {{- if (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.Version) }}
+            pathType: {{ .pathType | default "ImplementationSpecific" }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ template "retool.multiplayer.name" . }}
+                port:
+                  number: {{ .port }}
+          {{- end }}
+          {{- end }}
           - path:
             {{- if and $pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.Version) }}
             pathType: {{ $pathType }}
@@ -51,6 +65,20 @@ spec:
         paths:
           {{- with .extraPaths }}
 {{ toYaml . | indent 10 }}
+          {{- end }}
+          # The multiplayer paths must be added before the main path to avoid less specific paths being matched first.
+          {{- if ( and .Values.multiplayer.enabled .Values.multiplayer.ingress.enabled ) }}
+          {{- range .Values.multiplayer.ingress.paths }}
+          - path: {{ .path }}
+            {{- if (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.Version) }}
+            pathType: {{ .pathType | default "ImplementationSpecific" }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ template "retool.multiplayer.name" . }}
+                port:
+                  number: {{ .port }}
+          {{- end }}
           {{- end }}
           {{- range .paths }}
           - path: {{ .path }}

--- a/charts/retool/templates/ingress.yaml
+++ b/charts/retool/templates/ingress.yaml
@@ -31,7 +31,7 @@ spec:
       http:
         paths:
           # The multiplayer paths must be added before the main path to avoid less specific paths being matched first.
-          {{- if ( and .Values.multiplayer.enabled .Values.multiplayer.ingress.enabled ) }}
+          {{- if ( and ((.Values.multiplayer).enabled) (((.Values.multiplayer).ingress).enabled) ) }}
           {{- range .Values.multiplayer.ingress.paths }}
           - path: {{ .path }}
             {{- if (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.Version) }}
@@ -67,8 +67,8 @@ spec:
 {{ toYaml . | indent 10 }}
           {{- end }}
           # The multiplayer paths must be added before the main path to avoid less specific paths being matched first.
-          {{- if ( and .Values.multiplayer.enabled .Values.multiplayer.ingress.enabled ) }}
-          {{- range .Values.multiplayer.ingress.paths }}
+          {{- if ( and (($.Values.multiplayer).enabled) ((($.Values.multiplayer).ingress).enabled) ) }}
+          {{- range (($.Values.multiplayer).ingress).paths }}
           - path: {{ .path }}
             {{- if (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.Version) }}
             pathType: {{ .pathType | default "ImplementationSpecific" }}

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -461,6 +461,13 @@ multiplayer:
   # Labels for multiplayer pods
   labels: {}
 
+  # Paths to route to multiplayer pods; defaults to /api/multiplayer. Can specify both path and port.
+  ingress:
+    enabled: true
+    paths:
+      - path: /api/multiplayer
+        port: 80
+
 codeExecutor:
   # enabled by default from Chart version 6.0.15 and Retool image 3.20.15 onwards
   # explicitly set other fields as needed

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -463,6 +463,7 @@ multiplayer:
 
   # Paths to route to multiplayer pods; defaults to /api/multiplayer. Can specify both path and port.
   ingress:
+    # This conditional is dependent on multiplayer.enabled.
     enabled: true
     paths:
       - path: /api/multiplayer

--- a/values.yaml
+++ b/values.yaml
@@ -461,6 +461,14 @@ multiplayer:
   # Labels for multiplayer pods
   labels: {}
 
+  # Paths to route to multiplayer pods; defaults to /api/multiplayer. Can specify both path and port.
+  ingress:
+    # This conditional is dependent on multiplayer.enabled.
+    enabled: true
+    paths:
+      - path: /api/multiplayer
+        port: 80
+
 codeExecutor:
   # enabled by default from Chart version 6.0.15 and Retool image 3.20.15 onwards
   # explicitly set other fields as needed


### PR DESCRIPTION
Addresses https://github.com/tryretool/retool-helm/issues/199, aims to automatically create an ingress rule, if multiplayer is enabled, to point requests for `/api/multiplayer` to the multiplayer pod. To avoid conflicts with folks who already have this ingress rule set, this automatic rule can be disabled using `multiplayer.ingress.enabled=false`.

Tested by applying to our test cluster, which created a new (inaccessible) ingress, which looks like this (redacted hostnames just in case, but they shouldn't be sensitive):
<img width="748" alt="Screenshot 2025-01-22 at 8 15 26 AM" src="https://github.com/user-attachments/assets/e40e9c50-e137-4501-b570-2b412b78590e" />
<img width="428" alt="Screenshot 2025-01-22 at 8 15 34 AM" src="https://github.com/user-attachments/assets/6fae9954-4d36-4993-b045-7debf945236e" />

I also added these values to the `values.yaml` file:
```
ingress:
  enabled: true
  labels: {}
  annotations: {}
  # kubernetes.io/ingress.class: nginx
  # kubernetes.io/tls-acme: "true"
  hosts:
  - host: retool-dev.[hostname]
    paths:
      - path: /
  tls:
  - secretName: retool-dev-tls
    hosts:
      - retool-dev.[hostname]
  pathType: ImplementationSpecific
multiplayer:
  enabled: true
```