### PR TITLE
[fix] update startupProbe.successThreshold example to be 1

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.10.5
+version: 6.10.6
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -286,7 +286,7 @@ startupProbe:
   initialDelaySeconds: 60
   timeoutSeconds: 10
   periodSeconds: 10
-  successThreshold: 5
+  successThreshold: 1
 
 extraContainers: []
 

--- a/values.yaml
+++ b/values.yaml
@@ -286,7 +286,7 @@ startupProbe:
   initialDelaySeconds: 60
   timeoutSeconds: 10
   periodSeconds: 10
-  successThreshold: 5
+  successThreshold: 1
 
 extraContainers: []
 


### PR DESCRIPTION
From https://kubernetes.io/docs/concepts/workloads/pods/probes/#startup-probe:

> **successThreshold**
> Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup Probes. Minimum value is 1.

The startupProbe remains disabled - just updating the example values