### PR TITLE
Wire startupProbe into workflows-backend and code-executor

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.8.1
+version: 6.8.2
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/deployment_code_executor.yaml
+++ b/charts/retool/templates/deployment_code_executor.yaml
@@ -107,6 +107,16 @@ spec:
           successThreshold: {{ .Values.readinessProbe.successThreshold }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
 {{- end }}
+{{- if .Values.startupProbe.enabled }}
+        startupProbe:
+          httpGet:
+            path: {{ .Values.startupProbe.path }}
+            port: 3004
+          initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.startupProbe.successThreshold }}
+          periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+{{- end }}
         resources:
 {{ toYaml .Values.codeExecutor.resources | indent 10 }}
         volumeMounts:

--- a/charts/retool/templates/deployment_workflows.yaml
+++ b/charts/retool/templates/deployment_workflows.yaml
@@ -274,6 +274,16 @@ spec:
           successThreshold: {{ .Values.readinessProbe.successThreshold }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
 {{- end }}
+{{- if .Values.startupProbe.enabled }}
+        startupProbe:
+          httpGet:
+            path: {{ .Values.startupProbe.path }}
+            port: {{ .Values.service.internalPort }}
+          initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.startupProbe.successThreshold }}
+          periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+{{- end }}
         resources:
 {{- if .Values.workflows.backend.resources }}
 {{ toYaml .Values.workflows.backend.resources | indent 10 }}


### PR DESCRIPTION
## Summary
- The `.Values.startupProbe` block in `values.yaml` was previously only consumed by `deployment_backend.yaml`. This wires the same conditional into `deployment_workflows.yaml` and `deployment_code_executor.yaml` so the existing values apply uniformly across the main backend, workflows-backend, and code-executor.
- No values.yaml changes — `startupProbe.enabled` still defaults to `false`, so this is a no-op for existing installs.
- Bumps chart version 6.8.1 → 6.8.2.

## Test plan
- [x] `helm template` with `--set startupProbe.enabled=true` renders `startupProbe:` blocks on all three deployments (backend port 3000, workflows-backend port 3000, code-executor port 3004).
- [ ] Render diff review on CI kubeconform values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)