### PR TITLE
Fix: Change external-secrets api version

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.4.11
+version: 6.4.12
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/externalsecret.yaml
+++ b/charts/retool/templates/externalsecret.yaml
@@ -15,7 +15,11 @@ spec:
     - {{ .path }}
 ---
 {{- else }}
+{{- if $.Capabilities.APIVersions.Has "external-secrets.io/v1" }}
+apiVersion: external-secrets.io/v1
+{{- else }}
 apiVersion: external-secrets.io/v1beta1
+{{- end }}
 kind: ExternalSecret
 metadata:
   annotations:


### PR DESCRIPTION
Fixes "The Kubernetes API could not find version "v1beta1" of external-secrets.io/ExternalSecret for requested resource retool-dev/vault-external-secrets. Version "v1" of external-secrets.io/ExternalSecret is installed on the destination cluster."