### PR TITLE
rrGitServer: accept blob-storage env vars from .Values.env

### DIFF
--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -684,13 +684,18 @@ Set MCP server service name
 {{/*
 Validate that exactly one blob-storage provider is configured when rrGitServer
 is enabled. Skipped when the user has plumbed the RR_BLOB_STORAGE_PROVIDER /
-RR_DEFAULT_*_* env vars in directly via environmentVariables/environmentSecrets,
+RR_DEFAULT_*_* env vars in directly via env/environmentVariables/environmentSecrets,
 which is treated as an opt-out from the first-class blobStorage config.
 No-op when rrGitServer is disabled.
 */}}
 {{- define "retool.rrGitServer.validateBlobStorage" -}}
 {{- if .Values.rrGitServer.enabled -}}
 {{- $hasDirectEnv := false -}}
+{{- range $name, $value := .Values.env -}}
+{{- if or (hasPrefix "RR_DEFAULT_" $name) (eq $name "RR_BLOB_STORAGE_PROVIDER") -}}
+{{- $hasDirectEnv = true -}}
+{{- end -}}
+{{- end -}}
 {{- range .Values.environmentVariables -}}
 {{- if or (hasPrefix "RR_DEFAULT_" .name) (eq .name "RR_BLOB_STORAGE_PROVIDER") -}}
 {{- $hasDirectEnv = true -}}
@@ -708,7 +713,7 @@ No-op when rrGitServer is disabled.
 {{- if $bs.gcs }}{{ $providers = append $providers "gcs" }}{{ end -}}
 {{- if $bs.azure }}{{ $providers = append $providers "azure" }}{{ end -}}
 {{- if ne (len $providers) 1 -}}
-{{- fail "rrGitServer.enabled requires exactly one of blobStorage.s3, blobStorage.gcs, blobStorage.azure to be configured, or set RR_BLOB_STORAGE_PROVIDER / RR_DEFAULT_* directly via environmentVariables / environmentSecrets" -}}
+{{- fail "rrGitServer.enabled requires exactly one of blobStorage.s3, blobStorage.gcs, blobStorage.azure to be configured, or set RR_BLOB_STORAGE_PROVIDER / RR_DEFAULT_* directly via env / environmentVariables / environmentSecrets" -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -686,10 +686,13 @@ Validate that exactly one blob-storage provider is configured when rrGitServer
 is enabled. Skipped when the user has plumbed the RR_BLOB_STORAGE_PROVIDER /
 RR_DEFAULT_*_* env vars in directly via env/environmentVariables/environmentSecrets,
 which is treated as an opt-out from the first-class blobStorage config.
+Also skipped entirely when rrGitServer.skipBlobStorageValidation is true, which
+is the escape hatch for sources we cannot inspect at template time (e.g. env
+vars injected via envFrom from a Secret/ConfigMap).
 No-op when rrGitServer is disabled.
 */}}
 {{- define "retool.rrGitServer.validateBlobStorage" -}}
-{{- if .Values.rrGitServer.enabled -}}
+{{- if and .Values.rrGitServer.enabled (not .Values.rrGitServer.skipBlobStorageValidation) -}}
 {{- $hasDirectEnv := false -}}
 {{- range $name, $value := .Values.env -}}
 {{- if or (hasPrefix "RR_DEFAULT_" $name) (eq $name "RR_BLOB_STORAGE_PROVIDER") -}}
@@ -713,7 +716,7 @@ No-op when rrGitServer is disabled.
 {{- if $bs.gcs }}{{ $providers = append $providers "gcs" }}{{ end -}}
 {{- if $bs.azure }}{{ $providers = append $providers "azure" }}{{ end -}}
 {{- if ne (len $providers) 1 -}}
-{{- fail "rrGitServer.enabled requires exactly one of blobStorage.s3, blobStorage.gcs, blobStorage.azure to be configured, or set RR_BLOB_STORAGE_PROVIDER / RR_DEFAULT_* directly via env / environmentVariables / environmentSecrets" -}}
+{{- fail "rrGitServer.enabled requires exactly one of blobStorage.s3, blobStorage.gcs, blobStorage.azure to be configured, or set RR_BLOB_STORAGE_PROVIDER / RR_DEFAULT_* directly via env / environmentVariables / environmentSecrets. If those vars are supplied another way (e.g. envFrom), set rrGitServer.skipBlobStorageValidation=true to bypass this check." -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -728,6 +728,13 @@ rrGitServer:
   # Backend default is 100; unset to inherit it.
   repackThreshold: ~
 
+  # Escape hatch for the blob-storage validation below. The chart can only
+  # inspect blobStorage, env, environmentVariables, and environmentSecrets at
+  # template time; it cannot see env vars injected via envFrom (Secret/ConfigMap
+  # splat). Set this to true to bypass the check when RR_BLOB_STORAGE_PROVIDER /
+  # RR_DEFAULT_* are provided that way.
+  skipBlobStorageValidation: false
+
 # Shared blob-storage config used by git_server (and other features that
 # need object storage, e.g. snapshots). Set exactly one of s3, gcs, azure.
 # Renders RR_BLOB_STORAGE_PROVIDER + RR_DEFAULT_<provider>_* env vars on

--- a/values.yaml
+++ b/values.yaml
@@ -728,6 +728,13 @@ rrGitServer:
   # Backend default is 100; unset to inherit it.
   repackThreshold: ~
 
+  # Escape hatch for the blob-storage validation below. The chart can only
+  # inspect blobStorage, env, environmentVariables, and environmentSecrets at
+  # template time; it cannot see env vars injected via envFrom (Secret/ConfigMap
+  # splat). Set this to true to bypass the check when RR_BLOB_STORAGE_PROVIDER /
+  # RR_DEFAULT_* are provided that way.
+  skipBlobStorageValidation: false
+
 # Shared blob-storage config used by git_server (and other features that
 # need object storage, e.g. snapshots). Set exactly one of s3, gcs, azure.
 # Renders RR_BLOB_STORAGE_PROVIDER + RR_DEFAULT_<provider>_* env vars on


### PR DESCRIPTION
Part of the **r2-cleanup** integration branch (merges into `r2-cleanup`, then `r2` via #303).

## Problem
`retool.rrGitServer.validateBlobStorage` only scanned `.Values.environmentVariables` and `.Values.environmentSecrets` for `RR_BLOB_STORAGE_PROVIDER` / `RR_DEFAULT_*`. Deployments that set those via the `.Values.env` map were forced to *duplicate* the `RR_*` vars into `environmentVariables` just to pass the check. And env vars supplied via `envFrom` (Secret/ConfigMap splat) are invisible at template time, so a valid setup using them had no way to satisfy the guard.

## Fix
1. Range over `.Values.env` (keyed by var name) in the same opt-out check.
2. Add `rrGitServer.skipBlobStorageValidation` (default `false`) as an explicit escape hatch for sources the chart cannot inspect at template time (e.g. `envFrom`). The failure message now points at this flag.

## Verification (`helm template`, rrGitServer.enabled=true)
| Case | Result |
|------|--------|
| `env.RR_BLOB_STORAGE_PROVIDER=gcs` | ✅ passes (previously required duplication) |
| `env.RR_DEFAULT_GCS_BUCKET=...` | ✅ passes |
| `skipBlobStorageValidation=true`, nothing else | ✅ bypassed |
| nothing configured (default) | ❌ fails with updated message + envFrom hint |
| unrelated `env.SOME_OTHER=x` | ❌ still fails (no false-positive) |
| `rrGitServer.enabled=false` | ✅ no-op |

Both values.yaml copies stay in sync; `helm lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)