### PR TITLE
[fix] Only create pdb for code executor if it's enabled

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.3.4
+version: 6.3.5
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/deployment_code_executor.yaml
+++ b/charts/retool/templates/deployment_code_executor.yaml
@@ -144,7 +144,6 @@ spec:
     port: 80
     targetPort: 3004
     name: http-server
-{{- end }}
 ---
 {{- if .Values.podDisruptionBudget }}
 {{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.Version -}}
@@ -160,4 +159,5 @@ spec:
   selector:
     matchLabels:
   {{- include "retool.codeExecutor.selectorLabels" . | nindent 6 }}
+---
 {{- end }}

--- a/charts/retool/templates/deployment_code_executor.yaml
+++ b/charts/retool/templates/deployment_code_executor.yaml
@@ -159,5 +159,6 @@ spec:
   selector:
     matchLabels:
   {{- include "retool.codeExecutor.selectorLabels" . | nindent 6 }}
+{{- end }}
 ---
 {{- end }}


### PR DESCRIPTION
tested by running a new helm upgrade on a onprem-instance!

without code executor enabled: 
<img width="670" alt="image" src="https://github.com/user-attachments/assets/7fec7c32-b07f-4283-a897-4e71271398ee" />
