### PR TITLE
[fix[R2] Increase the AE proxy timeout to be inline with fix in retool-k8s

### DIFF
--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -1071,7 +1071,7 @@ agentSandbox:
     # Defaults to http://<fullname>:3000 (same-cluster backend service).
     backendUrl: ''
     backendDomainSuffixes: ''
-    sandboxProxyTimeoutMs: ''
+    sandboxProxyTimeoutMs: 180000 # 3 minutes
     service:
       # Set to LoadBalancer or NodePort to expose the proxy externally.
       type: ClusterIP

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -1071,7 +1071,7 @@ agentSandbox:
     # Defaults to http://<fullname>:3000 (same-cluster backend service).
     backendUrl: ''
     backendDomainSuffixes: ''
-    sandboxProxyTimeoutMs: 180000 # 3 minutes
+    sandboxProxyTimeoutMs: '180000' # 3 minutes
     service:
       # Set to LoadBalancer or NodePort to expose the proxy externally.
       type: ClusterIP

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -1071,7 +1071,7 @@ agentSandbox:
     # Defaults to http://<fullname>:3000 (same-cluster backend service).
     backendUrl: ''
     backendDomainSuffixes: ''
-    sandboxProxyTimeoutMs: '180000' # 3 minutes
+    sandboxProxyTimeoutMs: '180000'  # 3 minutes
     service:
       # Set to LoadBalancer or NodePort to expose the proxy externally.
       type: ClusterIP

--- a/values.yaml
+++ b/values.yaml
@@ -1071,7 +1071,7 @@ agentSandbox:
     # Defaults to http://<fullname>:3000 (same-cluster backend service).
     backendUrl: ''
     backendDomainSuffixes: ''
-    sandboxProxyTimeoutMs: ''
+    sandboxProxyTimeoutMs: 180000 # 3 minutes
     service:
       # Set to LoadBalancer or NodePort to expose the proxy externally.
       type: ClusterIP

--- a/values.yaml
+++ b/values.yaml
@@ -1071,7 +1071,7 @@ agentSandbox:
     # Defaults to http://<fullname>:3000 (same-cluster backend service).
     backendUrl: ''
     backendDomainSuffixes: ''
-    sandboxProxyTimeoutMs: 180000 # 3 minutes
+    sandboxProxyTimeoutMs: '180000' # 3 minutes
     service:
       # Set to LoadBalancer or NodePort to expose the proxy externally.
       type: ClusterIP

--- a/values.yaml
+++ b/values.yaml
@@ -1071,7 +1071,7 @@ agentSandbox:
     # Defaults to http://<fullname>:3000 (same-cluster backend service).
     backendUrl: ''
     backendDomainSuffixes: ''
-    sandboxProxyTimeoutMs: '180000' # 3 minutes
+    sandboxProxyTimeoutMs: '180000'  # 3 minutes
     service:
       # Set to LoadBalancer or NodePort to expose the proxy externally.
       type: ClusterIP


### PR DESCRIPTION
This brings a fix that we made over in retool-k8s to be over here too: https://app.graphite.com/github/pr/tryretool/retool-k8s/18000