### PR TITLE
[feat][r2] enable git_server in-process with rrGitServer.enabled + blobStorage config

### DIFF
--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -688,6 +688,23 @@ Set MCP server service name
 {{- end -}}
 
 {{/*
+Validate that exactly one blob-storage provider is configured when rrGitServer
+is enabled. No-op when rrGitServer is disabled.
+*/}}
+{{- define "retool.rrGitServer.validateBlobStorage" -}}
+{{- if .Values.rrGitServer.enabled -}}
+{{- $bs := .Values.blobStorage | default dict -}}
+{{- $providers := list -}}
+{{- if $bs.s3 }}{{ $providers = append $providers "s3" }}{{ end -}}
+{{- if $bs.gcs }}{{ $providers = append $providers "gcs" }}{{ end -}}
+{{- if $bs.azure }}{{ $providers = append $providers "azure" }}{{ end -}}
+{{- if ne (len $providers) 1 -}}
+{{- fail "rrGitServer.enabled requires exactly one of blobStorage.s3, blobStorage.gcs, blobStorage.azure to be configured" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Set code executor image tag
 Usage: (template "retool.codeExecutor.image.tag" .)
 */}}

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -689,17 +689,33 @@ Set MCP server service name
 
 {{/*
 Validate that exactly one blob-storage provider is configured when rrGitServer
-is enabled. No-op when rrGitServer is disabled.
+is enabled. Skipped when the user has plumbed the RR_BLOB_STORAGE_PROVIDER /
+RR_DEFAULT_*_* env vars in directly via environmentVariables/environmentSecrets,
+which is treated as an opt-out from the first-class blobStorage config.
+No-op when rrGitServer is disabled.
 */}}
 {{- define "retool.rrGitServer.validateBlobStorage" -}}
 {{- if .Values.rrGitServer.enabled -}}
+{{- $hasDirectEnv := false -}}
+{{- range .Values.environmentVariables -}}
+{{- if or (hasPrefix "RR_DEFAULT_" .name) (eq .name "RR_BLOB_STORAGE_PROVIDER") -}}
+{{- $hasDirectEnv = true -}}
+{{- end -}}
+{{- end -}}
+{{- range .Values.environmentSecrets -}}
+{{- if or (hasPrefix "RR_DEFAULT_" .name) (eq .name "RR_BLOB_STORAGE_PROVIDER") -}}
+{{- $hasDirectEnv = true -}}
+{{- end -}}
+{{- end -}}
+{{- if not $hasDirectEnv -}}
 {{- $bs := .Values.blobStorage | default dict -}}
 {{- $providers := list -}}
 {{- if $bs.s3 }}{{ $providers = append $providers "s3" }}{{ end -}}
 {{- if $bs.gcs }}{{ $providers = append $providers "gcs" }}{{ end -}}
 {{- if $bs.azure }}{{ $providers = append $providers "azure" }}{{ end -}}
 {{- if ne (len $providers) 1 -}}
-{{- fail "rrGitServer.enabled requires exactly one of blobStorage.s3, blobStorage.gcs, blobStorage.azure to be configured" -}}
+{{- fail "rrGitServer.enabled requires exactly one of blobStorage.s3, blobStorage.gcs, blobStorage.azure to be configured, or set RR_BLOB_STORAGE_PROVIDER / RR_DEFAULT_* directly via environmentVariables / environmentSecrets" -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -1,13 +1,4 @@
-{{- if .Values.rrGitServer.enabled }}
-{{- $bs := .Values.blobStorage | default dict }}
-{{- $providers := list }}
-{{- if $bs.s3 }}{{ $providers = append $providers "s3" }}{{ end }}
-{{- if $bs.gcs }}{{ $providers = append $providers "gcs" }}{{ end }}
-{{- if $bs.azure }}{{ $providers = append $providers "azure" }}{{ end }}
-{{- if ne (len $providers) 1 }}
-{{- fail "rrGitServer.enabled requires exactly one of blobStorage.s3, blobStorage.gcs, blobStorage.azure to be configured" }}
-{{- end }}
-{{- end }}
+{{- include "retool.rrGitServer.validateBlobStorage" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -1,3 +1,13 @@
+{{- if .Values.rrGitServer.enabled }}
+{{- $bs := .Values.blobStorage | default dict }}
+{{- $providers := list }}
+{{- if $bs.s3 }}{{ $providers = append $providers "s3" }}{{ end }}
+{{- if $bs.gcs }}{{ $providers = append $providers "gcs" }}{{ end }}
+{{- if $bs.azure }}{{ $providers = append $providers "azure" }}{{ end }}
+{{- if ne (len $providers) 1 }}
+{{- fail "rrGitServer.enabled requires exactly one of blobStorage.s3, blobStorage.gcs, blobStorage.azure to be configured" }}
+{{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -100,7 +110,9 @@ spec:
           {{- if not ( include "retool.jobRunner.enabled" . ) }}
             {{- $serviceType = append $serviceType "JOBS_RUNNER" }}
           {{- end }}
-          {{- $serviceType = append $serviceType "RR_GIT_SERVER" }}
+          {{- if .Values.rrGitServer.enabled }}
+            {{- $serviceType = append $serviceType "RR_GIT_SERVER" }}
+          {{- end }}
           - name: SERVICE_TYPE
             value: {{ join "," $serviceType }}
           {{ if and (  not $.Values.dbconnector.enabled  ) ( and ( include "retool_version_with_java_dbconnector_opt_out" . ) ( not $.Values.dbconnector.java.enabled ) ) }}
@@ -251,6 +263,71 @@ spec:
                 name: {{ template "retool.fullname" . }}
                 key: google-client-secret
                 {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.rrGitServer.enabled }}
+          {{- $bs := .Values.blobStorage }}
+          {{- if $bs.s3 }}
+          - name: RR_BLOB_STORAGE_PROVIDER
+            value: "s3"
+          - name: RR_DEFAULT_S3_BUCKET
+            value: {{ $bs.s3.bucket | quote }}
+          {{- if $bs.s3.region }}
+          - name: RR_DEFAULT_S3_REGION
+            value: {{ $bs.s3.region | quote }}
+          {{- end }}
+          {{- if $bs.s3.endpoint }}
+          - name: RR_DEFAULT_S3_ENDPOINT
+            value: {{ $bs.s3.endpoint | quote }}
+          {{- end }}
+          {{- if $bs.s3.accessKeyId }}
+          - name: RR_DEFAULT_S3_ACCESS_KEY_ID
+            value: {{ $bs.s3.accessKeyId | quote }}
+          {{- end }}
+          {{- if $bs.s3.secretAccessKeySecretName }}
+          - name: RR_DEFAULT_S3_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ $bs.s3.secretAccessKeySecretName }}
+                key: {{ $bs.s3.secretAccessKeySecretKey | default "secret-access-key" }}
+          {{- else if $bs.s3.secretAccessKey }}
+          - name: RR_DEFAULT_S3_SECRET_ACCESS_KEY
+            value: {{ $bs.s3.secretAccessKey | quote }}
+          {{- end }}
+          {{- else if $bs.gcs }}
+          - name: RR_BLOB_STORAGE_PROVIDER
+            value: "gcs"
+          - name: RR_DEFAULT_GCS_BUCKET
+            value: {{ $bs.gcs.bucket | quote }}
+          {{- if $bs.gcs.credentialsSecretName }}
+          - name: RR_DEFAULT_GCS_CREDENTIALS
+            valueFrom:
+              secretKeyRef:
+                name: {{ $bs.gcs.credentialsSecretName }}
+                key: {{ $bs.gcs.credentialsSecretKey | default "credentials.json" }}
+          {{- else if $bs.gcs.credentials }}
+          - name: RR_DEFAULT_GCS_CREDENTIALS
+            value: {{ $bs.gcs.credentials | quote }}
+          {{- end }}
+          {{- else if $bs.azure }}
+          - name: RR_BLOB_STORAGE_PROVIDER
+            value: "azure"
+          - name: RR_DEFAULT_AZURE_CONTAINER
+            value: {{ $bs.azure.container | quote }}
+          {{- if $bs.azure.connectionStringSecretName }}
+          - name: RR_DEFAULT_AZURE_CONNECTION_STRING
+            valueFrom:
+              secretKeyRef:
+                name: {{ $bs.azure.connectionStringSecretName }}
+                key: {{ $bs.azure.connectionStringSecretKey | default "connection-string" }}
+          {{- else if $bs.azure.connectionString }}
+          - name: RR_DEFAULT_AZURE_CONNECTION_STRING
+            value: {{ $bs.azure.connectionString | quote }}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.rrGitServer.repackThreshold }}
+          - name: RR_GIT_REPACK_THRESHOLD
+            value: {{ .Values.rrGitServer.repackThreshold | quote }}
           {{- end }}
           {{- end }}
           {{- include "retool.env" .Values.env | nindent 10 }}

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -100,6 +100,7 @@ spec:
           {{- if not ( include "retool.jobRunner.enabled" . ) }}
             {{- $serviceType = append $serviceType "JOBS_RUNNER" }}
           {{- end }}
+          {{- $serviceType = append $serviceType "RR_GIT_SERVER" }}
           - name: SERVICE_TYPE
             value: {{ join "," $serviceType }}
           {{ if and (  not $.Values.dbconnector.enabled  ) ( and ( include "retool_version_with_java_dbconnector_opt_out" . ) ( not $.Values.dbconnector.java.enabled ) ) }}

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -724,6 +724,10 @@ rrGitServer:
 # need object storage, e.g. snapshots). Set exactly one of s3, gcs, azure.
 # Renders RR_BLOB_STORAGE_PROVIDER + RR_DEFAULT_<provider>_* env vars on
 # the backend deployment.
+#
+# This block can be omitted entirely if RR_BLOB_STORAGE_PROVIDER and the
+# RR_DEFAULT_*_* env vars are provided directly via environmentVariables /
+# environmentSecrets above — the chart detects that and skips this guard.
 blobStorage: {}
   # s3:
   #   bucket: my-rr-bucket

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -705,6 +705,50 @@ mcp:
     annotations: {}
     labels: {}
 
+rrGitServer:
+  # Runs the React Retool Git Server in-process on the main backend pod
+  # (SERVICE_TYPE=...,RR_GIT_SERVER). The main backend internally proxies
+  # /api/ai/rr/git/v2/* to localhost:RR_GIT_SERVER_PORT, so no extra ingress
+  # routing is required. Required for the r2 / React Retool app pipeline.
+  #
+  # When enabled, exactly one of blobStorage.s3, blobStorage.gcs, or
+  # blobStorage.azure must be configured below — git_server stores all
+  # objects/packs in blob storage.
+  enabled: false
+
+  # Optional: number of loose objects before git_server triggers a repack.
+  # Backend default is 100; unset to inherit it.
+  repackThreshold: ~
+
+# Shared blob-storage config used by git_server (and other features that
+# need object storage, e.g. snapshots). Set exactly one of s3, gcs, azure.
+# Renders RR_BLOB_STORAGE_PROVIDER + RR_DEFAULT_<provider>_* env vars on
+# the backend deployment.
+blobStorage: {}
+  # s3:
+  #   bucket: my-rr-bucket
+  #   region: us-east-1
+  #   endpoint: ""                              # optional, for S3-compatible (MinIO, R2, etc.)
+  #   accessKeyId: AKIA...
+  #   # Provide secretAccessKey OR the secretName/secretKey pair below.
+  #   secretAccessKey: ""
+  #   secretAccessKeySecretName: ""
+  #   secretAccessKeySecretKey: secret-access-key
+  #
+  # gcs:
+  #   bucket: my-rr-bucket
+  #   # Provide credentials (JSON string) OR the secretName/secretKey pair below.
+  #   credentials: ""
+  #   credentialsSecretName: ""
+  #   credentialsSecretKey: credentials.json
+  #
+  # azure:
+  #   container: my-rr-container
+  #   # Provide connectionString OR the secretName/secretKey pair below.
+  #   connectionString: ""
+  #   connectionStringSecretName: ""
+  #   connectionStringSecretKey: connection-string
+
 codeExecutor:
   # as of Chart version 6.7.0, code-executor image version must align with the top-level `image` parameters
   # explicitly set other fields as needed

--- a/values.yaml
+++ b/values.yaml
@@ -705,6 +705,54 @@ mcp:
     annotations: {}
     labels: {}
 
+rrGitServer:
+  # Runs the React Retool Git Server in-process on the main backend pod
+  # (SERVICE_TYPE=...,RR_GIT_SERVER). The main backend internally proxies
+  # /api/ai/rr/git/v2/* to localhost:RR_GIT_SERVER_PORT, so no extra ingress
+  # routing is required. Required for the r2 / React Retool app pipeline.
+  #
+  # When enabled, exactly one of blobStorage.s3, blobStorage.gcs, or
+  # blobStorage.azure must be configured below — git_server stores all
+  # objects/packs in blob storage.
+  enabled: false
+
+  # Optional: number of loose objects before git_server triggers a repack.
+  # Backend default is 100; unset to inherit it.
+  repackThreshold: ~
+
+# Shared blob-storage config used by git_server (and other features that
+# need object storage, e.g. snapshots). Set exactly one of s3, gcs, azure.
+# Renders RR_BLOB_STORAGE_PROVIDER + RR_DEFAULT_<provider>_* env vars on
+# the backend deployment.
+#
+# This block can be omitted entirely if RR_BLOB_STORAGE_PROVIDER and the
+# RR_DEFAULT_*_* env vars are provided directly via environmentVariables /
+# environmentSecrets above — the chart detects that and skips this guard.
+blobStorage: {}
+  # s3:
+  #   bucket: my-rr-bucket
+  #   region: us-east-1
+  #   endpoint: ""                              # optional, for S3-compatible (MinIO, R2, etc.)
+  #   accessKeyId: AKIA...
+  #   # Provide secretAccessKey OR the secretName/secretKey pair below.
+  #   secretAccessKey: ""
+  #   secretAccessKeySecretName: ""
+  #   secretAccessKeySecretKey: secret-access-key
+  #
+  # gcs:
+  #   bucket: my-rr-bucket
+  #   # Provide credentials (JSON string) OR the secretName/secretKey pair below.
+  #   credentials: ""
+  #   credentialsSecretName: ""
+  #   credentialsSecretKey: credentials.json
+  #
+  # azure:
+  #   container: my-rr-container
+  #   # Provide connectionString OR the secretName/secretKey pair below.
+  #   connectionString: ""
+  #   connectionStringSecretName: ""
+  #   connectionStringSecretKey: connection-string
+
 codeExecutor:
   # as of Chart version 6.7.0, code-executor image version must align with the top-level `image` parameters
   # explicitly set other fields as needed


### PR DESCRIPTION
## Summary

Wires up the React Retool Git Server (`SERVICE_TYPE=RR_GIT_SERVER`) as an in-process listener on the main backend pod, gated behind a new `rrGitServer.enabled` flag and a `blobStorage` config block.

### What this PR adds

1. **`rrGitServer.enabled`** (default `false`) — when true, appends `RR_GIT_SERVER` to the main backend's `SERVICE_TYPE` so the git_server Express app (port 3020) starts in the same process.
2. **Top-level `blobStorage:` block** with `s3` / `gcs` / `azure` sub-blocks. Customers set exactly one; the chart `{{ fail }}`s otherwise. Renders `RR_BLOB_STORAGE_PROVIDER` + `RR_DEFAULT_<PROVIDER>_*` env vars on the backend deployment, with `secretKeyRef` support for the credential field of each provider. Top-level (not under `rrGitServer`) because the backend's `RR_DEFAULT_*` vars are shared with snapshots — same config will feed them once those get wired in.
3. **Optional `rrGitServer.repackThreshold`** → `RR_GIT_REPACK_THRESHOLD` (default 100 on the backend).

### Companion PR

Pairs with retool_development [PR #77899](https://github.com/tryretool/retool_development/pull/77899), which widens the existing `__DEV__`-gated proxy in `backend/src/server/app.ts` so main backend internally proxies `/api/ai/rr/git/v2/*` to `localhost:RR_GIT_SERVER_PORT`. Without that companion PR, helm-chart customers would still need ingress to route v2 paths to git_server's port — with it, no ingress changes are required.

### Out of scope

- Splitting git_server into its own deployment (rejected — backend co-residence is the simpler shape for helm chart customers and the companion backend PR makes the routing work automatically).
- Wiring snapshots to use `blobStorage` (deferred — that's a separate feature; this PR just lays the shared config foundation).

## Test plan

- [x] `helm template` with defaults (rrGitServer disabled): no `RR_GIT_SERVER` in SERVICE_TYPE, no blob storage env
- [x] `helm template --set rrGitServer.enabled=true` with no blob storage: `{{ fail }}` with helpful message
- [x] `helm template --set rrGitServer.enabled=true,blobStorage.s3.bucket=...,blobStorage.gcs.bucket=...`: `{{ fail }}` (two providers)
- [x] `helm template` with each of s3 (plaintext), s3 (secretKeyRef + repackThreshold), gcs, azure: renders correct env block + SERVICE_TYPE includes RR_GIT_SERVER
- [ ] After companion PR lands: deploy with `rrGitServer.enabled=true` + S3, verify `curl backend:3000/api/ai/rr/git/v2/apps/<uuid>/repo.git/info/refs` returns smart-HTTP refs (proxied through main backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)