### PR TITLE
increase jobs runner default priority

### DIFF
--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -46,7 +46,9 @@ spec:
     spec:
       serviceAccountName: {{ template "retool.serviceAccountName" . }}
       {{- if .Values.priorityClassName }}
-      priorityClassName: "{{ .Values.priorityClassName }}"
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- else }}
+      priorityClassName: {{ printf "%s-backend-priority" (include "retool.fullname" .) | quote }}
       {{- end }}
       {{- with .Values.hostAliases }}
       hostAliases:

--- a/charts/retool/templates/deployment_jobs.yaml
+++ b/charts/retool/templates/deployment_jobs.yaml
@@ -45,7 +45,9 @@ spec:
     spec:
       serviceAccountName: {{ template "retool.serviceAccountName" . }}
       {{- if .Values.priorityClassName }}
-      priorityClassName: "{{ .Values.priorityClassName }}"
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- else }}
+      priorityClassName: {{ printf "%s-jobs-runner-priority" (include "retool.fullname" .) | quote }}
       {{- end }}
 {{- if .Values.initContainers }}
       initContainers:

--- a/charts/retool/templates/priorityclass.yaml
+++ b/charts/retool/templates/priorityclass.yaml
@@ -1,0 +1,23 @@
+{{- if not .Values.priorityClassName }}
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{ include "retool.fullname" . }}-jobs-runner-priority
+  labels:
+    {{- include "retool.labels" . | nindent 4 }}
+value: 20
+preemptionPolicy: Never
+globalDefault: false
+description: "PriorityClass for Retool jobs runner pods"
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{ include "retool.fullname" . }}-backend-priority
+  labels:
+    {{- include "retool.labels" . | nindent 4 }}
+value: 10
+preemptionPolicy: Never
+globalDefault: false
+description: "PriorityClass for Retool backend pods"
+{{- end }}


### PR DESCRIPTION
Adding two new default (higher) priority classes to the backend and jobs-runners pods, in order to eliminate crash loops during upgrades due to un-ran jobs (namely db migrations).

Currently, this change will only be applied when the global “priorityClassName” is not set. If it is, these default values will be overridden. In the future, it might be useful to create per-pod PriorityClass overrides in order to enable similar behavior, while still allowing a global priorityClassName.