### PR TITLE
Remove hostPath volumes from telemetry deployment

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.4.3
+version: 6.4.4
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/ci/kubeconform/telemetry-enabled-full-values.yaml
+++ b/charts/retool/ci/kubeconform/telemetry-enabled-full-values.yaml
@@ -75,14 +75,6 @@ telemetry:
     foo.com/bar: baz
   extraPodSpec:
     hostname: bleepbloop
-  extraVolumes:
-    - name: varlog
-      hostPath:
-        path: "/var/log"
-  extraVolumeMounts:
-    - name: varlog
-      mountPath: "/hostvarlog"
-      readOnly: true
   extraPorts:
     - containerPort: 9999
       name: yaaaaa

--- a/charts/retool/templates/deployment_telemetry.yaml
+++ b/charts/retool/templates/deployment_telemetry.yaml
@@ -48,10 +48,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: PROCFS_ROOT
-            value: "/host/proc"
-          - name: SYSFS_ROOT
-            value: "/host/sys"
           {{- if include "shouldIncludeConfigSecretsEnvVars" . }}
           - name: LICENSE_KEY
             valueFrom:
@@ -110,18 +106,6 @@ spec:
             subPath: "grafana-agent-custom.river"
             readOnly: true
           {{- end }}
-          - name: var-log
-            mountPath: "/var/log/"
-            readOnly: true
-          - name: var-lib
-            mountPath: "/var/lib"
-            readOnly: true
-          - name: procfs
-            mountPath: "/host/proc"
-            readOnly: true
-          - name: sysfs
-            mountPath: "/host/sys"
-            readOnly: true
           {{- if .Values.telemetry.extraVolumeMounts }}
           {{- .Values.telemetry.extraVolumeMounts | toYaml | nindent 10 }}
           {{- end }}
@@ -147,18 +131,6 @@ spec:
           configMap:
             name: {{ include "retool.fullname" . }}-telemetry
         {{- end }}
-        - name: var-log
-          hostPath:
-            path: "/var/log/"
-        - name: var-lib
-          hostPath:
-            path: "/var/lib/"
-        - name: procfs
-          hostPath:
-            path: "/proc"
-        - name: sysfs
-          hostPath:
-            path: "/sys"
         {{- if .Values.telemetry.extraVolumes }}
         {{- .Values.telemetry.extraVolumes | toYaml | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
The telemetry pod no longer requires the four `hostPath` volumes `/var/lib`, `/var/log`, `/proc`, and `/sys`, due to the way it now collects logs and metrics (through the Kubernetes API and Prometheus, respectively).