### PR TITLE
[fix] Reference global values when grabbing multiplayer name in ingress

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.3.6
+version: 6.3.7
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/ingress.yaml
+++ b/charts/retool/templates/ingress.yaml
@@ -39,7 +39,7 @@ spec:
             {{- end }}
             backend:
               service:
-                name: {{ template "retool.multiplayer.name" . }}
+                name: {{ template "retool.multiplayer.name" $ }}
                 port:
                   number: {{ .port }}
           {{- end }}
@@ -75,7 +75,7 @@ spec:
             {{- end }}
             backend:
               service:
-                name: {{ template "retool.multiplayer.name" . }}
+                name: {{ template "retool.multiplayer.name" $ }}
                 port:
                   number: {{ .port }}
           {{- end }}


### PR DESCRIPTION
Tested this internally (msh test cluster), since this template reference is in a loop, we need to point it at $ instead of ., which points at the wrong context here.