### PR TITLE
Tune liveness probe for agent sandbox deployments

### DIFF
--- a/charts/retool/templates/deployment_agent_sandbox.yaml
+++ b/charts/retool/templates/deployment_agent_sandbox.yaml
@@ -380,9 +380,10 @@ spec:
             httpGet:
               path: /livez
               port: http
-            initialDelaySeconds: 3
+            initialDelaySeconds: 10
             periodSeconds: 10
-            timeoutSeconds: 3
+            timeoutSeconds: 5
+            failureThreshold: 5
           readinessProbe:
             httpGet:
               path: /health
@@ -563,9 +564,10 @@ spec:
             httpGet:
               path: /livez
               port: http
-            initialDelaySeconds: 3
+            initialDelaySeconds: 10
             periodSeconds: 10
-            timeoutSeconds: 3
+            timeoutSeconds: 5
+            failureThreshold: 5
           readinessProbe:
             httpGet:
               path: /health


### PR DESCRIPTION
agent sandbox controller and agent sandbox proxy fail liveness probes while still spinning up (for balloon instances at least) leading to restarts and crash loop backoffs. This loosens the liveness probe a bit so we don't run into this problem