### PR TITLE
allow external secrets to potentially clobber other secrets if opted in

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.3.2
+version: 6.3.3
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -351,3 +351,10 @@ Usage: (template "retool.codeExecutor.image.tag" .)
 {{- end -}}
 {{- $output -}}
 {{- end -}}
+
+{{/*
+Checks whether or not ExternalSecret definitions are enabled and can potentially clobber secrets or explicitly allow additional direct secret refs.
+*/}}
+{{- define "shouldIncludeConfigSecretsEnvVars" -}}
+{{- or (not (or (.Values.externalSecrets.enabled) (.Values.externalSecrets.externalSecretsOperator.enabled))) .Values.includeConfigSecrets -}}
+{{- end -}}

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -153,7 +153,7 @@ spec:
 
           {{- include "retool.telemetry.includeEnvVars" . | nindent 10 }}
 
-          {{- if and (not .Values.externalSecrets.enabled) (not .Values.externalSecrets.externalSecretsOperator.enabled) }}
+          {{- if (include "shouldIncludeConfigSecretsEnvVars" .) }}
           - name: LICENSE_KEY
             valueFrom:
               secretKeyRef:

--- a/charts/retool/templates/deployment_jobs.yaml
+++ b/charts/retool/templates/deployment_jobs.yaml
@@ -91,7 +91,7 @@ spec:
 
           {{- include "retool.telemetry.includeEnvVars" . | nindent 10 }}
 
-          {{- if and (not .Values.externalSecrets.enabled) (not .Values.externalSecrets.externalSecretsOperator.enabled) }}
+          {{- if (include "shouldIncludeConfigSecretsEnvVars" .) }}
           - name: LICENSE_KEY
             valueFrom:
               secretKeyRef:

--- a/charts/retool/templates/deployment_telemetry.yaml
+++ b/charts/retool/templates/deployment_telemetry.yaml
@@ -52,7 +52,7 @@ spec:
             value: "/host/proc"
           - name: SYSFS_ROOT
             value: "/host/sys"
-          {{- if and (not .Values.externalSecrets.enabled) (not .Values.externalSecrets.externalSecretsOperator.enabled) }}
+          {{- if (include "shouldIncludeConfigSecretsEnvVars" .) }}
           - name: LICENSE_KEY
             valueFrom:
               secretKeyRef:

--- a/charts/retool/templates/deployment_workflows.yaml
+++ b/charts/retool/templates/deployment_workflows.yaml
@@ -141,7 +141,7 @@ spec:
           - name: CODE_EXECUTOR_INGRESS_DOMAIN
             value: http://{{ template "retool.codeExecutor.name" . }}
           {{- end }}
-          {{- if and (not .Values.externalSecrets.enabled) (not .Values.externalSecrets.externalSecretsOperator.enabled) }}
+          {{- if (include "shouldIncludeConfigSecretsEnvVars" .) }}
           - name: LICENSE_KEY
             valueFrom:
               secretKeyRef:

--- a/charts/retool/templates/deployment_workflows_worker.yaml
+++ b/charts/retool/templates/deployment_workflows_worker.yaml
@@ -150,7 +150,7 @@ spec:
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: "http://$(HOST_IP):4317"
           {{- end }}
-          {{- if and (not .Values.externalSecrets.enabled) (not .Values.externalSecrets.externalSecretsOperator.enabled) }}
+          {{- if (include "shouldIncludeConfigSecretsEnvVars" .) }}
           - name: LICENSE_KEY
             valueFrom:
               secretKeyRef:

--- a/charts/retool/templates/secret.yaml
+++ b/charts/retool/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.externalSecrets.enabled) (not .Values.externalSecrets.externalSecretsOperator.enabled) }}
+{{- if (include "shouldIncludeConfigSecretsEnvVars" .) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -95,6 +95,9 @@ externalSecrets:
   # Support for legacy external secrets, note this is deprecated in favour of External Secrets Operator: https://github.com/godaddy/kubernetes-external-secrets
   # This mode only allows a single secret name to be provided.
   enabled: false
+  # If external secrets are currently enabled, it is disallowed to specify regular configuration secrets as a safeguard from clobbering.
+  # This flag allows bypassing that check and specifying both an ExternalSecret and a regular secret for different secrets.
+  includeConfigSecrets: false
   name: retool-config
   # Array of secrets to be use as env variables. (Optional)
   secrets:

--- a/values.yaml
+++ b/values.yaml
@@ -95,6 +95,9 @@ externalSecrets:
   # Support for legacy external secrets, note this is deprecated in favour of External Secrets Operator: https://github.com/godaddy/kubernetes-external-secrets
   # This mode only allows a single secret name to be provided.
   enabled: false
+  # If external secrets are currently enabled, it is disallowed to specify regular configuration secrets as a safeguard from clobbering.
+  # This flag allows bypassing that check and specifying both an ExternalSecret and a regular secret for different secrets.
+  includeConfigSecrets: false
   name: retool-config
   # Array of secrets to be use as env variables. (Optional)
   secrets:


### PR DESCRIPTION
if external secrets are currently enabled, they don't let us specify the regular configuration secrets as a safeguard from clobbering.

this flag should let us both use an externalsecret for something like the postgres password and just use a regular secret for the other things like license key