### PR TITLE
allow dynamic value references for env vars

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.10.3
+version: 6.10.4
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/ci/test-env-option.yaml
+++ b/charts/retool/ci/test-env-option.yaml
@@ -1,0 +1,8 @@
+
+env:
+  # test to ensure dynamic env vars render valid schema
+  FOOBAR:
+    valueFrom:
+      secretKeyRef:
+        name: mysecret
+        key: mysecret-key

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -415,6 +415,22 @@ Usage: (template "retool.codeExecutor.image.tag" .)
 {{/*
 Checks whether or not ExternalSecret definitions are enabled and can potentially clobber secrets or explicitly allow additional direct secret refs.
 */}}
+{{/*
+Render env vars from .Values.env, handling both string values and object values (e.g. valueFrom).
+Usage: {{- include "retool.env" .Values.env | nindent 10 }}
+*/}}
+{{- define "retool.env" -}}
+{{- range $key, $value := . }}
+{{- if kindIs "string" $value }}
+- name: "{{ $key }}"
+  value: "{{ $value }}"
+{{- else }}
+- name: "{{ $key }}"
+{{ toYaml $value | indent 2 }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
 {{- define "shouldIncludeConfigSecretsEnvVars" -}}
 {{- $output := "" -}}
 {{- if or (not (or (.Values.externalSecrets.enabled) (.Values.externalSecrets.externalSecretsOperator.enabled))) .Values.externalSecrets.includeConfigSecrets -}}

--- a/charts/retool/templates/_workers.tpl
+++ b/charts/retool/templates/_workers.tpl
@@ -273,10 +273,7 @@ spec:
                 {{- end }}
           {{- end }}
           {{- end }}
-          {{- range $key, $value := $.Values.env }}
-          - name: "{{ $key }}"
-            value: "{{ $value }}"
-          {{- end }}
+          {{- include "retool.env" $.Values.env | nindent 10 }}
           {{- range $.Values.environmentSecrets }}
           - name: {{ .name }}
             valueFrom:

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -247,10 +247,7 @@ spec:
                 {{- end }}
           {{- end }}
           {{- end }}
-          {{- range $key, $value := .Values.env }}
-          - name: "{{ $key }}"
-            value: "{{ $value }}"
-          {{- end }}
+          {{- include "retool.env" .Values.env | nindent 10 }}
           {{- range .Values.environmentSecrets }}
           - name: {{ .name }}
             valueFrom:

--- a/charts/retool/templates/deployment_code_executor.yaml
+++ b/charts/retool/templates/deployment_code_executor.yaml
@@ -76,10 +76,7 @@ spec:
 
           {{- include "retool.telemetry.includeEnvVars" . | nindent 10 }}
 
-          {{- range $key, $value := .Values.env }}
-          - name: "{{ $key }}"
-            value: "{{ $value }}"
-          {{- end }}
+          {{- include "retool.env" .Values.env | nindent 10 }}
           {{- range .Values.environmentSecrets }}
           - name: {{ .name }}
             valueFrom:

--- a/charts/retool/templates/deployment_dbconnector.yaml
+++ b/charts/retool/templates/deployment_dbconnector.yaml
@@ -168,10 +168,7 @@ spec:
                 {{- end }}
           {{- end }}
           {{- end }}
-          {{- range $key, $value := .Values.env }}
-          - name: "{{ $key }}"
-            value: "{{ $value }}"
-          {{- end }}
+          {{- include "retool.env" .Values.env | nindent 10 }}
           {{- range .Values.environmentSecrets }}
           - name: {{ .name }}
             valueFrom:

--- a/charts/retool/templates/deployment_jobs.yaml
+++ b/charts/retool/templates/deployment_jobs.yaml
@@ -152,10 +152,7 @@ spec:
                 {{- end }}
           {{- end }}
           {{- end }}
-          {{- range $key, $value := .Values.env }}
-          - name: "{{ $key }}"
-            value: "{{ $value }}"
-          {{- end }}
+          {{- include "retool.env" .Values.env | nindent 10 }}
           {{- range .Values.environmentSecrets }}
           - name: {{ .name }}
             valueFrom:

--- a/charts/retool/templates/deployment_workflows.yaml
+++ b/charts/retool/templates/deployment_workflows.yaml
@@ -235,10 +235,7 @@ spec:
                 {{- end }}
           {{- end }}
           {{- end }}
-          {{- range $key, $value := .Values.env }}
-          - name: "{{ $key }}"
-            value: "{{ $value }}"
-          {{- end }}
+          {{- include "retool.env" .Values.env | nindent 10 }}
           {{- range .Values.environmentSecrets }}
           - name: {{ .name }}
             valueFrom:


### PR DESCRIPTION
there are some niche situations in which a user might want to split a helm release's values across separate values files and supply them separately. when helm merges separate values layers, objects merge cleanly (key name conflicts overwrite, but key names that don't conflict get unioned) but lists don't (a list in layer2 will clobber a list at the same path in layer1).

this makes it so the `env:` block in our values file, which is an object keyed by env var name, allows not only static string values but also dynamic reference values (such as a secretKeyRef), so that env values can be supplied across disparate layers without clobbering.