### PR TITLE
Fix: Make retoolService selector consistent in multiplayer_ws deployment

### DIFF
--- a/charts/retool/templates/deployment_multiplayer_ws.yaml
+++ b/charts/retool/templates/deployment_multiplayer_ws.yaml
@@ -26,7 +26,7 @@ spec:
   replicas: {{ .Values.multiplayer.replicaCount }}
   selector:
     matchLabels:
-      retoolService: {{ include "retool.name" . }}-multiplayer-ws
+      retoolService: {{ template "retool.multiplayer.name" . }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   template:
     metadata:
@@ -38,7 +38,7 @@ spec:
 {{ toYaml .Values.multiplayer.annotations | indent 8 }}
 {{- end }}
       labels:
-        retoolService: {{ include "retool.name" . }}-multiplayer-ws
+        retoolService: {{ template "retool.multiplayer.name" . }}
 {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8 }}
 {{- end }}


### PR DESCRIPTION
When fullnameOverride is set, the Service and Deployment selectors for multiplayer-ws become inconsistent, causing the Service to not properly target the Deployment pods.

This change ensures both use the same template "retool.multiplayer.name", making them consistent regardless of configuration values.