### PR TITLE
Fix so CODE_EXECUTOR_INGRESS_DOMAIN is only added if workflows are en…

### DIFF
--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -151,6 +151,8 @@ spec:
           {{- if include "retool.workflows.enabled" . }}
           - name: WORKFLOW_BACKEND_HOST
             value: http://{{ template "retool.fullname" . }}-workflow-backend
+          - name: CODE_EXECUTOR_INGRESS_DOMAIN
+            value: http://{{ template "retool.codeExecutor.name" . }}
           {{- end }}
           {{- if ($temporalConfig).sslEnabled }}
           - name: WORKFLOW_TEMPORAL_TLS_ENABLED
@@ -170,8 +172,6 @@ spec:
               {{- end }}
           {{- end }}
           {{- end }}
-          - name: CODE_EXECUTOR_INGRESS_DOMAIN
-            value: http://{{ template "retool.codeExecutor.name" . }}
 
           {{- include "retool.telemetry.includeEnvVars" . | nindent 10 }}
 


### PR DESCRIPTION
## Short description of the problem

When `workflows.enabled` is set to `false`, the code executor will not be deployed. The `CODE_EXECUTOR_INGRESS_DOMAIN` environment variable will still be added to backend deployment and prevent it from starting as the backend would try to connect to the executor during start up.

You see the following error messages during boot:

```
Code executor is configured via CODE_EXECUTOR_INGRESS_DOMAIN but not available.
Could not detect healthy Code Executor. To ignore failures of this check on startup, set IGNORE_CODE_EXECUTOR_STARTUP_CHECK=true.
```

You can see the problem on the current main branch by running:

```bash
helm template \
    --set config.encryptionKey=key \
    --set image.tag=3.148.26-stable \
    --set workflows.enabled=false \
    -n retool retool charts/retool | less
```

In the output you can see that `CODE_EXECUTOR_INGRESS_DOMAIN` is set for the retool backend deployment, but there is no `retool-code-executor` service.

## Solution

With this change, the `CODE_EXECUTOR_INGRESS_DOMAIN` environment variable will only be added to the backend deployment if workflows are enabled