### PR TITLE
Leave code-executor environment variable unset if workflows disabled

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.8.1
+version: 6.8.2
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -155,6 +155,8 @@ spec:
           {{- if include "retool.workflows.enabled" . }}
           - name: WORKFLOW_BACKEND_HOST
             value: http://{{ template "retool.fullname" . }}-workflow-backend
+          - name: CODE_EXECUTOR_INGRESS_DOMAIN
+            value: http://{{ template "retool.codeExecutor.name" . }}
           {{- end }}
           {{- if ($temporalConfig).sslEnabled }}
           - name: WORKFLOW_TEMPORAL_TLS_ENABLED
@@ -174,8 +176,6 @@ spec:
               {{- end }}
           {{- end }}
           {{- end }}
-          - name: CODE_EXECUTOR_INGRESS_DOMAIN
-            value: http://{{ template "retool.codeExecutor.name" . }}
 
           {{- include "retool.telemetry.includeEnvVars" . | nindent 10 }}
 


### PR DESCRIPTION
For various reasons, the main backend now errors out if there's an issue reaching `code-executor` while Workflows is enabled. However, the environment variable that points the backend to `code-executor` is set independent of the `workflows.enabled` setting in the Helm chart, which leads to non-Workflow instances incorrectly crashing.

The other deployments that reference the env var are fine since they don't spin up in the first place when Workflows is disabled.