### PR TITLE
Make jse disabled by default

### DIFF
--- a/charts/retool/templates/_workers.tpl
+++ b/charts/retool/templates/_workers.tpl
@@ -213,8 +213,10 @@ spec:
             value: {{ template "retool.postgresql.ssl_enabled" $ }}
           - name: CODE_EXECUTOR_INGRESS_DOMAIN
             value: http://{{ template "retool.codeExecutor.name" $ }}
+          {{- if $.Values.jsExecutor.enabled }}
           - name: JS_EXECUTOR_INGRESS_DOMAIN
             value: http://{{ template "retool.jsExecutor.name" $ }}
+          {{- end }}
           {{- include "retool.agentSandbox.backendEnvVars" $ | nindent 10 }}
 
           {{- include "retool.telemetry.includeEnvVars" $ | nindent 10 }}

--- a/charts/retool/templates/configmap_js_executor.yaml
+++ b/charts/retool/templates/configmap_js_executor.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.jsExecutor.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -5,3 +6,4 @@ metadata:
 data:
   nsjail-seccomp.json: |
     {{- .Files.Get "files/nsjail-seccomp.json" | nindent 4 }}
+{{- end }}

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -180,8 +180,10 @@ spec:
               {{- end }}
           {{- end }}
           {{- end }}
+          {{- if .Values.jsExecutor.enabled }}
           - name: JS_EXECUTOR_INGRESS_DOMAIN
             value: http://{{ template "retool.jsExecutor.name" . }}
+          {{- end }}
 
           {{- include "retool.telemetry.includeEnvVars" . | nindent 10 }}
 

--- a/charts/retool/templates/deployment_js_executor.yaml
+++ b/charts/retool/templates/deployment_js_executor.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.jsExecutor.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -208,4 +209,4 @@ spec:
     matchLabels:
   {{- include "retool.jsExecutor.selectorLabels" . | nindent 6 }}
 {{- end }}
----
+{{- end }}

--- a/charts/retool/templates/deployment_workflows.yaml
+++ b/charts/retool/templates/deployment_workflows.yaml
@@ -153,8 +153,10 @@ spec:
               {{- end }}
           {{- end }}
           {{- end }}
+          {{- if .Values.jsExecutor.enabled }}
           - name: JS_EXECUTOR_INGRESS_DOMAIN
             value: http://{{ template "retool.jsExecutor.name" . }}
+          {{- end }}
 
           {{- include "retool.telemetry.includeEnvVars" . | nindent 10 }}
 

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -750,6 +750,8 @@ codeExecutor:
 
 # JS Executor
 jsExecutor:
+  enabled: false
+
   image:
     repository: tryretool/js-executor-service
     pullPolicy: IfNotPresent

--- a/values.yaml
+++ b/values.yaml
@@ -750,6 +750,8 @@ codeExecutor:
 
 # JS Executor
 jsExecutor:
+  enabled: false
+
   image:
     repository: tryretool/js-executor-service
     pullPolicy: IfNotPresent


### PR DESCRIPTION
until this is fully released, we need to have it disabled by default so balloon instances don't spin this up (part of adding r2 support for balloon)