### PR TITLE
Add db-ssh-connector config to workflows-backend to match main-backend

### DIFF
--- a/charts/retool/templates/deployment_workflows.yaml
+++ b/charts/retool/templates/deployment_workflows.yaml
@@ -88,6 +88,10 @@ spec:
             value: http://{{ template "retool.fullname" . }}-dbconnector
           - name: DB_CONNECTOR_PORT
             value: {{ $.Values.dbconnector.port | quote }}
+          - name: DB_SSH_CONNECTOR_HOST
+            value: http://{{ template "retool.fullname" . }}-dbconnector
+          - name: DB_SSH_CONNECTOR_PORT
+            value: {{ .Values.dbconnector.port | quote }}
           {{- if $.Values.dbconnector.java.enabled }}
           - name: JAVA_DBCONNECTOR_HOST
             value: http://{{ template "retool.fullname" . }}-dbconnector


### PR DESCRIPTION
More context in [this thread](https://retool.slack.com/archives/C03UM938TA4/p1756916238517879). When run in standalone mode, queries from resources configured for SSH tunnels in workflows aren't reaching the `db-connector` pod. Looks like it's due to not having `DB_SSH_CONNECTOR_HOST` set in `workflows-backend` like we do for the `main-backend`.