### PR TITLE
Add optional MCP git server URL

### DIFF
--- a/charts/retool/templates/deployment_mcp.yaml
+++ b/charts/retool/templates/deployment_mcp.yaml
@@ -115,6 +115,10 @@ spec:
             value: {{ $mcpInternalPort | quote }}
           - name: RETOOL_BACKEND_URL
             value: {{ $mcpConfig.retoolBackendUrl | default (printf "http://%s:%v" (include "retool.fullname" .) .Values.service.externalPort) | quote }}
+          {{- if $mcpConfig.retoolGitServerUrl }}
+          - name: RETOOL_GIT_SERVER_URL
+            value: {{ $mcpConfig.retoolGitServerUrl | quote }}
+          {{- end }}
           {{- if $mcpConfig.retoolUrl }}
           - name: RETOOL_URL
             value: {{ $mcpConfig.retoolUrl | quote }}

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -598,6 +598,10 @@ mcp:
   #   # Defaults to the release's internal Retool service when unset.
   #   retoolBackendUrl:
   #
+  #   # Internal URL used by the MCP server to call the Retool git server.
+  #   # Unset by default.
+  #   retoolGitServerUrl:
+  #
   #   # Public Retool URL used for links. Set explicitly when the request
   #   # origin is not the right public URL.
   #   retoolUrl:

--- a/values.yaml
+++ b/values.yaml
@@ -598,6 +598,10 @@ mcp:
   #   # Defaults to the release's internal Retool service when unset.
   #   retoolBackendUrl:
   #
+  #   # Internal URL used by the MCP server to call the Retool git server.
+  #   # Unset by default.
+  #   retoolGitServerUrl:
+  #
   #   # Public Retool URL used for links. Set explicitly when the request
   #   # origin is not the right public URL.
   #   retoolUrl:


### PR DESCRIPTION
Adds an optional `mcp.config.retoolGitServerUrl` setting that emits `RETOOL_GIT_SERVER_URL` for the MCP deployment only when configured.

This is used to direct MCP server git server requests to the standalone node when appropriate in the cluster.
