### PR TITLE
docs: multiplayer env variable correction

### DIFF
--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -452,8 +452,7 @@ multiplayer:
 
   # Set environment variables for multiplayer pods, e.g. defining which origin to use
   # environmentVariables:
-  #   - name: MAIN_DOMAIN
-  #     value: retool.foo.com
+  #   MAIN_DOMAIN: "retool.foo.com"
 
   # Annotations for multiplayer pods
   annotations: {}


### PR DESCRIPTION
As discussed in the issue #199, I found an error to add the environment variable as it was written ;-)

In fact, the environmentVariables map wasn't correct set