### PR TITLE
[fix] Java dbconnector support when standalone dbconnector is enabled

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.4.6
+version: 6.4.7
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -105,7 +105,6 @@ spec:
           - name: DISABLE_JAVA_DBCONNECTOR
             value: "true"
           {{ end }}
-          {{ end }}
           - name: CLIENT_ID
             value: {{ default "" .Values.config.auth.google.clientId }}
           - name: COOKIE_INSECURE

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -85,7 +85,7 @@ spec:
           {{- if and ( not ( include "retool_version_with_java_dbconnector_opt_out" . ) ) ( $.Values.dbconnector.java.enabled ) }}
             {{- $serviceType = append $serviceType "JAVA_DBCONNECTOR" }}
           {{- end }}
-          {{- /* 
+          {{- /*
             The dbconnector.enabled setting is to enable a standalone dbconnector deployment.
             If it is not enabled (default), the main backend acts as its own dbconnector.
           */ -}}
@@ -105,6 +105,7 @@ spec:
           - name: DISABLE_JAVA_DBCONNECTOR
             value: "true"
           {{ end }}
+          {{ end }}
           - name: CLIENT_ID
             value: {{ default "" .Values.config.auth.google.clientId }}
           - name: COOKIE_INSECURE
@@ -123,7 +124,13 @@ spec:
           - name: DB_CONNECTOR_HOST
             value: http://{{ template "retool.fullname" . }}-dbconnector
           - name: DB_CONNECTOR_PORT
-            value: {{ .Values.dbconnector.port | quote }}
+            value: {{ $.Values.dbconnector.port | quote }}
+          {{- if $.Values.dbconnector.java.enabled }}
+          - name: JAVA_DBCONNECTOR_HOST
+            value: http://{{ template "retool.fullname" . }}-dbconnector
+          - name: JAVA_DBCONNECTOR_PORT
+            value: {{ $.Values.dbconnector.java.port | quote }}
+          {{- end }}
           {{- end }}
           {{- if .Values.config.dbConnectorTimeout }}
           - name: DBCONNECTOR_QUERY_TIMEOUT_MS

--- a/charts/retool/templates/deployment_dbconnector.yaml
+++ b/charts/retool/templates/deployment_dbconnector.yaml
@@ -31,7 +31,7 @@ spec:
         {{- include "retool.labels" . | nindent 8 }}
     spec:
       {{- if .Values.dbconnector.terminationGracePeriodSeconds }}
-      terminationGracePeriodSeconds: {{ .Values.dbconnector.terminationGracePeriodSeconds }} 
+      terminationGracePeriodSeconds: {{ .Values.dbconnector.terminationGracePeriodSeconds }}
       {{- end }}
       containers:
       - args:
@@ -267,4 +267,10 @@ spec:
     name: http-server
     port: {{ .Values.dbconnector.port }}
     targetPort: {{ .Values.dbconnector.port }}
+  {{ if .Values.dbconnector.java.enabled }}
+  - protocol: TCP
+    name: java-dbconnector-server
+    port: {{ .Values.dbconnector.java.port }}
+    targetPort: {{ .Values.dbconnector.java.port }}
+  {{ end }}
 {{- end }}

--- a/charts/retool/templates/deployment_workflows.yaml
+++ b/charts/retool/templates/deployment_workflows.yaml
@@ -74,7 +74,7 @@ spec:
           {{- if and ( not ( include "retool_version_with_java_dbconnector_opt_out" . ) ) ( $.Values.dbconnector.java.enabled ) }}
             {{- $serviceType = append $serviceType "JAVA_DBCONNECTOR" }}
           {{- end }}
-          {{- /* 
+          {{- /*
             The dbconnector.enabled setting is to enable a standalone dbconnector deployment.
             If it is not enabled (default), the main backend acts as its own dbconnector.
           */ -}}
@@ -87,7 +87,13 @@ spec:
           - name: DB_CONNECTOR_HOST
             value: http://{{ template "retool.fullname" . }}-dbconnector
           - name: DB_CONNECTOR_PORT
-            value: {{ .Values.dbconnector.port | quote }}
+            value: {{ $.Values.dbconnector.port | quote }}
+          {{- if $.Values.dbconnector.java.enabled }}
+          - name: JAVA_DBCONNECTOR_HOST
+            value: http://{{ template "retool.fullname" . }}-dbconnector
+          - name: JAVA_DBCONNECTOR_PORT
+            value: {{ $.Values.dbconnector.java.port | quote }}
+          {{- end }}
           {{- end }}
           {{ if and ( include "retool_version_with_java_dbconnector_opt_out" . ) ( not $.Values.dbconnector.java.enabled ) }}
           - name: DISABLE_JAVA_DBCONNECTOR

--- a/charts/retool/templates/deployment_workflows_worker.yaml
+++ b/charts/retool/templates/deployment_workflows_worker.yaml
@@ -82,7 +82,13 @@ spec:
           - name: DB_CONNECTOR_HOST
             value: http://{{ template "retool.fullname" . }}-dbconnector
           - name: DB_CONNECTOR_PORT
-            value: {{ .Values.dbconnector.port | quote }}
+            value: {{ $.Values.dbconnector.port | quote }}
+          {{- if $.Values.dbconnector.java.enabled }}
+          - name: JAVA_DBCONNECTOR_HOST
+            value: http://{{ template "retool.fullname" . }}-dbconnector
+          - name: JAVA_DBCONNECTOR_PORT
+            value: {{ $.Values.dbconnector.java.port | quote }}
+          {{- end }}
           {{ end }}
           - name: DBCONNECTOR_QUERY_TIMEOUT_MS
           {{- if .Values.workflows.dbConnectorTimeout }}

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -454,6 +454,7 @@ dbconnector:
     # Disable this to disable Retool's Java dbconnector. Applies whether
     # dbconnector.enabled is true or false.
     enabled: true
+    port: 3007
 
   # Desired pod count for dbconnector deployment.
   replicas: 1

--- a/values.yaml
+++ b/values.yaml
@@ -454,6 +454,7 @@ dbconnector:
     # Disable this to disable Retool's Java dbconnector. Applies whether
     # dbconnector.enabled is true or false.
     enabled: true
+    port: 3007
 
   # Desired pod count for dbconnector deployment.
   replicas: 1


### PR DESCRIPTION
Currently, it's not possible to expose the Java dbconnector with the standalone dbconnector; this was an oversight when we merged that change.