### PR TITLE
agent-sandbox: validate required secrets + existing-secret DSN ref

### DIFF
--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -624,6 +624,100 @@ telemetry.retool.com/service-name: agent-sandbox-proxy
 {{- end -}}
 
 {{/*
+Validate that an enabled agent sandbox has its required secrets supplied. The
+controller and proxy fail to boot without a Postgres connection and a JWT
+public key, and the Retool backend needs the JWT private key to sign sandbox
+tokens. Each may come from a plaintext value, the per-key existing-secret refs,
+or the catch-all externalSecret.name. No-op when agentSandbox is disabled.
+*/}}
+{{- define "retool.agentSandbox.validateSecrets" -}}
+{{- if .Values.agentSandbox.enabled -}}
+{{- $as := .Values.agentSandbox -}}
+{{- $ext := $as.externalSecret.name -}}
+{{- if not (or $as.postgres.url $as.postgres.urlSecretName $as.postgres.host $ext) -}}
+{{- fail "agentSandbox.enabled requires a Postgres connection. Set one of: agentSandbox.postgres.url (DSN), agentSandbox.postgres.host + user + database (the chart assembles the DSN, password from postgres.password or postgres.passwordSecretName), agentSandbox.postgres.urlSecretName (existing secret holding the DSN), or agentSandbox.externalSecret.name." -}}
+{{- end -}}
+{{- if $as.postgres.host -}}
+{{- if not (and $as.postgres.user $as.postgres.database) -}}
+{{- fail "agentSandbox.postgres.host is set, so postgres.user and postgres.database are also required to assemble the DSN." -}}
+{{- end -}}
+{{- /*
+  user and database are embedded verbatim in the assembled DSN, so reject the
+  characters that would break URL parsing. '@' is allowed in user (managed
+  services like Azure use user@servername; the parser splits on the last '@'),
+  but ':' '/' and whitespace would be mis-parsed as a password/host/path. For
+  values needing other characters, supply a full DSN via postgres.url or
+  postgres.urlSecretName instead.
+*/}}
+{{- if regexMatch "[\\s:/?#]" ($as.postgres.user | toString) -}}
+{{- fail "agentSandbox.postgres.user contains a character that breaks DSN assembly (whitespace, : / ? #). '@' is fine (e.g. Azure user@server); otherwise supply a full DSN via agentSandbox.postgres.url or postgres.urlSecretName." -}}
+{{- end -}}
+{{- if regexMatch "[\\s?#]" ($as.postgres.database | toString) -}}
+{{- fail "agentSandbox.postgres.database contains a character that breaks DSN assembly (whitespace, ? #); supply a full DSN via agentSandbox.postgres.url or postgres.urlSecretName." -}}
+{{- end -}}
+{{- end -}}
+{{- if not (or $as.jwtPublicKey $ext) -}}
+{{- fail "agentSandbox.enabled requires a JWT public key. Set agentSandbox.jwtPublicKey or agentSandbox.externalSecret.name." -}}
+{{- end -}}
+{{- if not (or $as.jwtPrivateKey $ext) -}}
+{{- fail "agentSandbox.enabled requires a JWT private key (the backend signs sandbox tokens with it). Set agentSandbox.jwtPrivateKey or agentSandbox.externalSecret.name." -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Render the AGENT_SANDBOX_POSTGRES_URL env entry for the controller/proxy (plus a
+PGPASSWORD entry when assembling from fields). validateSecrets guarantees one of
+these applies, in order: postgres.url -> postgres.host -> postgres.urlSecretName
+-> externalSecret.name.
+
+For the host path the password is passed via PGPASSWORD rather than embedded in
+the URL: node-postgres reads PGPASSWORD when the connection string omits the
+password, so it needs no URL escaping. PGPASSWORD is process-global but safe
+here because the controller/proxy open exactly one Postgres connection. user and
+database are embedded verbatim (percent-encoding doesn't round-trip here -- the
+parser decodes userinfo before splitting on ':', and runs the path through
+decodeURI); validateSecrets instead rejects the characters that would break
+parsing. An Azure-style "user@servername" is fine -- the parser splits on the
+last '@'.
+Usage: {{- include "retool.agentSandbox.postgresUrlEnv" . | nindent 12 }}
+*/}}
+{{- define "retool.agentSandbox.postgresUrlEnv" -}}
+{{- $pg := .Values.agentSandbox.postgres -}}
+{{- $ext := .Values.agentSandbox.externalSecret.name -}}
+{{- if $pg.url }}
+- name: AGENT_SANDBOX_POSTGRES_URL
+  value: {{ $pg.url | quote }}
+{{- else if $pg.host }}
+{{- $port := $pg.port | default 5432 -}}
+{{- if $pg.passwordSecretName }}
+- name: PGPASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ $pg.passwordSecretName }}
+      key: {{ $pg.passwordSecretKey | default "password" }}
+{{- else if $pg.password }}
+- name: PGPASSWORD
+  value: {{ $pg.password | quote }}
+{{- end }}
+- name: AGENT_SANDBOX_POSTGRES_URL
+  value: {{ printf "postgres://%s@%s:%v/%s" $pg.user $pg.host $port $pg.database | quote }}
+{{- else if $pg.urlSecretName }}
+- name: AGENT_SANDBOX_POSTGRES_URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ $pg.urlSecretName }}
+      key: {{ $pg.urlSecretKey | default "postgres-url" }}
+{{- else if $ext }}
+- name: AGENT_SANDBOX_POSTGRES_URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ $ext }}
+      key: postgres-url
+{{- end }}
+{{- end -}}
+
+{{/*
 Agent sandbox env vars for the Retool backend, workflow backend, and workers.
 Outputs env entries that tell the backend how to reach the agent sandbox services.
 Usage: {{- include "retool.agentSandbox.backendEnvVars" . | nindent 10 }}

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -634,8 +634,15 @@ or the catch-all externalSecret.name. No-op when agentSandbox is disabled.
 {{- if .Values.agentSandbox.enabled -}}
 {{- $as := .Values.agentSandbox -}}
 {{- $ext := $as.externalSecret.name -}}
-{{- if not (or $as.postgres.url $as.postgres.urlSecretName $as.postgres.host $ext) -}}
-{{- fail "agentSandbox.enabled requires a Postgres connection. Set one of: agentSandbox.postgres.url (DSN), agentSandbox.postgres.host + user + database (the chart assembles the DSN, password from postgres.password or postgres.passwordSecretName), agentSandbox.postgres.urlSecretName (existing secret holding the DSN), or agentSandbox.externalSecret.name." -}}
+{{- $explicitPg := or $as.postgres.url $as.postgres.urlSecretName $as.postgres.host $ext -}}
+{{- if not $explicitPg -}}
+{{- /* No explicit source: inherit the backend's Postgres connection. */ -}}
+{{- if not (include "retool.postgresql.host" . | trimAll "\"") -}}
+{{- fail "agentSandbox.enabled defaults to reusing the backend's Postgres connection, but config.postgresql resolved no host. Set agentSandbox.postgres.url / .host / .urlSecretName / externalSecret.name, or configure config.postgresql." -}}
+{{- end -}}
+{{- if not (or .Values.postgresql.enabled .Values.config.postgresql.passwordSecretName (eq (include "shouldIncludeConfigSecretsEnvVars" . | trim) "1")) -}}
+{{- fail "agentSandbox.postgres is unset so it would inherit the backend's Postgres password, but that password is supplied via external secrets (envFrom) and cannot be referenced from a separate pod. Set agentSandbox.postgres.url / .urlSecretName / .host (+ passwordSecretName), or agentSandbox.externalSecret.name." -}}
+{{- end -}}
 {{- end -}}
 {{- if $as.postgres.host -}}
 {{- if not (and $as.postgres.user $as.postgres.database) -}}
@@ -669,7 +676,8 @@ or the catch-all externalSecret.name. No-op when agentSandbox is disabled.
 Render the AGENT_SANDBOX_POSTGRES_URL env entry for the controller/proxy (plus a
 PGPASSWORD entry when assembling from fields). validateSecrets guarantees one of
 these applies, in order: postgres.url -> postgres.host -> postgres.urlSecretName
--> externalSecret.name.
+-> externalSecret.name -> inherit the backend's config.postgresql connection
+(the default when nothing agent-specific is set).
 
 For the host path the password is passed via PGPASSWORD rather than embedded in
 the URL: node-postgres reads PGPASSWORD when the connection string omits the
@@ -714,6 +722,34 @@ Usage: {{- include "retool.agentSandbox.postgresUrlEnv" . | nindent 12 }}
     secretKeyRef:
       name: {{ $ext }}
       key: postgres-url
+{{- else }}
+{{- /*
+  Default: inherit the backend's Postgres connection (config.postgresql or the
+  postgresql subchart) -- same instance/database, separate schema. The password
+  is sourced from the same secret the backend uses; this block mirrors the
+  POSTGRES_PASSWORD secretKeyRef in deployment_backend.yaml. validateSecrets
+  rejects the one combination this can't reach (external-secrets mode with no
+  discrete password key).
+*/}}
+- name: PGPASSWORD
+  valueFrom:
+    secretKeyRef:
+      {{- if .Values.postgresql.enabled }}
+      name: {{ template "retool.postgresql.fullname" . }}
+      {{- if eq .Values.postgresql.auth.username "postgres" }}
+      key: postgres-password
+      {{- else }}
+      key: password
+      {{- end }}
+      {{- else if .Values.config.postgresql.passwordSecretName }}
+      name: {{ .Values.config.postgresql.passwordSecretName }}
+      key: {{ .Values.config.postgresql.passwordSecretKey | default "postgresql-password" }}
+      {{- else }}
+      name: {{ template "retool.fullname" . }}
+      key: postgresql-password
+      {{- end }}
+- name: AGENT_SANDBOX_POSTGRES_URL
+  value: {{ printf "postgres://%s@%s:%s/%s" (include "retool.postgresql.user" . | trimAll "\"") (include "retool.postgresql.host" . | trimAll "\"") (include "retool.postgresql.port" . | trimAll "\"" | default "5432") (include "retool.postgresql.database" . | trimAll "\"") | quote }}
 {{- end }}
 {{- end -}}
 

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -648,6 +648,9 @@ or the catch-all externalSecret.name. No-op when agentSandbox is disabled.
 {{- if not (and $as.postgres.user $as.postgres.database) -}}
 {{- fail "agentSandbox.postgres.host is set, so postgres.user and postgres.database are also required to assemble the DSN." -}}
 {{- end -}}
+{{- if not (or $as.postgres.password $as.postgres.passwordSecretName) -}}
+{{- fail "agentSandbox.postgres.host is set, so a password is required: set postgres.password or postgres.passwordSecretName. For a passwordless connection (e.g. IAM/trust auth), supply the full connection string via postgres.url or postgres.urlSecretName instead." -}}
+{{- end -}}
 {{- /*
   user and database are embedded verbatim in the assembled DSN, so reject the
   characters that would break URL parsing. '@' is allowed in user (managed

--- a/charts/retool/templates/deployment_agent_sandbox.yaml
+++ b/charts/retool/templates/deployment_agent_sandbox.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.agentSandbox.enabled }}
+{{- include "retool.agentSandbox.validateSecrets" . }}
 {{- $as := .Values.agentSandbox -}}
 {{- $defaultSecretName := $as.externalSecret.name | default (include "retool.agentSandbox.name" .) -}}
 {{- $nodeSelector := $as.nodeSelector | default .Values.nodeSelector -}}
@@ -22,7 +23,9 @@ data:
   jwt-private-key: {{ $as.jwtPrivateKey | default "" | b64enc | quote }}
   encryption-key: {{ $as.encryptionKey | default "" | b64enc | quote }}
   api-secret: {{ $as.apiSecret | default "" | b64enc | quote }}
-  postgres-url: {{ $as.postgres.url | default "" | b64enc | quote }}
+  {{- if $as.postgres.url }}
+  postgres-url: {{ $as.postgres.url | b64enc | quote }}
+  {{- end }}
 ---
 {{- end }}
 {{- /*
@@ -300,15 +303,7 @@ spec:
               value: {{ $as.controller.port | quote }}
             - name: STATE_BACKEND
               value: "postgres"
-            - name: AGENT_SANDBOX_POSTGRES_URL
-            {{- if $as.postgres.url }}
-              value: {{ $as.postgres.url | quote }}
-            {{- else }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $defaultSecretName }}
-                  key: postgres-url
-            {{- end }}
+            {{- include "retool.agentSandbox.postgresUrlEnv" . | nindent 12 }}
             - name: AGENT_SANDBOX_POSTGRES_SCHEMA
               value: {{ $as.postgres.schema | quote }}
             - name: AGENT_SANDBOX_POSTGRES_POOL_MAX
@@ -504,15 +499,7 @@ spec:
               value: {{ $as.proxy.port | quote }}
             - name: STATE_BACKEND
               value: "postgres"
-            - name: AGENT_SANDBOX_POSTGRES_URL
-            {{- if $as.postgres.url }}
-              value: {{ $as.postgres.url | quote }}
-            {{- else }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $defaultSecretName }}
-                  key: postgres-url
-            {{- end }}
+            {{- include "retool.agentSandbox.postgresUrlEnv" . | nindent 12 }}
             - name: AGENT_SANDBOX_POSTGRES_SCHEMA
               value: {{ $as.postgres.schema | quote }}
             - name: AGENT_SANDBOX_POSTGRES_POOL_MAX

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -928,33 +928,47 @@ agentSandbox:
   # Labels for agent sandbox pods
   labels: {}
 
-  # Pre-existing K8s Secret containing keys: jwt-public-key, jwt-private-key,
-  # encryption-key, api-secret, postgres-url. When set, the chart references
-  # this secret by default for all secret-backed env vars.
-  #
-  # Individual keys can still be overridden by setting the corresponding
-  # plaintext values below (e.g. jwtPublicKey, postgres.url). When a plaintext
-  # value is provided alongside externalSecret.name, the plaintext value takes
-  # precedence for that key and the external secret is used for the rest.
+  # === Secrets ============================================================
+  # Provide each secret as a plaintext value below, OR set externalSecret.name
+  # to a pre-existing Secret with keys jwt-public-key, jwt-private-key,
+  # encryption-key, api-secret, postgres-url. A plaintext value always wins over
+  # the external secret for that key.
   externalSecret:
-    name: ''
+    name: ''                 # optional: existing Secret holding all keys below
 
-  # Secrets — used directly when externalSecret.name is not set, or as
-  # per-key overrides when externalSecret.name IS set.
-  # JWT key pair (ES256) for sandbox token authentication.
-  jwtPublicKey: ''
-  jwtPrivateKey: ''
-  # Hex-encoded 256-bit key for encrypting credentials stored in state backend.
-  # Must match the backend's AGENT_SANDBOX_ENCRYPTION_KEY.
-  encryptionKey: ''
-  # API secret for admin/test endpoints.
-  apiSecret: ''
+  jwtPublicKey: ''           # REQUIRED (ES256) unless provided via externalSecret
+  jwtPrivateKey: ''          # REQUIRED (ES256) unless provided via externalSecret
+  encryptionKey: ''          # optional: hex 256-bit; must match backend AGENT_SANDBOX_ENCRYPTION_KEY
+  apiSecret: ''              # optional: admin/test endpoints
 
-  # Postgres state backend (shared by controller and proxy for state coordination).
-  # Connection string for the agent sandbox's state database. When set, takes
-  # precedence over the postgres-url key in externalSecret.
+  # === Postgres state backend =============================================
+  # REQUIRED. Choose exactly ONE sourcing option; leave the others blank.
   postgres:
+    # -- Option 1: plaintext DSN --
     url: ''
+
+    # -- Option 2: assemble from fields --
+    # The password is passed via PGPASSWORD (never embedded in the URL), so any
+    # characters are safe and a password-only secret can be reused as-is.
+    # Set either password or passwordSecretName.
+    # user/database are embedded in the DSN verbatim (user may contain '@', e.g.
+    # Azure user@servername); for values with : / ? # use Option 1 or 3.
+    host: ''
+    port: 5432
+    database: ''
+    user: ''
+    password: ''
+    passwordSecretName: ''
+    passwordSecretKey: 'password'
+
+    # -- Option 3: existing Secret holding the full DSN --
+    urlSecretName: ''
+    urlSecretKey: 'postgres-url'
+
+    # -- Option 4: reuse externalSecret.name (its postgres-url key) --
+    # Nothing to set here; just leave options 1-3 blank.
+
+    # -- Optional tuning (defaults shown) --
     schema: 'agent_executor'
     poolMax: 10
     sweeperIntervalMs: 60000

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -987,7 +987,11 @@ agentSandbox:
     urlSecretKey: 'postgres-url'
 
     # -- Option 4: reuse externalSecret.name (its postgres-url key) --
-    # Nothing to set here; just leave options 1-3 blank.
+    # Selected by setting agentSandbox.externalSecret.name (in the Secrets
+    # section above), not by anything here. Used when options 1-3 are blank.
+    #
+    # If options 1-4 are ALL unset, the default (inherit config.postgresql)
+    # applies -- see the note at the top of this block.
 
     # -- Optional tuning (defaults shown) --
     schema: 'agent_executor'

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -942,7 +942,13 @@ agentSandbox:
   apiSecret: ''              # optional: admin/test endpoints
 
   # === Postgres state backend =============================================
-  # REQUIRED. Choose exactly ONE sourcing option; leave the others blank.
+  # By DEFAULT (all options below left blank) the agent sandbox reuses the
+  # backend's Postgres connection from config.postgresql / the postgresql
+  # subchart -- same instance and database, separate schema (see schema below).
+  # So enabling it on an existing deployment needs nothing here. (Exception:
+  # if the backend's DB password is supplied via external secrets / envFrom, it
+  # can't be inherited by a separate pod -- set an option below in that case.)
+  # To point the sandbox at a different database, set exactly ONE option:
   postgres:
     # -- Option 1: plaintext DSN --
     url: ''

--- a/values.yaml
+++ b/values.yaml
@@ -928,33 +928,47 @@ agentSandbox:
   # Labels for agent sandbox pods
   labels: {}
 
-  # Pre-existing K8s Secret containing keys: jwt-public-key, jwt-private-key,
-  # encryption-key, api-secret, postgres-url. When set, the chart references
-  # this secret by default for all secret-backed env vars.
-  #
-  # Individual keys can still be overridden by setting the corresponding
-  # plaintext values below (e.g. jwtPublicKey, postgres.url). When a plaintext
-  # value is provided alongside externalSecret.name, the plaintext value takes
-  # precedence for that key and the external secret is used for the rest.
+  # === Secrets ============================================================
+  # Provide each secret as a plaintext value below, OR set externalSecret.name
+  # to a pre-existing Secret with keys jwt-public-key, jwt-private-key,
+  # encryption-key, api-secret, postgres-url. A plaintext value always wins over
+  # the external secret for that key.
   externalSecret:
-    name: ''
+    name: ''                 # optional: existing Secret holding all keys below
 
-  # Secrets — used directly when externalSecret.name is not set, or as
-  # per-key overrides when externalSecret.name IS set.
-  # JWT key pair (ES256) for sandbox token authentication.
-  jwtPublicKey: ''
-  jwtPrivateKey: ''
-  # Hex-encoded 256-bit key for encrypting credentials stored in state backend.
-  # Must match the backend's AGENT_SANDBOX_ENCRYPTION_KEY.
-  encryptionKey: ''
-  # API secret for admin/test endpoints.
-  apiSecret: ''
+  jwtPublicKey: ''           # REQUIRED (ES256) unless provided via externalSecret
+  jwtPrivateKey: ''          # REQUIRED (ES256) unless provided via externalSecret
+  encryptionKey: ''          # optional: hex 256-bit; must match backend AGENT_SANDBOX_ENCRYPTION_KEY
+  apiSecret: ''              # optional: admin/test endpoints
 
-  # Postgres state backend (shared by controller and proxy for state coordination).
-  # Connection string for the agent sandbox's state database. When set, takes
-  # precedence over the postgres-url key in externalSecret.
+  # === Postgres state backend =============================================
+  # REQUIRED. Choose exactly ONE sourcing option; leave the others blank.
   postgres:
+    # -- Option 1: plaintext DSN --
     url: ''
+
+    # -- Option 2: assemble from fields --
+    # The password is passed via PGPASSWORD (never embedded in the URL), so any
+    # characters are safe and a password-only secret can be reused as-is.
+    # Set either password or passwordSecretName.
+    # user/database are embedded in the DSN verbatim (user may contain '@', e.g.
+    # Azure user@servername); for values with : / ? # use Option 1 or 3.
+    host: ''
+    port: 5432
+    database: ''
+    user: ''
+    password: ''
+    passwordSecretName: ''
+    passwordSecretKey: 'password'
+
+    # -- Option 3: existing Secret holding the full DSN --
+    urlSecretName: ''
+    urlSecretKey: 'postgres-url'
+
+    # -- Option 4: reuse externalSecret.name (its postgres-url key) --
+    # Nothing to set here; just leave options 1-3 blank.
+
+    # -- Optional tuning (defaults shown) --
     schema: 'agent_executor'
     poolMax: 10
     sweeperIntervalMs: 60000

--- a/values.yaml
+++ b/values.yaml
@@ -987,7 +987,11 @@ agentSandbox:
     urlSecretKey: 'postgres-url'
 
     # -- Option 4: reuse externalSecret.name (its postgres-url key) --
-    # Nothing to set here; just leave options 1-3 blank.
+    # Selected by setting agentSandbox.externalSecret.name (in the Secrets
+    # section above), not by anything here. Used when options 1-3 are blank.
+    #
+    # If options 1-4 are ALL unset, the default (inherit config.postgresql)
+    # applies -- see the note at the top of this block.
 
     # -- Optional tuning (defaults shown) --
     schema: 'agent_executor'

--- a/values.yaml
+++ b/values.yaml
@@ -942,7 +942,13 @@ agentSandbox:
   apiSecret: ''              # optional: admin/test endpoints
 
   # === Postgres state backend =============================================
-  # REQUIRED. Choose exactly ONE sourcing option; leave the others blank.
+  # By DEFAULT (all options below left blank) the agent sandbox reuses the
+  # backend's Postgres connection from config.postgresql / the postgresql
+  # subchart -- same instance and database, separate schema (see schema below).
+  # So enabling it on an existing deployment needs nothing here. (Exception:
+  # if the backend's DB password is supplied via external secrets / envFrom, it
+  # can't be inherited by a separate pod -- set an option below in that case.)
+  # To point the sandbox at a different database, set exactly ONE option:
   postgres:
     # -- Option 1: plaintext DSN --
     url: ''


### PR DESCRIPTION
Part of the **r2-cleanup** integration branch (merges into `r2-cleanup`, then `r2` via #303).

## Problems
1. **Silent empty postgres URL.** `{{ $as.postgres.url | default "" | b64enc }}` base64-encodes an empty value, so a deploy missing the DSN installs cleanly and the controller/proxy crash-loop at runtime.
2. **Unguarded required secrets.** `jwtPublicKey` (controller + proxy `process.exit(1)` without it) and `jwtPrivateKey` (the backend signs sandbox tokens with it) had no install-time check.
3. **Rigid / redundant postgres config.** Only a plaintext DSN was accepted, and enabling the sandbox against the *existing* database forced operators to re-enter host/user/password even though it just needs a separate schema in the same DB.

## Postgres connection — inherits the backend by default
The agent sandbox lives in the **same database** as the backend (separate schema, `agent_executor`). So **by default (nothing set under `agentSandbox.postgres`), the chart reuses the backend's connection** — host/port/database/user from `config.postgresql` (or the postgresql subchart), and `PGPASSWORD` from the same secret the backend uses. Enabling r2 on an existing deployment needs **no** new Postgres values.

To point the sandbox elsewhere, set exactly one (resolution order):
1. `postgres.url` — plaintext DSN.
2. `postgres.host` (+ `user` + `database`) — chart assembles `postgres://user@host:port/database`; password via `PGPASSWORD` from `postgres.password` or `postgres.passwordSecretName` (reuse a password-only secret).
3. `postgres.urlSecretName`/`urlSecretKey` — existing secret with the full DSN.
4. `externalSecret.name` — catch-all secret, `postgres-url` key.
5. *(default)* inherit `config.postgresql`.

**Edge gated by validateSecrets:** if the backend password comes via external secrets (`envFrom`) with no discrete key, inheritance can't reference it, so install fails with guidance to set an explicit option.

## App constraint & PGPASSWORD
The app passes a single connection string to Knex/`pg` (no split-field path). To carry a secret-sourced password without URL escaping, the chart omits the password from the DSN and supplies `PGPASSWORD`; node-postgres reads it when the connection string has no password (verified on `pg-connection-string` 2.4.0 + `pg` 8.11.3). `PGPASSWORD` is process-global but safe — the controller/proxy open exactly one Postgres connection.

## user/database characters (review follow-up)
`user`/`database` are embedded verbatim. Tested `pg-connection-string` 2.4.0: percent-encoding does **not** round-trip (userinfo is decoded *before* the `:` split; the path uses `decodeURI`), and Azure-style `user@servername` already parses correctly (splits on the **last** `@`). So `validateSecrets` rejects only the chars that genuinely break parsing — `:` `/` `?` `#`/whitespace in `user`, `?` `#`/whitespace in `database` — and points to options 1/3 otherwise. `@` is allowed.

## Other changes
- **`retool.agentSandbox.validateSecrets`** — fails on missing Postgres source (when inheritance is also unavailable), missing user/database on the assemble path, unsafe chars, or missing JWT public/private key.
- Controller/proxy URL block promoted to **`retool.agentSandbox.postgresUrlEnv`**.
- Chart-managed secret writes `postgres-url` only when a plaintext url is set.
- Docs in `values.yaml` lead with the inherit-by-default behavior.

## Audit of the other r2 workloads
- **mcp**: already fails when `oauthIntrospectionAuthToken` is absent. No change.
- **js_executor**: no secrets (none after #304). No change.

## Verification (`helm template`, agentSandbox.enabled=true)
| Case | Result |
|------|--------|
| subchart, `agentSandbox.postgres` unset | ✅ inherits `r2-postgresql` host + `postgres-password` |
| `config.postgresql` (plaintext pw), unset | ✅ inherits; `PGPASSWORD` from `postgresql-password`; port defaults 5432 |
| `config.postgresql.passwordSecretName`, unset | ✅ inherits; `PGPASSWORD` from that secret |
| external-secrets mode, unset | ❌ fails with guidance |
| `postgres.url` / `urlSecretName` / `externalSecret` | ✅ overrides inheritance |
| assemble + `passwordSecretName` / plaintext (incl. `p@ss/w:rd`) | ✅ `PGPASSWORD`; URL omits password |
| assemble `user=admin@pg` (Azure) | ✅ `postgres://admin@pg@host:5432/db` |
| assemble `user` `:`/`/`, `database` `?`/`#` | ❌ fails with guidance |
| missing jwt public / jwt private | ❌ fails (distinct messages) |
| `agentSandbox.enabled=false` | ✅ no-op |

Both values.yaml copies stay in sync; `helm lint` passes; no CI fixture enables agentSandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)