### PR TITLE
[feat] Flexible security contexts

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.3.1
+version: 6.3.2
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/ci/kubeconform/telemetry-enabled-full-values.yaml
+++ b/charts/retool/ci/kubeconform/telemetry-enabled-full-values.yaml
@@ -50,6 +50,12 @@ replicaCount: 1
 
 persistentVolumeClaim:
   size: '3Gi'
+
+securityContext:
+  enabled: true
+  allowPrivilegeEscalation: false
+  runAsUser: 1000
+  fsGroup: 2000
 # ================================================
 
 # === New telemetry stuff ===

--- a/charts/retool/ci/kubeconform/telemetry-enabled-full-values.yaml
+++ b/charts/retool/ci/kubeconform/telemetry-enabled-full-values.yaml
@@ -53,9 +53,10 @@ persistentVolumeClaim:
 
 securityContext:
   enabled: true
-  allowPrivilegeEscalation: false
   runAsUser: 1000
   fsGroup: 2000
+  extraContainerLevelSecurityContext:
+    allowPrivilegeEscalation: false
 # ================================================
 
 # === New telemetry stuff ===

--- a/charts/retool/ci/test-extra-security-context-option.yaml
+++ b/charts/retool/ci/test-extra-security-context-option.yaml
@@ -1,0 +1,10 @@
+# default security context
+securityContext:
+  enabled: true
+  allowPrivilegeEscalation: false
+  runAsUser: 10
+  fsGroup: 20
+  extraSecurityContext:
+    supplementalGroups: [4000]
+    supplementalGroupsPolicy: Strict
+    runAsNonRoot: true

--- a/charts/retool/ci/test-extra-security-context-option.yaml
+++ b/charts/retool/ci/test-extra-security-context-option.yaml
@@ -5,6 +5,4 @@ securityContext:
   runAsUser: 10
   fsGroup: 20
   extraSecurityContext:
-    supplementalGroups: [4000]
-    supplementalGroupsPolicy: Strict
     runAsNonRoot: true

--- a/charts/retool/ci/test-extra-security-context-option.yaml
+++ b/charts/retool/ci/test-extra-security-context-option.yaml
@@ -1,8 +1,9 @@
 # default security context
 securityContext:
   enabled: true
-  allowPrivilegeEscalation: false
   runAsUser: 10
   fsGroup: 20
   extraSecurityContext:
     runAsNonRoot: true
+  extraContainerLevelSecurityContext:
+    allowPrivilegeEscalation: false

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -309,9 +309,9 @@ spec:
           mountPath: {{ .mountPath }}
           subPath: {{ .subPath }}
 {{- end }}
-{{- if .Values.securityContext.extraContainerLevelSecurityContext }}
+{{- if .Values.securityContext.extraContainerSecurityContext }}
         securityContext:
-{{ toYaml .Values.securityContext.extraContainerLevelSecurityContext | indent 10 }}
+{{ toYaml .Values.securityContext.extraContainerSecurityContext | indent 10 }}
 {{- end }}
     {{- if .Values.image.pullSecrets }}
       imagePullSecrets:

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -325,12 +325,11 @@ spec:
 {{ toYaml .Values.tolerations | indent 8 }}
 {{- if .Values.securityContext.enabled }}
       securityContext:
-{{- if .Values.securityContext.values }}
-{{ toYaml .Values.securityContext.values | indent 8 }}
-{{- else }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
         allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+{{- if .Values.securityContext.extraSecurityContext }}
+{{ toYaml .Values.securityContext.extraSecurityContext | indent 8 }}
 {{- end }}
 {{- end }}
       volumes:

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -325,8 +325,13 @@ spec:
 {{ toYaml .Values.tolerations | indent 8 }}
 {{- if .Values.securityContext.enabled }}
       securityContext:
+{{- if .Values.securityContext.values }}
+{{ toYaml .Values.securityContext.values | indent 8 }}
+{{- else }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
+        allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+{{- end }}
 {{- end }}
       volumes:
 {{- range .Values.extraConfigMapMounts }}

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -309,6 +309,10 @@ spec:
           mountPath: {{ .mountPath }}
           subPath: {{ .subPath }}
 {{- end }}
+{{- if .Values.securityContext.extraContainerLevelSecurityContext }}
+        securityContext:
+{{ toYaml .Values.securityContext.extraContainerLevelSecurityContext | indent 10 }}
+{{- end }}
     {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.image.pullSecrets | indent 8 }}
@@ -327,7 +331,6 @@ spec:
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
-        allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
 {{- if .Values.securityContext.extraSecurityContext }}
 {{ toYaml .Values.securityContext.extraSecurityContext | indent 8 }}
 {{- end }}

--- a/charts/retool/templates/deployment_jobs.yaml
+++ b/charts/retool/templates/deployment_jobs.yaml
@@ -223,6 +223,10 @@ spec:
           mountPath: {{ .mountPath }}
           subPath: {{ .subPath }}
 {{- end }}
+{{- if .Values.securityContext.extraContainerLevelSecurityContext }}
+        securityContext:
+{{ toYaml .Values.securityContext.extraContainerLevelSecurityContext | indent 10 }}
+{{- end }}
     {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.image.pullSecrets | indent 8 }}
@@ -241,7 +245,6 @@ spec:
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
-        allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
 {{- if .Values.securityContext.extraSecurityContext }}
 {{ toYaml .Values.securityContext.extraSecurityContext | indent 8 }}
 {{- end }}

--- a/charts/retool/templates/deployment_jobs.yaml
+++ b/charts/retool/templates/deployment_jobs.yaml
@@ -166,9 +166,9 @@ spec:
         envFrom:
         - secretRef:
             name: {{ .Values.externalSecrets.name }}
-        {{- range .Values.externalSecrets.secrets }}	
-        - secretRef:	
-            name: {{ .name }}	
+        {{- range .Values.externalSecrets.secrets }}
+        - secretRef:
+            name: {{ .name }}
         {{- end }}
         {{- end }}
         {{- if .Values.externalSecrets.externalSecretsOperator.enabled  }}
@@ -239,8 +239,13 @@ spec:
 {{ toYaml .Values.tolerations | indent 8 }}
 {{- if .Values.securityContext.enabled }}
       securityContext:
+{{- if .Values.securityContext.values }}
+{{ toYaml .Values.securityContext.values | indent 8 }}
+{{- else }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
+        allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+{{- end }}
 {{- end }}
       volumes:
 {{- range .Values.extraConfigMapMounts }}

--- a/charts/retool/templates/deployment_jobs.yaml
+++ b/charts/retool/templates/deployment_jobs.yaml
@@ -223,9 +223,9 @@ spec:
           mountPath: {{ .mountPath }}
           subPath: {{ .subPath }}
 {{- end }}
-{{- if .Values.securityContext.extraContainerLevelSecurityContext }}
+{{- if .Values.securityContext.extraContainerSecurityContext }}
         securityContext:
-{{ toYaml .Values.securityContext.extraContainerLevelSecurityContext | indent 10 }}
+{{ toYaml .Values.securityContext.extraContainerSecurityContext | indent 10 }}
 {{- end }}
     {{- if .Values.image.pullSecrets }}
       imagePullSecrets:

--- a/charts/retool/templates/deployment_jobs.yaml
+++ b/charts/retool/templates/deployment_jobs.yaml
@@ -239,12 +239,11 @@ spec:
 {{ toYaml .Values.tolerations | indent 8 }}
 {{- if .Values.securityContext.enabled }}
       securityContext:
-{{- if .Values.securityContext.values }}
-{{ toYaml .Values.securityContext.values | indent 8 }}
-{{- else }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
         allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+{{- if .Values.securityContext.extraSecurityContext }}
+{{ toYaml .Values.securityContext.extraSecurityContext | indent 8 }}
 {{- end }}
 {{- end }}
       volumes:

--- a/charts/retool/templates/deployment_multiplayer_ws.yaml
+++ b/charts/retool/templates/deployment_multiplayer_ws.yaml
@@ -184,12 +184,11 @@ spec:
 {{ toYaml .Values.tolerations | indent 8 }}
 {{- if .Values.securityContext.enabled }}
       securityContext:
-{{- if .Values.securityContext.values }}
-{{ toYaml .Values.securityContext.values | indent 8 }}
-{{- else }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
         allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+{{- if .Values.securityContext.extraSecurityContext }}
+{{ toYaml .Values.securityContext.extraSecurityContext | indent 8 }}
 {{- end }}
 {{- end }}
       volumes:

--- a/charts/retool/templates/deployment_multiplayer_ws.yaml
+++ b/charts/retool/templates/deployment_multiplayer_ws.yaml
@@ -184,8 +184,13 @@ spec:
 {{ toYaml .Values.tolerations | indent 8 }}
 {{- if .Values.securityContext.enabled }}
       securityContext:
+{{- if .Values.securityContext.values }}
+{{ toYaml .Values.securityContext.values | indent 8 }}
+{{- else }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
+        allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+{{- end }}
 {{- end }}
       volumes:
 {{- range .Values.extraConfigMapMounts }}

--- a/charts/retool/templates/deployment_multiplayer_ws.yaml
+++ b/charts/retool/templates/deployment_multiplayer_ws.yaml
@@ -160,9 +160,9 @@ spec:
 {{- if .Values.extraVolumeMounts }}
 {{ toYaml .Values.extraVolumeMounts | indent 8 }}
 {{- end }}
-{{- if .Values.securityContext.extraContainerLevelSecurityContext }}
+{{- if .Values.securityContext.extraContainerSecurityContext }}
         securityContext:
-{{ toYaml .Values.securityContext.extraContainerLevelSecurityContext | indent 10 }}
+{{ toYaml .Values.securityContext.extraContainerSecurityContext | indent 10 }}
 {{- end }}
 {{- with .Values.extraContainers }}
 {{ tpl . $ | indent 6 }}

--- a/charts/retool/templates/deployment_multiplayer_ws.yaml
+++ b/charts/retool/templates/deployment_multiplayer_ws.yaml
@@ -160,6 +160,10 @@ spec:
 {{- if .Values.extraVolumeMounts }}
 {{ toYaml .Values.extraVolumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.securityContext.extraContainerLevelSecurityContext }}
+        securityContext:
+{{ toYaml .Values.securityContext.extraContainerLevelSecurityContext | indent 10 }}
+{{- end }}
 {{- with .Values.extraContainers }}
 {{ tpl . $ | indent 6 }}
 {{- end }}
@@ -186,7 +190,6 @@ spec:
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
-        allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
 {{- if .Values.securityContext.extraSecurityContext }}
 {{ toYaml .Values.securityContext.extraSecurityContext | indent 8 }}
 {{- end }}

--- a/charts/retool/templates/deployment_workflows.yaml
+++ b/charts/retool/templates/deployment_workflows.yaml
@@ -290,12 +290,11 @@ spec:
 {{ toYaml .Values.tolerations | indent 8 }}
 {{- if .Values.securityContext.enabled }}
       securityContext:
-{{- if .Values.securityContext.values }}
-{{ toYaml .Values.securityContext.values | indent 8 }}
-{{- else }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
         allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+{{- if .Values.securityContext.extraSecurityContext }}
+{{ toYaml .Values.securityContext.extraSecurityContext | indent 8 }}
 {{- end }}
 {{- end }}
       volumes:

--- a/charts/retool/templates/deployment_workflows.yaml
+++ b/charts/retool/templates/deployment_workflows.yaml
@@ -266,9 +266,9 @@ spec:
 {{- if .Values.extraVolumeMounts }}
 {{ toYaml .Values.extraVolumeMounts | indent 8 }}
 {{- end }}
-{{- if .Values.securityContext.extraContainerLevelSecurityContext }}
+{{- if .Values.securityContext.extraContainerSecurityContext }}
         securityContext:
-{{ toYaml .Values.securityContext.extraContainerLevelSecurityContext | indent 10 }}
+{{ toYaml .Values.securityContext.extraContainerSecurityContext | indent 10 }}
 {{- end }}
 {{- with .Values.extraContainers }}
 {{ tpl . $ | indent 6 }}

--- a/charts/retool/templates/deployment_workflows.yaml
+++ b/charts/retool/templates/deployment_workflows.yaml
@@ -290,8 +290,13 @@ spec:
 {{ toYaml .Values.tolerations | indent 8 }}
 {{- if .Values.securityContext.enabled }}
       securityContext:
+{{- if .Values.securityContext.values }}
+{{ toYaml .Values.securityContext.values | indent 8 }}
+{{- else }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
+        allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+{{- end }}
 {{- end }}
       volumes:
 {{- range .Values.extraConfigMapMounts }}

--- a/charts/retool/templates/deployment_workflows.yaml
+++ b/charts/retool/templates/deployment_workflows.yaml
@@ -266,6 +266,10 @@ spec:
 {{- if .Values.extraVolumeMounts }}
 {{ toYaml .Values.extraVolumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.securityContext.extraContainerLevelSecurityContext }}
+        securityContext:
+{{ toYaml .Values.securityContext.extraContainerLevelSecurityContext | indent 10 }}
+{{- end }}
 {{- with .Values.extraContainers }}
 {{ tpl . $ | indent 6 }}
 {{- end }}
@@ -292,7 +296,6 @@ spec:
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
-        allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
 {{- if .Values.securityContext.extraSecurityContext }}
 {{ toYaml .Values.securityContext.extraSecurityContext | indent 8 }}
 {{- end }}

--- a/charts/retool/templates/deployment_workflows_worker.yaml
+++ b/charts/retool/templates/deployment_workflows_worker.yaml
@@ -278,6 +278,10 @@ spec:
 {{- if .Values.extraVolumeMounts }}
 {{ toYaml .Values.extraVolumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.securityContext.extraContainerLevelSecurityContext }}
+        securityContext:
+{{ toYaml .Values.securityContext.extraContainerLevelSecurityContext | indent 10 }}
+{{- end }}
 {{- with .Values.extraContainers }}
 {{ tpl . $ | indent 6 }}
 {{- end }}
@@ -304,7 +308,6 @@ spec:
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
-        allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
 {{- if .Values.securityContext.extraSecurityContext }}
 {{ toYaml .Values.securityContext.extraSecurityContext | indent 8 }}
 {{- end }}

--- a/charts/retool/templates/deployment_workflows_worker.yaml
+++ b/charts/retool/templates/deployment_workflows_worker.yaml
@@ -302,8 +302,13 @@ spec:
 {{ toYaml .Values.tolerations | indent 8 }}
 {{- if .Values.securityContext.enabled }}
       securityContext:
+{{- if .Values.securityContext.values }}
+{{ toYaml .Values.securityContext.values | indent 8 }}
+{{- else }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
+        allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+{{- end }}
 {{- end }}
       volumes:
 {{- range .Values.extraConfigMapMounts }}

--- a/charts/retool/templates/deployment_workflows_worker.yaml
+++ b/charts/retool/templates/deployment_workflows_worker.yaml
@@ -278,9 +278,9 @@ spec:
 {{- if .Values.extraVolumeMounts }}
 {{ toYaml .Values.extraVolumeMounts | indent 8 }}
 {{- end }}
-{{- if .Values.securityContext.extraContainerLevelSecurityContext }}
+{{- if .Values.securityContext.extraContainerSecurityContext }}
         securityContext:
-{{ toYaml .Values.securityContext.extraContainerLevelSecurityContext | indent 10 }}
+{{ toYaml .Values.securityContext.extraContainerSecurityContext | indent 10 }}
 {{- end }}
 {{- with .Values.extraContainers }}
 {{ tpl . $ | indent 6 }}

--- a/charts/retool/templates/deployment_workflows_worker.yaml
+++ b/charts/retool/templates/deployment_workflows_worker.yaml
@@ -302,12 +302,11 @@ spec:
 {{ toYaml .Values.tolerations | indent 8 }}
 {{- if .Values.securityContext.enabled }}
       securityContext:
-{{- if .Values.securityContext.values }}
-{{ toYaml .Values.securityContext.values | indent 8 }}
-{{- else }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
         allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+{{- if .Values.securityContext.extraSecurityContext }}
+{{ toYaml .Values.securityContext.extraSecurityContext | indent 8 }}
 {{- end }}
 {{- end }}
       volumes:

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -637,8 +637,7 @@ securityContext:
   runAsUser: 1000
   fsGroup: 2000
   # Use this section to define additional security context values not provided by default.
-  # Existing values above will be fully replaced by the values in this section.
-  values: {}
+  extraSecurityContext: {}
 
 extraConfigMapMounts: []
 

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -636,6 +636,9 @@ securityContext:
   allowPrivilegeEscalation: false
   runAsUser: 1000
   fsGroup: 2000
+  # Use this section to define additional security context values not provided by default.
+  # Existing values above will be fully replaced by the values in this section.
+  values: {}
 
 extraConfigMapMounts: []
 

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -637,7 +637,7 @@ securityContext:
   fsGroup: 2000
   # Use this section to define additional security context values not provided by default.
   extraSecurityContext: {}
-  extraContainerLevelSecurityContext: {}
+  extraContainerSecurityContext: {}
 
 extraConfigMapMounts: []
 

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -635,8 +635,9 @@ securityContext:
   enabled: false
   runAsUser: 1000
   fsGroup: 2000
-  # Use this section to define additional security context values not provided by default.
+  # Use this section to define additional pod security context values for primary Retool pods not provided by default.
   extraSecurityContext: {}
+  # Use this section to define additional container security context values for primary Retool pods not provided by default.
   extraContainerSecurityContext: {}
 
 extraConfigMapMounts: []

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -636,8 +636,10 @@ securityContext:
   runAsUser: 1000
   fsGroup: 2000
   # Use this section to define additional pod security context values for primary Retool pods not provided by default.
+  # See this doc for options allowed here (ensure the Kubernetes version matches the version of the Kubernetes cluster you are deploying to): https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podsecuritycontext-v1-core
   extraSecurityContext: {}
   # Use this section to define additional container security context values for primary Retool pods not provided by default.
+  # See this doc for options allowed here (ensure the Kubernetes version matches the version of the Kubernetes cluster you are deploying to): https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#securitycontext-v1-core
   extraContainerSecurityContext: {}
 
 extraConfigMapMounts: []

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -633,11 +633,11 @@ persistentVolumeClaim:
 # default security context
 securityContext:
   enabled: false
-  allowPrivilegeEscalation: false
   runAsUser: 1000
   fsGroup: 2000
   # Use this section to define additional security context values not provided by default.
   extraSecurityContext: {}
+  extraContainerLevelSecurityContext: {}
 
 extraConfigMapMounts: []
 

--- a/values.yaml
+++ b/values.yaml
@@ -637,8 +637,7 @@ securityContext:
   runAsUser: 1000
   fsGroup: 2000
   # Use this section to define additional security context values not provided by default.
-  # Existing values above will be fully replaced by the values in this section.
-  values: {}
+  extraSecurityContext: {}
 
 extraConfigMapMounts: []
 

--- a/values.yaml
+++ b/values.yaml
@@ -636,6 +636,9 @@ securityContext:
   allowPrivilegeEscalation: false
   runAsUser: 1000
   fsGroup: 2000
+  # Use this section to define additional security context values not provided by default.
+  # Existing values above will be fully replaced by the values in this section.
+  values: {}
 
 extraConfigMapMounts: []
 

--- a/values.yaml
+++ b/values.yaml
@@ -637,7 +637,7 @@ securityContext:
   fsGroup: 2000
   # Use this section to define additional security context values not provided by default.
   extraSecurityContext: {}
-  extraContainerLevelSecurityContext: {}
+  extraContainerSecurityContext: {}
 
 extraConfigMapMounts: []
 

--- a/values.yaml
+++ b/values.yaml
@@ -635,8 +635,9 @@ securityContext:
   enabled: false
   runAsUser: 1000
   fsGroup: 2000
-  # Use this section to define additional security context values not provided by default.
+  # Use this section to define additional pod security context values for primary Retool pods not provided by default.
   extraSecurityContext: {}
+  # Use this section to define additional container security context values for primary Retool pods not provided by default.
   extraContainerSecurityContext: {}
 
 extraConfigMapMounts: []

--- a/values.yaml
+++ b/values.yaml
@@ -636,8 +636,10 @@ securityContext:
   runAsUser: 1000
   fsGroup: 2000
   # Use this section to define additional pod security context values for primary Retool pods not provided by default.
+  # See this doc for options allowed here (ensure the Kubernetes version matches the version of the Kubernetes cluster you are deploying to): https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podsecuritycontext-v1-core
   extraSecurityContext: {}
   # Use this section to define additional container security context values for primary Retool pods not provided by default.
+  # See this doc for options allowed here (ensure the Kubernetes version matches the version of the Kubernetes cluster you are deploying to): https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#securitycontext-v1-core
   extraContainerSecurityContext: {}
 
 extraConfigMapMounts: []

--- a/values.yaml
+++ b/values.yaml
@@ -633,11 +633,11 @@ persistentVolumeClaim:
 # default security context
 securityContext:
   enabled: false
-  allowPrivilegeEscalation: false
   runAsUser: 1000
   fsGroup: 2000
   # Use this section to define additional security context values not provided by default.
   extraSecurityContext: {}
+  extraContainerLevelSecurityContext: {}
 
 extraConfigMapMounts: []
 


### PR DESCRIPTION
Allows users to fully define the security contexts of their pods rather than only supporting a limited list. Previous format must be maintained for backwards compatibility, which necessitates the complex set of if statements.

This is meant to address these issues:
* https://github.com/tryretool/retool-helm/issues/124
* https://github.com/tryretool/retool-helm/issues/57

Tested locally, confirmed the following:
* `helm template charts/retool --values charts/retool/ci/test-install-values.yaml` runs successfully without error
* When `securityContext.enabled=false`, no security context block is added
* When `securityContext.values={}`, the legacy values are used
* When there are values in `securityContext.values`, those values are overridden, ignoring the legacy values

Update: changed PR to match telemetry deployment model of maintaining legacy params while providing the option to add extra custom ones.