### PR TITLE
Document self-hosted same-origin agent-sandbox proxy (no extra ingress)

### DIFF
--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -1094,8 +1094,13 @@ agentSandbox:
   # controllerUrl and proxyUrl default to internal service URLs when empty.
   controllerUrl: ''
   proxyUrl: ''
-  # Required: public URL for frontend browsers to reach the proxy via WebSocket.
-  # e.g. https://sandbox.yourdomain.com
+  # Public URL for frontend browsers to reach the proxy via WebSocket.
+  # Leave EMPTY for self-hosted: the backend then serves the sandbox same-origin
+  # as the editor (your Retool base URL) and the front server reverse-proxies the
+  # /sandbox/* WS+Vite paths to the in-cluster proxy Service — so no dedicated
+  # proxy domain or ingress is required, and your catch-all ingress is untouched.
+  # Only set this (e.g. https://sandbox.yourdomain.com) if you deliberately want
+  # the proxy on a separate domain, in which case also enable proxy.ingress above.
   frontendWsProxyDomain: ''
   # Public URL for proxy domain. Defaults to frontendWsProxyDomain if empty.
   proxyDomain: ''


### PR DESCRIPTION
## Summary

Documents that, for **self-hosted**, leaving `agentSandbox.frontendWsProxyDomain` empty makes the backend serve the agent-sandbox proxy **same-origin via the main ingress** — so no dedicated proxy domain or `proxy.ingress` object is required, and a customer-managed catch-all ingress is left untouched.

The chart already defaults the backend→controller/proxy env vars (`AGENT_EXECUTOR_*_INGRESS_DOMAIN`) to in-cluster Service URLs and ships `proxy.ingress.enabled: false`, so this is a values.yaml comment clarification only — no template/behavior change.

The actual routing change lives in the backend: tryretool/retool_development#78870.

## Test plan

- `helm template` renders unchanged (comment-only edit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)