### PR TITLE
js-executor: drop backend-shared env inheritance + resize resources

### DIFF
--- a/charts/retool/templates/deployment_js_executor.yaml
+++ b/charts/retool/templates/deployment_js_executor.yaml
@@ -97,18 +97,15 @@ spec:
           - name: NODE_ENV
             value: production
           {{- include "retool.telemetry.includeEnvVars" . | nindent 10 }}
-          {{- range $key, $value := .Values.env }}
-          - name: "{{ $key }}"
-            value: "{{ $value }}"
-          {{- end }}
-          {{- range .Values.environmentSecrets }}
+          {{- include "retool.env" .Values.jsExecutor.env | nindent 10 }}
+          {{- range .Values.jsExecutor.environmentSecrets }}
           - name: {{ .name }}
             valueFrom:
               secretKeyRef:
                 name: {{ .secretKeyRef.name }}
                 key: {{ .secretKeyRef.key }}
           {{- end }}
-          {{- with .Values.environmentVariables }}
+          {{- with .Values.jsExecutor.environmentVariables }}
 {{ toYaml . | indent 10 }}
           {{- end }}
         ports:

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -836,14 +836,16 @@ jsExecutor:
   # Config affinity and anti-affinity rules for the JS executor pods
   affinity: {}
 
-  # Resources for the JS executor
+  # Resources for the JS executor. Memory request and limit are kept equal:
+  # JSE reads its memory limit and rejects requests at 80% of it, so the
+  # request must reserve the full amount to avoid premature rejections.
   resources:
     limits:
-      cpu: 2000m
-      memory: 8192Mi
+      cpu: 6000m
+      memory: 6Gi
     requests:
-      cpu: 1000m
-      memory: 4096Mi
+      cpu: 6000m
+      memory: 6Gi
 
 agents:
   # Enable AI Agents

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -818,6 +818,12 @@ jsExecutor:
 
   seccompLocalhostProfile: profiles/nsjail-seccomp.json
 
+  # JS-executor-specific environment; not inherited from the top-level
+  # .Values.env / .Values.environmentSecrets / .Values.environmentVariables.
+  env: {}
+  environmentSecrets: []
+  environmentVariables: []
+
   # Annotations for JS executor pods
   annotations: {}
 

--- a/values.yaml
+++ b/values.yaml
@@ -836,14 +836,16 @@ jsExecutor:
   # Config affinity and anti-affinity rules for the JS executor pods
   affinity: {}
 
-  # Resources for the JS executor
+  # Resources for the JS executor. Memory request and limit are kept equal:
+  # JSE reads its memory limit and rejects requests at 80% of it, so the
+  # request must reserve the full amount to avoid premature rejections.
   resources:
     limits:
-      cpu: 2000m
-      memory: 8192Mi
+      cpu: 6000m
+      memory: 6Gi
     requests:
-      cpu: 1000m
-      memory: 4096Mi
+      cpu: 6000m
+      memory: 6Gi
 
 agents:
   # Enable AI Agents

--- a/values.yaml
+++ b/values.yaml
@@ -818,6 +818,12 @@ jsExecutor:
 
   seccompLocalhostProfile: profiles/nsjail-seccomp.json
 
+  # JS-executor-specific environment; not inherited from the top-level
+  # .Values.env / .Values.environmentSecrets / .Values.environmentVariables.
+  env: {}
+  environmentSecrets: []
+  environmentVariables: []
+
   # Annotations for JS executor pods
   annotations: {}
 


### PR DESCRIPTION
Part of the **r2-cleanup** integration branch (merges into `r2-cleanup`, which later merges into `r2`).

## Changes

**1. Stop inheriting backend-shared env**
The js-executor deployment looped over the backend-shared `.Values.env`, `.Values.environmentSecrets`, and `.Values.environmentVariables` unfiltered, injecting db creds, auth/encryption secrets, the license key, and other backend config into a sandbox pod that needs none of it. Replaced with per-workload overrides `jsExecutor.env` / `jsExecutor.environmentSecrets` / `jsExecutor.environmentVariables` (all default empty), matching the self-contained pattern already used by the `mcp` and `agent_sandbox` workloads.

Verified against the `js_executor` service in `retool_development`: it reads **zero** backend-shared env vars (no Postgres/DB, JWT, encryption, license, or auth secrets) — only deployment/telemetry metadata and config that all have defaults.

**2. Resize resources**
Bump CPU to `6000m` and set memory to `6Gi`, with `requests == limits` (Guaranteed QoS). Memory request is kept equal to the limit because JSE reads its memory limit and rejects requests at 80% of it.

## Audit note
The env bleed only affected js-executor — `agent_sandbox` and `mcp` were already self-contained and need no change. (mcp still inherits `.Values.files`/PVC/`commandline.args`, left as a separate follow-up.)

## Verification
`helm template` confirms backend `.Values.env`/`.Values.environmentSecrets` no longer render in the js-executor pod, resources show `6000m`/`6Gi` req=limit; both values.yaml copies stay in sync; `helm lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)