### PR TITLE
Allow configuring labels, annotations,  and ports for the multiplayer Service

### DIFF
--- a/charts/retool/templates/deployment_multiplayer_ws.yaml
+++ b/charts/retool/templates/deployment_multiplayer_ws.yaml
@@ -3,14 +3,37 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "retool.multiplayer.name" . }}
+  labels:
+    {{- include "retool.labels" . | nindent 4 }}
+  {{- if .Values.service.labels }}
+  {{- range $key, $value := .Values.service.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.multiplayer.service.annotations }}
+  {{- with .Values.multiplayer.service.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+  {{- end }}
 spec:
   selector:
     retoolService: {{ template "retool.multiplayer.name" . }}
   ports:
   - name: http-server
     protocol: TCP
+    {{- if .Values.multiplayer.service.externalPort }}
+    port: {{ .Values.service.externalPort }}
+    {{- else }}
     port: 80
+    {{- end }}
+    {{- if .Values.multiplayer.service.internalPort }}
+    targetPort: {{ .Values.service.internalPort }}
+    {{- else }}
     targetPort: 3001
+    {{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/values.yaml
+++ b/values.yaml
@@ -520,6 +520,12 @@ multiplayer:
       - path: /api/multiplayer
         port: 80
 
+  service:
+    externalPort: 80
+    internalPort: 3001
+    annotations: {}
+    labels: {}
+
 codeExecutor:
   # enabled by default from Chart version 6.0.15 and Retool image 3.20.15 onwards
   # explicitly set other fields as needed


### PR DESCRIPTION
The main use for this is that in our implementation, the multiplayer Service is exposed as a Network Endpoint Group in Google Cloud. This requires adding a particular `annotation` to the Service. So I am using the following Service definition, managed outside of the Helm chart:
```yaml
apiVersion: v1
kind: Service
metadata:
  name: my-retool-multiplayer-ws
  annotations:
    cloud.google.com/neg: '{"exposed_ports": {"3001": {"name": "retool-multiplayer-neg"}}}'
spec:
  type: ClusterIP
  ports:
    - port: 3001
      targetPort: 3001
      protocol: TCP
      name: http
  selector:
    retoolService: retool-multiplayer-ws
```
(Our setup is roughly along the lines of [this guide](https://cloud.google.com/kubernetes-engine/docs/how-to/standalone-neg).)

It'd be amazing if this pattern could be supported through the Helm chart directly. It is already supported for the backend Service, simply by setting this in `values.yaml`:
```yaml
service:
  type: ClusterIP
  externalPort: 3000
  internalPort: 3000
  annotations:
    cloud.google.com/neg: '{"exposed_ports": {"3000": {"name": "retool-backend-neg"}}}'
  labels: {}
  selector: {}
```

I am not a Kubernetes expert, and haven't messed with Helm charts before. So it's quite likely something needs adjusting. Also, this code is untested as of writing. Feel free to push changes to this branch.