### PR TITLE
Fix Java db-connector env vars when run in standalone mode

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.8.2
+version: 6.8.3
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/_workers.tpl
+++ b/charts/retool/templates/_workers.tpl
@@ -123,9 +123,9 @@ spec:
           - name: DB_CONNECTOR_PORT
             value: {{ $.Values.dbconnector.port | quote }}
           {{- if $.Values.dbconnector.java.enabled }}
-          - name: JAVA_DBCONNECTOR_HOST
+          - name: JAVA_DB_CONNECTOR_HOST
             value: http://{{ template "retool.fullname" $ }}-dbconnector
-          - name: JAVA_DBCONNECTOR_PORT
+          - name: JAVA_DB_CONNECTOR_PORT
             value: {{ $.Values.dbconnector.java.port | quote }}
           {{- end }}
           {{- end }}

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -129,9 +129,9 @@ spec:
           - name: DB_SSH_CONNECTOR_PORT
             value: {{ .Values.dbconnector.port | quote }}
           {{- if $.Values.dbconnector.java.enabled }}
-          - name: JAVA_DBCONNECTOR_HOST
+          - name: JAVA_DB_CONNECTOR_HOST
             value: http://{{ template "retool.fullname" . }}-dbconnector
-          - name: JAVA_DBCONNECTOR_PORT
+          - name: JAVA_DB_CONNECTOR_PORT
             value: {{ $.Values.dbconnector.java.port | quote }}
           {{- end }}
           {{- end }}

--- a/charts/retool/templates/deployment_workflows.yaml
+++ b/charts/retool/templates/deployment_workflows.yaml
@@ -93,9 +93,9 @@ spec:
           - name: DB_SSH_CONNECTOR_PORT
             value: {{ .Values.dbconnector.port | quote }}
           {{- if $.Values.dbconnector.java.enabled }}
-          - name: JAVA_DBCONNECTOR_HOST
+          - name: JAVA_DB_CONNECTOR_HOST
             value: http://{{ template "retool.fullname" . }}-dbconnector
-          - name: JAVA_DBCONNECTOR_PORT
+          - name: JAVA_DB_CONNECTOR_PORT
             value: {{ $.Values.dbconnector.java.port | quote }}
           {{- end }}
           {{- end }}


### PR DESCRIPTION
Fixing `JAVA_DBCONNECTOR_HOST/PORT` -> `JAVA_DB_CONNECTOR_HOST/PORT` when run in standalone mode