### PR TITLE
[chore][PLAT-1058] Add support for extraContainers to code-executor deployment

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.10.2
+version: 6.10.3
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/deployment_code_executor.yaml
+++ b/charts/retool/templates/deployment_code_executor.yaml
@@ -61,6 +61,9 @@ spec:
           {{ else }}
           privileged: true
           {{ end }}
+          {{- if .Values.securityContext.extraContainerSecurityContext }}
+{{ toYaml .Values.securityContext.extraContainerSecurityContext | indent 10 }}
+          {{- end }}
         env:
           - name: DEPLOYMENT_TEMPLATE_TYPE
             value: {{ template "retool.deploymentTemplateType" . }}
@@ -116,9 +119,28 @@ spec:
 {{- if .Values.codeExecutor.volumeMounts }}
 {{ toYaml .Values.codeExecutor.volumeMounts | indent 10 }}
 {{- end }}
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 10 }}
+{{- end }}
+{{- range .Values.extraConfigMapMounts }}
+          - name: {{ .name }}
+            mountPath: {{ .mountPath }}
+            subPath: {{ .subPath }}
+{{- end }}
+{{- with .Values.extraContainers }}
+{{ tpl . $ | indent 6 }}
+{{- end }}
       volumes:
 {{- if .Values.codeExecutor.volumes }}
 {{ toYaml .Values.codeExecutor.volumes | indent 8 }}
+{{- end }}
+{{- range .Values.extraConfigMapMounts }}
+        - name: {{ .name }}
+          configMap:
+            name: {{ .configMap }}
+{{- end }}
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 8 }}
 {{- end }}
 {{- if .Values.image.pullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
Test to make sure that existing templates don't completely change:

```bash
# See generated templates without the change
git checkout main
mkdir -p /tmp/before
for f in charts/retool/ci/*.yaml; do
  name=$(basename "$f" .yaml)
  helm template charts/retool -f "$f" > /tmp/before/$name.yaml 2>&1
done

# See generated templates with the change
git checkout jhemphill/helm-extra-sidecar
mkdir -p /tmp/after
for f in charts/retool/ci/*.yaml; do
  name=$(basename "$f" .yaml)
  helm template charts/retool -f "$f" > /tmp/after/$name.yaml 2>&1
done

# Diff to make sure existing templates are unchanged
diff -r /tmp/before /tmp/after
```

<details><summary>Result of diff</summary>

```diff
diff -ur /tmp/before/test-install-values.yaml /tmp/after/test-install-values.yaml
--- /tmp/before/test-install-values.yaml	2026-04-20 13:28:01
+++ /tmp/after/test-install-values.yaml	2026-04-20 13:28:09
@@ -6,7 +6,7 @@
 metadata:
   name: release-name-retool
   labels:
-    helm.sh/chart: retool-6.10.2
+    helm.sh/chart: retool-6.10.3
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: retool/charts/postgresql/templates/secrets.yaml
@@ -32,7 +32,7 @@
 metadata:
   name: release-name-retool
   labels:
-    helm.sh/chart: retool-6.10.2
+    helm.sh/chart: retool-6.10.3
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/resource-policy": no-upgrade-existing
@@ -167,7 +167,7 @@
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: retool-6.10.2
+    helm.sh/chart: retool-6.10.3
     app.kubernetes.io/managed-by: Helm
   name: release-name-retool
 spec:
@@ -187,7 +187,7 @@
 metadata:
   name: release-name-retool
   labels:
-    helm.sh/chart: retool-6.10.2
+    helm.sh/chart: retool-6.10.3
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: retool
     app.kubernetes.io/instance: release-name
@@ -202,7 +202,7 @@
     metadata:
       annotations:
       labels:
-        helm.sh/chart: retool-6.10.2
+        helm.sh/chart: retool-6.10.3
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: retool
         app.kubernetes.io/instance: release-name
@@ -222,7 +222,7 @@
           - name: DEPLOYMENT_TEMPLATE_TYPE
             value: "k8s-helm"
           - name: DEPLOYMENT_TEMPLATE_VERSION
-            value: "6.10.2"
+            value: "6.10.3"
           - name: NODE_ENV
             value: production
           - name: SERVICE_TYPE
@@ -339,7 +339,7 @@
     app.kubernetes.io/name: release-name-retool-code-executor
     app.kubernetes.io/instance: release-name
     telemetry.retool.com/service-name: code-executor
-    helm.sh/chart: retool-6.10.2
+    helm.sh/chart: retool-6.10.3
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -355,7 +355,7 @@
         app.kubernetes.io/name: release-name-retool-code-executor
         app.kubernetes.io/instance: release-name
         telemetry.retool.com/service-name: code-executor
-        helm.sh/chart: retool-6.10.2
+        helm.sh/chart: retool-6.10.3
         app.kubernetes.io/managed-by: Helm
     spec:
       serviceAccountName: release-name-retool
@@ -371,7 +371,7 @@
           - name: DEPLOYMENT_TEMPLATE_TYPE
             value: "k8s-helm"
           - name: DEPLOYMENT_TEMPLATE_VERSION
-            value: "6.10.2"
+            value: "6.10.3"
           - name: NODE_ENV
             value: production
           - name: NODE_OPTIONS
@@ -422,7 +422,7 @@
     app.kubernetes.io/name: release-name-retool-workflow-worker
     app.kubernetes.io/instance: release-name
     telemetry.retool.com/service-name: workflow-worker
-    helm.sh/chart: retool-6.10.2
+    helm.sh/chart: retool-6.10.3
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -441,7 +441,7 @@
         app.kubernetes.io/name: release-name-retool-workflow-worker
         app.kubernetes.io/instance: release-name
         telemetry.retool.com/service-name: workflow-worker
-        helm.sh/chart: retool-6.10.2
+        helm.sh/chart: retool-6.10.3
         app.kubernetes.io/managed-by: Helm
     spec:
       serviceAccountName: release-name-retool
@@ -457,7 +457,7 @@
           - name: DEPLOYMENT_TEMPLATE_TYPE
             value: "k8s-helm"
           - name: DEPLOYMENT_TEMPLATE_VERSION
-            value: "6.10.2"
+            value: "6.10.3"
           - name: NODE_ENV
             value: production
           - name: NODE_OPTIONS
@@ -576,7 +576,7 @@
     app.kubernetes.io/name: release-name-retool-workflow-backend
     app.kubernetes.io/instance: release-name
     telemetry.retool.com/service-name: workflow-backend
-    helm.sh/chart: retool-6.10.2
+    helm.sh/chart: retool-6.10.3
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -592,7 +592,7 @@
         app.kubernetes.io/name: release-name-retool-workflow-backend
         app.kubernetes.io/instance: release-name
         telemetry.retool.com/service-name: workflow-backend
-        helm.sh/chart: retool-6.10.2
+        helm.sh/chart: retool-6.10.3
         app.kubernetes.io/managed-by: Helm
     spec:
       serviceAccountName: release-name-retool
@@ -608,7 +608,7 @@
           - name: DEPLOYMENT_TEMPLATE_TYPE
             value: "k8s-helm"
           - name: DEPLOYMENT_TEMPLATE_VERSION
-            value: "6.10.2"
+            value: "6.10.3"
           - name: NODE_ENV
             value: production
           - name: SERVICE_TYPE
@@ -871,7 +871,7 @@
 kind: Ingress
 metadata:
   labels:
-    helm.sh/chart: retool-6.10.2
+    helm.sh/chart: retool-6.10.3
     app.kubernetes.io/managed-by: Helm
   name: release-name-retool
 spec:
```

</details>