### PR TITLE
Expose more ExternalSecret options

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.4.10
+version: 6.4.11
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/ci/test-eso-secretref-option.yaml
+++ b/charts/retool/ci/test-eso-secretref-option.yaml
@@ -10,5 +10,13 @@ externalSecrets:
       name: retool
       kind: SecretStore
     secretRef:
+      # secret with just name and path
       - name: retool-config
         path: mysecret
+      # secrets with lifecycle options
+      - name: retool-config-creation-policy
+        path: mysecret-creation-policy
+        creationPolicy: Merge
+      - name: retool-config-deletion-policy
+        path: mysecret-deletion-policy
+        deletionPolicy: Merge

--- a/charts/retool/ci/test-eso-secretref-option.yaml
+++ b/charts/retool/ci/test-eso-secretref-option.yaml
@@ -20,3 +20,7 @@ externalSecrets:
       - name: retool-config-deletion-policy
         path: mysecret-deletion-policy
         deletionPolicy: Merge
+      # secrets that don't have to exist
+      - name: retool-config-maybe
+        path: mysecret-maybe
+        optional: true

--- a/charts/retool/ci/test-install-values.yaml
+++ b/charts/retool/ci/test-install-values.yaml
@@ -52,7 +52,9 @@ image:
 commandline:
   args: []
 
-env: {}
+env:
+  # required env var for backend to start up, but not actually registered
+  BASE_DOMAIN: "https://helm-ci.retool.dev"
 
 # Optionally specify additional environment variables to be populated from Kubernetes secrets.
 # Useful for passing in SCIM_AUTH_TOKEN or other secret environment variables from Kubernetes secrets.

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -267,6 +267,7 @@ spec:
         {{- range .Values.externalSecrets.externalSecretsOperator.secretRef }}
         - secretRef:
             name: {{ .name }}
+            optional: {{ .optional | default false}}
         {{- end }}
         {{- end }}
         ports:

--- a/charts/retool/templates/externalsecret.yaml
+++ b/charts/retool/templates/externalsecret.yaml
@@ -29,11 +29,13 @@ spec:
     name: {{ $.Values.externalSecrets.externalSecretsOperator.secretStoreRef.name }}
     kind: {{ $.Values.externalSecrets.externalSecretsOperator.secretStoreRef.kind }}
   target:
-    name: {{ .name }}
-    creationPolicy: Owner
+    name: {{ .name | quote }}
+    # reference: https://external-secrets.io/main/guides/ownership-deletion-policy/
+    creationPolicy: {{ .creationPolicy | default "Owner" | quote }}
+    deletionPolicy: {{ .deletionPolicy | default "Retain" | quote }}
   dataFrom:
     - extract:
-        key: {{ .path }}
+        key: {{ .path | quote }}
 ---
 {{- end }}
 {{- end }}

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -117,13 +117,25 @@ externalSecrets:
       name: aws-secretsmanager
       kind: SecretStore  # or ClusterSecretStore
 
-    # Array of name/path key/value pairs to use for the External Secrets Objects.
-    secretRef:
-      []
-      # - name: retool-config
-      #   path: global-retool-config
-      # - name: retool-db
-      #   path: global-retool-db-config
+    # Array of options to use for the ExternalSecret objects and their
+    # corresponding secretRef in pod envFrom.
+    #
+    # Example with only required fields:
+    #
+    #   secretRef:
+    #     - name: retool-config
+    #       path: global-retool-config
+    #
+    # Example with all optional fields:
+    #
+    #   secretRef
+    #     - name: extra-secrets
+    #       path: global-extra-secrets
+    #       creationPolicy: Owner
+    #       deletionPolicy: Retain
+    #       optional: true
+    #
+    secretRef: []
 
     # When true, uses kubernetes-client CRDs and not external-secrets CRDs
     # Defaults to true

--- a/values.yaml
+++ b/values.yaml
@@ -117,13 +117,25 @@ externalSecrets:
       name: aws-secretsmanager
       kind: SecretStore  # or ClusterSecretStore
 
-    # Array of name/path key/value pairs to use for the External Secrets Objects.
-    secretRef:
-      []
-      # - name: retool-config
-      #   path: global-retool-config
-      # - name: retool-db
-      #   path: global-retool-db-config
+    # Array of options to use for the ExternalSecret objects and their
+    # corresponding secretRef in pod envFrom.
+    #
+    # Example with only required fields:
+    #
+    #   secretRef:
+    #     - name: retool-config
+    #       path: global-retool-config
+    #
+    # Example with all optional fields:
+    #
+    #   secretRef
+    #     - name: extra-secrets
+    #       path: global-extra-secrets
+    #       creationPolicy: Owner
+    #       deletionPolicy: Retain
+    #       optional: true
+    #
+    secretRef: []
 
     # When true, uses kubernetes-client CRDs and not external-secrets CRDs
     # Defaults to true


### PR DESCRIPTION
Make all of the following possible 
* change the creationPolicy for an ExternalSecret
* change the deletionPolicy for an ExternalSecret
* mark the `secretRef` that uses an ExternalSecret itself optional, s.t. the pod is still allowed to start if that secret fails to sync or gets deleted