### PR TITLE
feat(serviceaccount): add automountToken capabilities

### DIFF
--- a/charts/retool/templates/serviceaccount.yaml
+++ b/charts/retool/templates/serviceaccount.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.serviceAccount.automountToken }}
 metadata:
   name: {{ include "retool.serviceAccountName" . }}
   labels: {{- include "retool.labels" . | nindent 4 }}

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -205,6 +205,7 @@ serviceAccount:
   # If set and create is false, the service account must be existing
   name:
   annotations: {}
+  automountToken: false
 
 livenessProbe:
   enabled: true

--- a/values.yaml
+++ b/values.yaml
@@ -205,6 +205,7 @@ serviceAccount:
   # If set and create is false, the service account must be existing
   name:
   annotations: {}
+  automountToken: false
 
 livenessProbe:
   enabled: true


### PR DESCRIPTION
As outlined in #217, we require this configuration to be able to attach an IRSA to the retool agent in our self-hosted retool instance on Amazon EKS.