### PR TITLE
remove agents-preview note

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.6.0
+version: 6.6.1
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -568,7 +568,6 @@ codeExecutor:
 
 agents:
   # Enable AI Agents
-  # NOTE: at present, agents may only be used in combination with the `agents-preview` image tag
   enabled: false
 
   # Labels for agent worker pods

--- a/values.yaml
+++ b/values.yaml
@@ -568,7 +568,6 @@ codeExecutor:
 
 agents:
   # Enable AI Agents
-  # NOTE: at present, agents may only be used in combination with the `agents-preview` image tag
   enabled: false
 
   # Labels for agent worker pods


### PR DESCRIPTION
removing the agents-preview note, since it is now possible to enable agents via the edge release.