### PR TITLE
[feat][r2] optionally split rrGitServer into its own deployment

### DIFF
--- a/charts/retool/ci/test-rr-git-server-separate-option.yaml
+++ b/charts/retool/ci/test-rr-git-server-separate-option.yaml
@@ -1,0 +1,38 @@
+podDisruptionBudget:
+  minAvailable: 1
+
+rrGitServer:
+  enabled: true
+  repackThreshold: 200
+  separate:
+    enabled: true
+    replicaCount: 2
+    port: 3010
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+    annotations:
+      test-pod-annotation: "true"
+    labels:
+      test-pod-label: "true"
+    service:
+      annotations:
+        test-service-annotation: "true"
+      labels:
+        test-service-label: "true"
+
+blobStorage:
+  s3:
+    bucket: test-rr-bucket
+    region: us-east-1
+    accessKeyId: AKIATEST
+    secretAccessKeySecretName: rr-blob-storage
+    secretAccessKeySecretKey: secret-access-key
+
+# Exercise the MCP auto-wiring to the standalone git server service.
+mcp:
+  enabled: true
+  config:
+    oauthMainDomain: https://oauth.example.com
+    oauthIntrospectionAuthToken: test-oauth-introspection-token

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -682,6 +682,112 @@ Set MCP server service name
 {{- end -}}
 
 {{/*
+Set git server deployment/service name (only used when rrGitServer.separate is enabled)
+*/}}
+{{- define "retool.rrGitServer.name" -}}
+{{ template "retool.fullname" . }}-git-server
+{{- end -}}
+
+{{/*
+Returns "1" when the git server should run as its own deployment/service
+(rrGitServer.enabled AND rrGitServer.separate.enabled), empty otherwise.
+*/}}
+{{- define "retool.rrGitServer.separateEnabled" -}}
+{{- if and .Values.rrGitServer.enabled (.Values.rrGitServer.separate | default dict).enabled -}}
+1
+{{- end -}}
+{{- end -}}
+
+{{/*
+Port the standalone git server listens on (RR_GIT_SERVER_PORT) and exposes via its service.
+*/}}
+{{- define "retool.rrGitServer.port" -}}
+{{- (.Values.rrGitServer.separate | default dict).port | default 3010 -}}
+{{- end -}}
+
+{{/*
+In-cluster URL of the standalone git server service, e.g. http://<release>-git-server:3010.
+Used to point the MCP server (and any other consumer) at the split-out git server.
+*/}}
+{{- define "retool.rrGitServer.url" -}}
+http://{{ template "retool.rrGitServer.name" . }}:{{ include "retool.rrGitServer.port" . }}
+{{- end -}}
+
+{{/*
+Blob-storage + git repack env vars shared by the in-process git server (main
+backend) and the standalone git server deployment. git_server stores all
+objects/packs in blob storage; the same RR_DEFAULT_* vars are also used by
+snapshots. Emits nothing when no blobStorage provider is configured (in which
+case the user is expected to plumb RR_BLOB_STORAGE_PROVIDER / RR_DEFAULT_*
+directly via environmentVariables / environmentSecrets).
+*/}}
+{{- define "retool.rrGitServer.commonEnv" -}}
+{{- $bs := .Values.blobStorage | default dict }}
+{{- if $bs.s3 }}
+- name: RR_BLOB_STORAGE_PROVIDER
+  value: "s3"
+- name: RR_DEFAULT_S3_BUCKET
+  value: {{ $bs.s3.bucket | quote }}
+{{- if $bs.s3.region }}
+- name: RR_DEFAULT_S3_REGION
+  value: {{ $bs.s3.region | quote }}
+{{- end }}
+{{- if $bs.s3.endpoint }}
+- name: RR_DEFAULT_S3_ENDPOINT
+  value: {{ $bs.s3.endpoint | quote }}
+{{- end }}
+{{- if $bs.s3.accessKeyId }}
+- name: RR_DEFAULT_S3_ACCESS_KEY_ID
+  value: {{ $bs.s3.accessKeyId | quote }}
+{{- end }}
+{{- if $bs.s3.secretAccessKeySecretName }}
+- name: RR_DEFAULT_S3_SECRET_ACCESS_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ $bs.s3.secretAccessKeySecretName }}
+      key: {{ $bs.s3.secretAccessKeySecretKey | default "secret-access-key" }}
+{{- else if $bs.s3.secretAccessKey }}
+- name: RR_DEFAULT_S3_SECRET_ACCESS_KEY
+  value: {{ $bs.s3.secretAccessKey | quote }}
+{{- end }}
+{{- else if $bs.gcs }}
+- name: RR_BLOB_STORAGE_PROVIDER
+  value: "gcs"
+- name: RR_DEFAULT_GCS_BUCKET
+  value: {{ $bs.gcs.bucket | quote }}
+{{- if $bs.gcs.credentialsSecretName }}
+- name: RR_DEFAULT_GCS_CREDENTIALS
+  valueFrom:
+    secretKeyRef:
+      name: {{ $bs.gcs.credentialsSecretName }}
+      key: {{ $bs.gcs.credentialsSecretKey | default "credentials.json" }}
+{{- else if $bs.gcs.credentials }}
+- name: RR_DEFAULT_GCS_CREDENTIALS
+  value: {{ $bs.gcs.credentials | quote }}
+{{- end }}
+{{- else if $bs.azure }}
+- name: RR_BLOB_STORAGE_PROVIDER
+  value: "azure"
+- name: RR_DEFAULT_AZURE_CONTAINER
+  value: {{ $bs.azure.container | quote }}
+{{- if $bs.azure.connectionStringSecretName }}
+- name: RR_DEFAULT_AZURE_CONNECTION_STRING
+  valueFrom:
+    secretKeyRef:
+      name: {{ $bs.azure.connectionStringSecretName }}
+      key: {{ $bs.azure.connectionStringSecretKey | default "connection-string" }}
+{{- else if $bs.azure.connectionString }}
+- name: RR_DEFAULT_AZURE_CONNECTION_STRING
+  value: {{ $bs.azure.connectionString | quote }}
+{{- end }}
+{{- end }}
+{{- if .Values.rrGitServer.repackThreshold }}
+- name: RR_GIT_REPACK_THRESHOLD
+  value: {{ .Values.rrGitServer.repackThreshold | quote }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Validate that exactly one blob-storage provider is configured when rrGitServer
 is enabled. Skipped when the user has plumbed the RR_BLOB_STORAGE_PROVIDER /
 RR_DEFAULT_*_* env vars in directly via env/environmentVariables/environmentSecrets,

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -101,7 +101,11 @@ spec:
           {{- if not ( include "retool.jobRunner.enabled" . ) }}
             {{- $serviceType = append $serviceType "JOBS_RUNNER" }}
           {{- end }}
-          {{- if .Values.rrGitServer.enabled }}
+          {{- /*
+            Run the git server in-process on the main backend unless it has been
+            split out into its own deployment (rrGitServer.separate.enabled).
+          */}}
+          {{- if and .Values.rrGitServer.enabled (not (include "retool.rrGitServer.separateEnabled" .)) }}
             {{- $serviceType = append $serviceType "RR_GIT_SERVER" }}
           {{- end }}
           - name: SERVICE_TYPE
@@ -257,68 +261,18 @@ spec:
           {{- end }}
           {{- end }}
           {{- if .Values.rrGitServer.enabled }}
-          {{- $bs := .Values.blobStorage }}
-          {{- if $bs.s3 }}
-          - name: RR_BLOB_STORAGE_PROVIDER
-            value: "s3"
-          - name: RR_DEFAULT_S3_BUCKET
-            value: {{ $bs.s3.bucket | quote }}
-          {{- if $bs.s3.region }}
-          - name: RR_DEFAULT_S3_REGION
-            value: {{ $bs.s3.region | quote }}
-          {{- end }}
-          {{- if $bs.s3.endpoint }}
-          - name: RR_DEFAULT_S3_ENDPOINT
-            value: {{ $bs.s3.endpoint | quote }}
-          {{- end }}
-          {{- if $bs.s3.accessKeyId }}
-          - name: RR_DEFAULT_S3_ACCESS_KEY_ID
-            value: {{ $bs.s3.accessKeyId | quote }}
-          {{- end }}
-          {{- if $bs.s3.secretAccessKeySecretName }}
-          - name: RR_DEFAULT_S3_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: {{ $bs.s3.secretAccessKeySecretName }}
-                key: {{ $bs.s3.secretAccessKeySecretKey | default "secret-access-key" }}
-          {{- else if $bs.s3.secretAccessKey }}
-          - name: RR_DEFAULT_S3_SECRET_ACCESS_KEY
-            value: {{ $bs.s3.secretAccessKey | quote }}
-          {{- end }}
-          {{- else if $bs.gcs }}
-          - name: RR_BLOB_STORAGE_PROVIDER
-            value: "gcs"
-          - name: RR_DEFAULT_GCS_BUCKET
-            value: {{ $bs.gcs.bucket | quote }}
-          {{- if $bs.gcs.credentialsSecretName }}
-          - name: RR_DEFAULT_GCS_CREDENTIALS
-            valueFrom:
-              secretKeyRef:
-                name: {{ $bs.gcs.credentialsSecretName }}
-                key: {{ $bs.gcs.credentialsSecretKey | default "credentials.json" }}
-          {{- else if $bs.gcs.credentials }}
-          - name: RR_DEFAULT_GCS_CREDENTIALS
-            value: {{ $bs.gcs.credentials | quote }}
-          {{- end }}
-          {{- else if $bs.azure }}
-          - name: RR_BLOB_STORAGE_PROVIDER
-            value: "azure"
-          - name: RR_DEFAULT_AZURE_CONTAINER
-            value: {{ $bs.azure.container | quote }}
-          {{- if $bs.azure.connectionStringSecretName }}
-          - name: RR_DEFAULT_AZURE_CONNECTION_STRING
-            valueFrom:
-              secretKeyRef:
-                name: {{ $bs.azure.connectionStringSecretName }}
-                key: {{ $bs.azure.connectionStringSecretKey | default "connection-string" }}
-          {{- else if $bs.azure.connectionString }}
-          - name: RR_DEFAULT_AZURE_CONNECTION_STRING
-            value: {{ $bs.azure.connectionString | quote }}
-          {{- end }}
-          {{- end }}
-          {{- if .Values.rrGitServer.repackThreshold }}
-          - name: RR_GIT_REPACK_THRESHOLD
-            value: {{ .Values.rrGitServer.repackThreshold | quote }}
+          {{- if include "retool.rrGitServer.separateEnabled" . }}
+          {{- /*
+            git server runs in its own deployment; point the main backend's
+            proxy (/api/ai/rr/git/v2/*) at the git-server service instead of
+            localhost.
+          */}}
+          - name: RR_GIT_SERVER_HOST
+            value: {{ template "retool.rrGitServer.name" . }}
+          - name: RR_GIT_SERVER_PORT
+            value: {{ include "retool.rrGitServer.port" . | quote }}
+          {{- else }}
+          {{- include "retool.rrGitServer.commonEnv" . | nindent 10 }}
           {{- end }}
           {{- end }}
           {{- include "retool.env" .Values.env | nindent 10 }}

--- a/charts/retool/templates/deployment_git_server.yaml
+++ b/charts/retool/templates/deployment_git_server.yaml
@@ -1,0 +1,296 @@
+{{- if include "retool.rrGitServer.separateEnabled" . }}
+{{- include "retool.rrGitServer.validateBlobStorage" . }}
+{{- $gitServerPort := include "retool.rrGitServer.port" . }}
+{{- $gitServerValues := .Values.rrGitServer.separate }}
+{{- $gitServerService := $gitServerValues.service | default dict }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "retool.rrGitServer.name" . }}
+  labels:
+    {{- include "retool.labels" . | nindent 4 }}
+  {{- with $gitServerService.labels }}
+  {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+  {{- with $gitServerService.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  selector:
+    retoolService: {{ template "retool.rrGitServer.name" . }}
+  ports:
+  - name: http-server
+    protocol: TCP
+    port: {{ $gitServerPort }}
+    targetPort: {{ $gitServerPort }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "retool.rrGitServer.name" . }}
+  labels:
+{{- include "retool.labels" . | nindent 4 }}
+{{- if .Values.deployment.annotations }}
+  annotations:
+{{ toYaml .Values.deployment.annotations | indent 4 }}
+{{- end }}
+spec:
+  replicas: {{ $gitServerValues.replicaCount | default 1 }}
+  selector:
+    matchLabels:
+      retoolService: {{ template "retool.rrGitServer.name" . }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  template:
+    metadata:
+      annotations:
+{{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
+{{- with $gitServerValues.annotations }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+      labels:
+        {{- include "retool.labels" . | nindent 8 }}
+        retoolService: {{ template "retool.rrGitServer.name" . }}
+        telemetry.retool.com/service-name: rr-git-server
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
+{{- with $gitServerValues.labels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+    spec:
+      serviceAccountName: {{ template "retool.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
+{{- if .Values.initContainers }}
+      initContainers:
+{{- range $key, $value := .Values.initContainers }}
+      - name: "{{ $key }}"
+{{ toYaml $value | indent 8 }}
+{{- end }}
+{{- end }}
+      containers:
+      - name: rr-git-server
+        image: "{{ .Values.image.repository }}:{{ required "Please set a value for .Values.image.tag" .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+          - bash
+          - -c
+          - chmod -R +x ./docker_scripts; sync; ./docker_scripts/wait-for-it.sh -t 0 {{ template "retool.postgresql.host" . }}:{{ template "retool.postgresql.port" . }}; ./docker_scripts/start_api.sh
+        {{- if .Values.commandline.args }}
+{{ toYaml .Values.commandline.args | indent 10 }}
+        {{- end }}
+        env:
+          - name: DEPLOYMENT_TEMPLATE_TYPE
+            value: {{ template "retool.deploymentTemplateType" . }}
+          - name: DEPLOYMENT_TEMPLATE_VERSION
+            value: {{ template "retool.deploymentTemplateVersion" . }}
+          - name: NODE_ENV
+            value: production
+          - name: SERVICE_TYPE
+            value: RR_GIT_SERVER
+          - name: RR_GIT_SERVER_PORT
+            value: {{ $gitServerPort | quote }}
+          # The standalone git server does not run migrations; the main backend owns them.
+          - name: DISABLE_DATABASE_MIGRATIONS
+            value: "true"
+          - name: COOKIE_INSECURE
+            value: {{ .Values.config.useInsecureCookies | quote }}
+          - name: POSTGRES_HOST
+            value: {{ template "retool.postgresql.host" . }}
+          - name: POSTGRES_PORT
+            value: {{ template "retool.postgresql.port" . }}
+          - name: POSTGRES_DB
+            value: {{ template "retool.postgresql.database" . }}
+          - name: POSTGRES_USER
+            value: {{ template "retool.postgresql.user" . }}
+          - name: POSTGRES_SSL_ENABLED
+            value: {{ template "retool.postgresql.ssl_enabled" . }}
+
+          {{- include "retool.telemetry.includeEnvVars" . | nindent 10 }}
+
+          {{- if include "shouldIncludeConfigSecretsEnvVars" . }}
+          - name: LICENSE_KEY
+            valueFrom:
+              secretKeyRef:
+                {{- if .Values.config.licenseKeySecretName }}
+                name: {{ .Values.config.licenseKeySecretName }}
+                key: {{ .Values.config.licenseKeySecretKey | default "license-key" }}
+                {{- else }}
+                name: {{ template "retool.fullname" . }}
+                key: license-key
+                {{- end }}
+          - name: JWT_SECRET
+            valueFrom:
+              secretKeyRef:
+                {{- if .Values.config.jwtSecretSecretName }}
+                name: {{ .Values.config.jwtSecretSecretName }}
+                key: {{ .Values.config.jwtSecretSecretKey | default "jwt-secret" }}
+                {{- else }}
+                name: {{ template "retool.fullname" . }}
+                key: jwt-secret
+                {{- end }}
+          - name: ENCRYPTION_KEY
+            valueFrom:
+              secretKeyRef:
+                {{- if .Values.config.encryptionKeySecretName }}
+                name: {{ .Values.config.encryptionKeySecretName }}
+                key: {{ .Values.config.encryptionKeySecretKey | default "encryption-key" }}
+                {{- else }}
+                name: {{ template "retool.fullname" . }}
+                key: encryption-key
+                {{- end }}
+          - name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+          {{- if .Values.postgresql.enabled }}
+                name: {{ template "retool.postgresql.fullname" . }}
+                # `postgres` is the default admin username for postgres in the subchart we use, so it needs the admin password
+                # if a different username is picked, then it needs the custom password instead.
+                {{- if eq .Values.postgresql.auth.username "postgres" }}
+                key: postgres-password
+                {{- else }}
+                key: password
+                {{- end }}
+          {{- else }}
+                {{- if .Values.config.postgresql.passwordSecretName }}
+                name: {{ .Values.config.postgresql.passwordSecretName }}
+                key: {{ .Values.config.postgresql.passwordSecretKey | default "postgresql-password" }}
+                {{- else }}
+                name: {{ template "retool.fullname" . }}
+                key: postgresql-password
+                {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- include "retool.rrGitServer.commonEnv" . | nindent 10 }}
+          {{- include "retool.env" .Values.env | nindent 10 }}
+          {{- range .Values.environmentSecrets }}
+          - name: {{ .name }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ .secretKeyRef.name }}
+                key: {{ .secretKeyRef.key }}
+          {{- end }}
+          {{- with .Values.environmentVariables }}
+{{ toYaml . | indent 10 }}
+          {{- end }}
+        {{- if .Values.externalSecrets.enabled }}
+        envFrom:
+        - secretRef:
+            name: {{ .Values.externalSecrets.name }}
+        {{- range .Values.externalSecrets.secrets }}
+        - secretRef:
+            name: {{ .name }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.externalSecrets.externalSecretsOperator.enabled }}
+        envFrom:
+        {{- range .Values.externalSecrets.externalSecretsOperator.secretRef }}
+        - secretRef:
+            name: {{ .name }}
+            optional: {{ .optional | default false }}
+        {{- end }}
+        {{- end }}
+        ports:
+        - containerPort: {{ $gitServerPort }}
+          name: http-server
+          protocol: TCP
+        readinessProbe:
+          tcpSocket:
+            port: {{ $gitServerPort }}
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: {{ $gitServerPort }}
+          initialDelaySeconds: 30
+          failureThreshold: 10
+          timeoutSeconds: 10
+          periodSeconds: 20
+        resources:
+{{ toYaml ($gitServerValues.resources | default .Values.resources) | indent 10 }}
+        volumeMounts:
+        {{- range $configFile := (keys .Values.files) }}
+        - name: {{ template "retool.name" $ }}
+          mountPath: "/usr/share/retool/config/{{ $configFile }}"
+          subPath: {{ $configFile }}
+        {{- end }}
+        {{if and .Values.persistentVolumeClaim.enabled .Values.persistentVolumeClaim.mountPath }}
+        - name: retool-pv
+          mountPath: {{ .Values.persistentVolumeClaim.mountPath }}
+        {{- end }}
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 8 }}
+{{- end }}
+{{- if .Values.securityContext.extraContainerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.securityContext.extraContainerSecurityContext | indent 10 }}
+{{- end }}
+{{- with .Values.extraContainers }}
+{{ tpl . $ | indent 6 }}
+{{- end }}
+{{- range .Values.extraConfigMapMounts }}
+        - name: {{ .name }}
+          mountPath: {{ .mountPath }}
+          subPath: {{ .subPath }}
+{{- end }}
+    {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.image.pullSecrets | indent 8 }}
+    {{- end }}
+    {{- $affinity := $gitServerValues.affinity | default .Values.affinity }}
+    {{- if $affinity }}
+      affinity:
+{{ toYaml $affinity | indent 8 }}
+    {{- end }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+{{- if .Values.securityContext.enabled }}
+      securityContext:
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+{{- if .Values.securityContext.extraSecurityContext }}
+{{ toYaml .Values.securityContext.extraSecurityContext | indent 8 }}
+{{- end }}
+{{- end }}
+      volumes:
+{{- range .Values.extraConfigMapMounts }}
+        - name: {{ .name }}
+          configMap:
+            name: {{ .configMap }}
+{{- end }}
+      {{- if .Values.persistentVolumeClaim.enabled }}
+        - name: retool-pv
+          persistentVolumeClaim:
+            claimName: {{ default (include "retool.fullname" .) .Values.persistentVolumeClaim.existingClaim }}
+      {{- end }}
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 8 }}
+{{- end }}
+{{- if .Values.podDisruptionBudget }}
+---
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.Version }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "retool.rrGitServer.name" . }}
+spec:
+  {{- toYaml .Values.podDisruptionBudget | nindent 2 }}
+  selector:
+    matchLabels:
+      retoolService: {{ template "retool.rrGitServer.name" . }}
+{{- end }}
+{{- end }}

--- a/charts/retool/templates/deployment_mcp.yaml
+++ b/charts/retool/templates/deployment_mcp.yaml
@@ -115,9 +115,17 @@ spec:
             value: {{ $mcpInternalPort | quote }}
           - name: RETOOL_BACKEND_URL
             value: {{ $mcpConfig.retoolBackendUrl | default (printf "http://%s:%v" (include "retool.fullname" .) .Values.service.externalPort) | quote }}
-          {{- if $mcpConfig.retoolGitServerUrl }}
+          {{- /*
+            Prefer an explicit mcp.config.retoolGitServerUrl; otherwise, when the
+            git server is split into its own deployment, auto-point MCP at it.
+          */}}
+          {{- $retoolGitServerUrl := $mcpConfig.retoolGitServerUrl }}
+          {{- if and (not $retoolGitServerUrl) (include "retool.rrGitServer.separateEnabled" .) }}
+          {{- $retoolGitServerUrl = include "retool.rrGitServer.url" . }}
+          {{- end }}
+          {{- if $retoolGitServerUrl }}
           - name: RETOOL_GIT_SERVER_URL
-            value: {{ $mcpConfig.retoolGitServerUrl | quote }}
+            value: {{ $retoolGitServerUrl | quote }}
           {{- end }}
           {{- if $mcpConfig.retoolUrl }}
           - name: RETOOL_URL

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -735,6 +735,34 @@ rrGitServer:
   # RR_DEFAULT_* are provided that way.
   skipBlobStorageValidation: false
 
+  # Optionally split the git server out of the main backend into its own
+  # deployment + service (mirrors how the workload is split in Retool Cloud).
+  # Requires rrGitServer.enabled: true. When enabled:
+  #   - a dedicated <release>-git-server Deployment runs SERVICE_TYPE=RR_GIT_SERVER
+  #   - the main backend drops RR_GIT_SERVER from its SERVICE_TYPE and proxies git
+  #     traffic to the service via RR_GIT_SERVER_HOST / RR_GIT_SERVER_PORT
+  #   - the MCP server (if enabled) is auto-pointed at the same service unless
+  #     mcp.config.retoolGitServerUrl is set explicitly
+  # The blobStorage config below is rendered onto the git-server pod instead of
+  # the main backend in this mode.
+  separate:
+    enabled: false
+    replicaCount: 1
+    # Port the git server listens on (RR_GIT_SERVER_PORT) and that its service exposes.
+    port: 3010
+    # Pod resource requests/limits. Falls back to top-level `resources` if unset.
+    resources: {}
+    # Falls back to top-level `affinity` if unset.
+    affinity: {}
+    # Annotations/labels applied to the git-server pod template.
+    annotations: {}
+    labels: {}
+    # Annotations/labels applied to the git-server Service (kept separate from
+    # the pod ones above).
+    service:
+      annotations: {}
+      labels: {}
+
 # Shared blob-storage config used by git_server (and other features that
 # need object storage, e.g. snapshots). Set exactly one of s3, gcs, azure.
 # Renders RR_BLOB_STORAGE_PROVIDER + RR_DEFAULT_<provider>_* env vars on

--- a/values.yaml
+++ b/values.yaml
@@ -735,6 +735,34 @@ rrGitServer:
   # RR_DEFAULT_* are provided that way.
   skipBlobStorageValidation: false
 
+  # Optionally split the git server out of the main backend into its own
+  # deployment + service (mirrors how the workload is split in Retool Cloud).
+  # Requires rrGitServer.enabled: true. When enabled:
+  #   - a dedicated <release>-git-server Deployment runs SERVICE_TYPE=RR_GIT_SERVER
+  #   - the main backend drops RR_GIT_SERVER from its SERVICE_TYPE and proxies git
+  #     traffic to the service via RR_GIT_SERVER_HOST / RR_GIT_SERVER_PORT
+  #   - the MCP server (if enabled) is auto-pointed at the same service unless
+  #     mcp.config.retoolGitServerUrl is set explicitly
+  # The blobStorage config below is rendered onto the git-server pod instead of
+  # the main backend in this mode.
+  separate:
+    enabled: false
+    replicaCount: 1
+    # Port the git server listens on (RR_GIT_SERVER_PORT) and that its service exposes.
+    port: 3010
+    # Pod resource requests/limits. Falls back to top-level `resources` if unset.
+    resources: {}
+    # Falls back to top-level `affinity` if unset.
+    affinity: {}
+    # Annotations/labels applied to the git-server pod template.
+    annotations: {}
+    labels: {}
+    # Annotations/labels applied to the git-server Service (kept separate from
+    # the pod ones above).
+    service:
+      annotations: {}
+      labels: {}
+
 # Shared blob-storage config used by git_server (and other features that
 # need object storage, e.g. snapshots). Set exactly one of s3, gcs, azure.
 # Renders RR_BLOB_STORAGE_PROVIDER + RR_DEFAULT_<provider>_* env vars on


### PR DESCRIPTION
## Summary

Adds `rrGitServer.separate.enabled` to optionally run the git server as a **dedicated deployment + service** instead of in-process on the main backend, mirroring how the workload is split in Retool Cloud. The split-out git server is reached over normal Kubernetes service discovery.

Stacks on top of the in-process git server work (`#296`), so this PR targets `r2-cleanup`.

### When `rrGitServer.separate.enabled: true`
- A dedicated `<release>-git-server` Deployment runs `SERVICE_TYPE=RR_GIT_SERVER` on `RR_GIT_SERVER_PORT`, with the Postgres connection, bootstrap secrets (license/JWT/encryption/pg password), blob-storage env, and telemetry. A matching Service (+ PDB) is rendered.
- The main backend drops `RR_GIT_SERVER` from its `SERVICE_TYPE` and proxies git traffic to the service via `RR_GIT_SERVER_HOST` / `RR_GIT_SERVER_PORT`.
- The MCP server (if enabled) is auto-pointed at the service via `RETOOL_GIT_SERVER_URL`, unless `mcp.config.retoolGitServerUrl` is set explicitly.

In-process mode (`rrGitServer.enabled` without `separate`) is **unchanged**.

### Implementation notes
- Extracted the blob-storage + repack env block into a shared helper `retool.rrGitServer.commonEnv` so the in-process backend and the standalone deployment stay in sync.
- New helpers: `retool.rrGitServer.{name,separateEnabled,port,url}`.
- Both `values.yaml` files kept byte-identical (sync check).

### ⚠️ Needs confirmation
The backend→remote git server contract uses `RR_GIT_SERVER_HOST` (bare service DNS) + `RR_GIT_SERVER_PORT`, extending the documented in-process `RR_GIT_SERVER_PORT`. If the backend expects a different var (e.g. a full URL), it's a one-line change in `deployment_backend.yaml`. Default `rrGitServer.separate.port` is `3010`.

## Testing
- `helm lint` passes.
- Rendered + verified: **separate mode** (correct Service, backend pointer, git-server env, MCP URL, `RR_GIT_SERVER` absent from backend), **in-process mode** (unchanged), and **default-off** mode. All parse as valid YAML.
- Added `ci/test-rr-git-server-separate-option.yaml` exercising the split + S3 blob storage + MCP auto-wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)