### PR TITLE
Only use `semverCompare` with valid version strings

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.10.1
+version: 6.10.2
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -251,7 +251,8 @@ Usage: (include "retool.workflows.enabled" .)
 {{- define "retool.workflows.enabled" -}}
 {{- $output := "" -}}
 {{- $valid_retool_version_regexp := "([0-9]+\\.[0-9]+(\\.[0-9]+)?(-[a-zA-Z0-9]+)?)" }}
-{{- $retool_version_with_workflows := ( and ( regexMatch $valid_retool_version_regexp $.Values.image.tag ) ( semverCompare ">= 3.6.11-0" ( regexFind $valid_retool_version_regexp $.Values.image.tag ) ) ) }}
+{{- $semver_version_regexp := "[0-9]+\\.[0-9]+(\\.[0-9]+)?" }}
+{{- $retool_version_with_workflows := ( and ( regexMatch $valid_retool_version_regexp $.Values.image.tag ) ( semverCompare ">= 3.6.11-0" ( regexFind $semver_version_regexp $.Values.image.tag ) ) ) }}
 {{- if or
     (eq (toString .Values.workflows.enabled) "true")
     (eq (toString .Values.workflows.enabled) "false")
@@ -385,7 +386,8 @@ Usage: (template "retool.codeExecutor.image.tag" .)
 {{- define "retool.codeExecutor.image.tag" -}}
 {{- if .Values.image.tag -}}
   {{- $valid_retool_version_regexp := "([0-9]+\\.[0-9]+(\\.[0-9]+)?(-[a-zA-Z0-9]+)?)" }}
-  {{- $retool_version_with_ce := ( and ( regexMatch $valid_retool_version_regexp $.Values.image.tag ) ( semverCompare ">= 3.20.15-0" ( regexFind $valid_retool_version_regexp $.Values.image.tag ) ) ) }}
+  {{- $semver_version_regexp := "[0-9]+\\.[0-9]+(\\.[0-9]+)?" }}
+  {{- $retool_version_with_ce := ( and ( regexMatch $valid_retool_version_regexp $.Values.image.tag ) ( semverCompare ">= 3.20.15-0" ( regexFind $semver_version_regexp $.Values.image.tag ) ) ) }}
   {{- if $retool_version_with_ce -}}
     {{- .Values.image.tag -}}
   {{- else -}}
@@ -399,9 +401,10 @@ Usage: (template "retool.codeExecutor.image.tag" .)
 {{- define "retool_version_with_java_dbconnector_opt_out" -}}
 {{- $output := "" -}}
 {{- $valid_retool_version_regexp := "([0-9]+\\.[0-9]+(\\.[0-9]+)?(-[a-zA-Z0-9]+)?)" }}
+{{- $semver_version_regexp := "[0-9]+\\.[0-9]+(\\.[0-9]+)?" }}
 {{- if not ( regexMatch $valid_retool_version_regexp .Values.image.tag ) -}}
   {{- $output = "1" -}}
-{{- else if semverCompare ">= 3.93.0-0" ( regexFind $valid_retool_version_regexp .Values.image.tag ) -}}
+{{- else if semverCompare ">= 3.93.0-0" ( regexFind $semver_version_regexp .Values.image.tag ) -}}
   {{- $output = "1" -}}
 {{- else -}}
   {{- $output = "" -}}

--- a/charts/retool/templates/deployment_jobs.yaml
+++ b/charts/retool/templates/deployment_jobs.yaml
@@ -190,7 +190,8 @@ spec:
 {{ toYaml .Values.resources | indent 10 }}
 {{- end }}
         {{- if regexMatch "^([0-9]+)\\.([0-9]+)\\.([0-9]+)" .Values.image.tag }}
-        {{- if semverCompare ">=2.110.0-0" .Values.image.tag }}
+        {{- $semver_version_regexp := "[0-9]+\\.[0-9]+(\\.[0-9]+)?" }}
+        {{- if semverCompare ">=2.110.0-0" (regexFind $semver_version_regexp .Values.image.tag) }}
         livenessProbe:
           httpGet:
             path: /api/checkJobsRunnerHealth


### PR DESCRIPTION
Handle image tags where the pre-release part of the semver version string contains a leading zero, e.g. `3.284.10-0360315`.

Fix for errors like this:

```
Error: template: retool/templates/deployment_workflows.yaml:1:7: executing "retool/templates/deployment_workflows.yaml" at <include "retool.workflows.enabled" .>: error calling include: template: retool/templates/_helpers.tpl:254:109: executing "retool.workflows.enabled" at <semverCompare ">= 3.6.11-0" (regexFind $valid_retool_version_regexp $.Values.image.tag)>: error calling semverCompare: Version segment starts with 0
```