### PR TITLE
Fix shouldIncludeConfigSecretsEnvVars output format

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.3.3
+version: 6.3.4
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -356,5 +356,11 @@ Usage: (template "retool.codeExecutor.image.tag" .)
 Checks whether or not ExternalSecret definitions are enabled and can potentially clobber secrets or explicitly allow additional direct secret refs.
 */}}
 {{- define "shouldIncludeConfigSecretsEnvVars" -}}
-{{- or (not (or (.Values.externalSecrets.enabled) (.Values.externalSecrets.externalSecretsOperator.enabled))) .Values.includeConfigSecrets -}}
+{{- $output := "" -}}
+{{- if or (not (or (.Values.externalSecrets.enabled) (.Values.externalSecrets.externalSecretsOperator.enabled))) .Values.externalSecrets.includeConfigSecrets -}}
+  {{- $output = "1" -}}
+{{- else -}}
+  {{- $output = "" -}}
+{{- end -}}
+{{- $output -}}
 {{- end -}}

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -153,7 +153,7 @@ spec:
 
           {{- include "retool.telemetry.includeEnvVars" . | nindent 10 }}
 
-          {{- if (include "shouldIncludeConfigSecretsEnvVars" .) }}
+          {{- if include "shouldIncludeConfigSecretsEnvVars" . }}
           - name: LICENSE_KEY
             valueFrom:
               secretKeyRef:

--- a/charts/retool/templates/deployment_jobs.yaml
+++ b/charts/retool/templates/deployment_jobs.yaml
@@ -91,7 +91,7 @@ spec:
 
           {{- include "retool.telemetry.includeEnvVars" . | nindent 10 }}
 
-          {{- if (include "shouldIncludeConfigSecretsEnvVars" .) }}
+          {{- if include "shouldIncludeConfigSecretsEnvVars" . }}
           - name: LICENSE_KEY
             valueFrom:
               secretKeyRef:

--- a/charts/retool/templates/deployment_telemetry.yaml
+++ b/charts/retool/templates/deployment_telemetry.yaml
@@ -52,7 +52,7 @@ spec:
             value: "/host/proc"
           - name: SYSFS_ROOT
             value: "/host/sys"
-          {{- if (include "shouldIncludeConfigSecretsEnvVars" .) }}
+          {{- if include "shouldIncludeConfigSecretsEnvVars" . }}
           - name: LICENSE_KEY
             valueFrom:
               secretKeyRef:

--- a/charts/retool/templates/deployment_workflows.yaml
+++ b/charts/retool/templates/deployment_workflows.yaml
@@ -141,7 +141,7 @@ spec:
           - name: CODE_EXECUTOR_INGRESS_DOMAIN
             value: http://{{ template "retool.codeExecutor.name" . }}
           {{- end }}
-          {{- if (include "shouldIncludeConfigSecretsEnvVars" .) }}
+          {{- if include "shouldIncludeConfigSecretsEnvVars" . }}
           - name: LICENSE_KEY
             valueFrom:
               secretKeyRef:

--- a/charts/retool/templates/deployment_workflows_worker.yaml
+++ b/charts/retool/templates/deployment_workflows_worker.yaml
@@ -150,7 +150,7 @@ spec:
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: "http://$(HOST_IP):4317"
           {{- end }}
-          {{- if (include "shouldIncludeConfigSecretsEnvVars" .) }}
+          {{- if include "shouldIncludeConfigSecretsEnvVars" . }}
           - name: LICENSE_KEY
             valueFrom:
               secretKeyRef:

--- a/charts/retool/templates/secret.yaml
+++ b/charts/retool/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if (include "shouldIncludeConfigSecretsEnvVars" .) }}
+{{- if include "shouldIncludeConfigSecretsEnvVars" . }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
need string output for this to work ._. (was previously always evaluating to 'true' since it was a non-empty string)

tested it this time with all combinations of inputs :')