### PR TITLE
Make js-executor-seccomp configmap prefixed

### DIFF
--- a/charts/retool/templates/configmap_js_executor.yaml
+++ b/charts/retool/templates/configmap_js_executor.yaml
@@ -1,7 +1,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: js-executor-seccomp
+  name: {{ template "retool.fullname" . }}-js-executor-seccomp
+  labels:
+    {{- include "retool.labels" . | nindent 4 }}
 data:
   nsjail-seccomp.json: |
     {{- .Files.Get "files/nsjail-seccomp.json" | nindent 4 }}

--- a/charts/retool/templates/deployment_js_executor.yaml
+++ b/charts/retool/templates/deployment_js_executor.yaml
@@ -149,7 +149,7 @@ spec:
       volumes:
         - name: seccomp-profile
           configMap:
-            name: "js-executor-seccomp"
+            name: {{ template "retool.fullname" . }}-js-executor-seccomp
         - name: host-seccomp
           hostPath:
             path: /var/lib/kubelet/seccomp


### PR DESCRIPTION
Change the js-executor-seccomp configmap name to be prefixed with `retool.fullname`, similar to all the other deployments. Also allows for multiple retool instances within the same namespace because will no longer lead to naming collision