### PR TITLE
[feat][plat-1012] Add opt-in seccomp sandboxing for code-executor (codeExecutor.useSeccompProfile)

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.11.0
+version: 6.12.0
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/configmap_code_executor.yaml
+++ b/charts/retool/templates/configmap_code_executor.yaml
@@ -1,5 +1,5 @@
 {{- if include "retool.workflows.enabled" . }}
-{{- if and (not .Values.codeExecutor.securityContext) (semverCompare ">=1.33-0" .Capabilities.KubeVersion.Version) }}
+{{- if and (not .Values.codeExecutor.securityContext) .Values.codeExecutor.useSeccompProfile }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/retool/templates/configmap_code_executor.yaml
+++ b/charts/retool/templates/configmap_code_executor.yaml
@@ -1,0 +1,13 @@
+{{- if include "retool.workflows.enabled" . }}
+{{- if and (not .Values.codeExecutor.securityContext) (semverCompare ">=1.33-0" .Capabilities.KubeVersion.Version) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "retool.fullname" . }}-code-executor-seccomp
+  labels:
+    {{- include "retool.labels" . | nindent 4 }}
+data:
+  nsjail-seccomp.json: |
+    {{- .Files.Get "files/nsjail-seccomp.json" | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/retool/templates/deployment_code_executor.yaml
+++ b/charts/retool/templates/deployment_code_executor.yaml
@@ -1,5 +1,5 @@
 {{- if include "retool.workflows.enabled" . }}
-{{- /* Use the less-privileged seccomp sandbox (see codeExecutor.useSeccompProfile in values.yaml) only when the operator opted in and has not pinned an explicit securityContext. */ -}}
+{{- /* Use the less-privileged seccomp sandbox (see codeExecutor.useSeccompProfile in values.yaml) only when it is enabled and no explicit codeExecutor.securityContext is set. */ -}}
 {{- $useSecComp := and (not .Values.codeExecutor.securityContext) .Values.codeExecutor.useSeccompProfile -}}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/retool/templates/deployment_code_executor.yaml
+++ b/charts/retool/templates/deployment_code_executor.yaml
@@ -27,6 +27,7 @@ spec:
       annotations:
 {{- if $useSecComp }}
         checksum/seccomp: {{ .Files.Get "files/nsjail-seccomp.json" | sha256sum }}
+        container.apparmor.security.beta.kubernetes.io/code-executor: unconfined
 {{- end }}
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}

--- a/charts/retool/templates/deployment_code_executor.yaml
+++ b/charts/retool/templates/deployment_code_executor.yaml
@@ -1,18 +1,5 @@
 {{- if include "retool.workflows.enabled" . }}
-{{- /*
-  Workflows are run securely within Code Executor via nsjail sandboxes. Creating
-  those sandboxes requires the container to have elevated privileges. By default
-  these privileges are granted by running the container as privileged
-  (securityContext.privileged: true). Setting codeExecutor.useSeccompProfile: true
-  instead grants only what nsjail needs, far more granularly than the privileged
-  flag: a slightly relaxed version of Docker's default seccomp profile, the
-  NET_ADMIN capability for network isolation, and an unmasked /proc for process
-  resource monitoring. This requires Kubernetes 1.33 or higher (for the
-  ProcMountType and UserNamespacesSupport feature gates) -- do not enable it on
-  older clusters. $useSecComp selects this less-privileged path when
-  useSeccompProfile is enabled and the operator has not pinned an explicit
-  securityContext; otherwise we fall back to privileged.
-*/ -}}
+{{- /* Use the less-privileged seccomp sandbox (see codeExecutor.useSeccompProfile in values.yaml) only when the operator opted in and has not pinned an explicit securityContext. */ -}}
 {{- $useSecComp := and (not .Values.codeExecutor.securityContext) .Values.codeExecutor.useSeccompProfile -}}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/retool/templates/deployment_code_executor.yaml
+++ b/charts/retool/templates/deployment_code_executor.yaml
@@ -1,4 +1,15 @@
 {{- if include "retool.workflows.enabled" . }}
+{{- /*
+  Workflows are run securely within Code Executor via nsjail sandboxes. Creating
+  those sandboxes requires the container to have elevated privileges. By default
+  these privileges are granted by running the container as privileged
+  (securityContext.privileged: true). On Kubernetes 1.33+ we can instead grant only
+  what nsjail needs, far more granularly than the privileged flag: a slightly
+  relaxed version of Docker's default seccomp profile, the NET_ADMIN capability for
+  network isolation, and an unmasked /proc for process resource monitoring.
+  $useSecComp selects this less-privileged path when the operator has not pinned a
+  securityContext and the cluster is >= 1.33; otherwise we fall back to privileged.
+*/ -}}
 {{- $useSecComp := and (not .Values.codeExecutor.securityContext) (semverCompare ">=1.33-0" .Capabilities.KubeVersion.Version) -}}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/retool/templates/deployment_code_executor.yaml
+++ b/charts/retool/templates/deployment_code_executor.yaml
@@ -9,6 +9,8 @@
   network isolation, and an unmasked /proc for process resource monitoring.
   $useSecComp selects this less-privileged path when the operator has not pinned a
   securityContext and the cluster is >= 1.33; otherwise we fall back to privileged.
+  To use the more fine-grained privileges, please upgrade your k8s cluster to 1.33
+  or higher.
 */ -}}
 {{- $useSecComp := and (not .Values.codeExecutor.securityContext) (semverCompare ">=1.33-0" .Capabilities.KubeVersion.Version) -}}
 apiVersion: apps/v1

--- a/charts/retool/templates/deployment_code_executor.yaml
+++ b/charts/retool/templates/deployment_code_executor.yaml
@@ -3,16 +3,17 @@
   Workflows are run securely within Code Executor via nsjail sandboxes. Creating
   those sandboxes requires the container to have elevated privileges. By default
   these privileges are granted by running the container as privileged
-  (securityContext.privileged: true). On Kubernetes 1.33+ we can instead grant only
-  what nsjail needs, far more granularly than the privileged flag: a slightly
-  relaxed version of Docker's default seccomp profile, the NET_ADMIN capability for
-  network isolation, and an unmasked /proc for process resource monitoring.
-  $useSecComp selects this less-privileged path when the operator has not pinned a
-  securityContext and the cluster is >= 1.33; otherwise we fall back to privileged.
-  To use the more fine-grained privileges, please upgrade your k8s cluster to 1.33
-  or higher.
+  (securityContext.privileged: true). Setting codeExecutor.useSeccompProfile: true
+  instead grants only what nsjail needs, far more granularly than the privileged
+  flag: a slightly relaxed version of Docker's default seccomp profile, the
+  NET_ADMIN capability for network isolation, and an unmasked /proc for process
+  resource monitoring. This requires Kubernetes 1.33 or higher (for the
+  ProcMountType and UserNamespacesSupport feature gates) -- do not enable it on
+  older clusters. $useSecComp selects this less-privileged path when
+  useSeccompProfile is enabled and the operator has not pinned an explicit
+  securityContext; otherwise we fall back to privileged.
 */ -}}
-{{- $useSecComp := and (not .Values.codeExecutor.securityContext) (semverCompare ">=1.33-0" .Capabilities.KubeVersion.Version) -}}
+{{- $useSecComp := and (not .Values.codeExecutor.securityContext) .Values.codeExecutor.useSeccompProfile -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/retool/templates/deployment_code_executor.yaml
+++ b/charts/retool/templates/deployment_code_executor.yaml
@@ -1,4 +1,5 @@
 {{- if include "retool.workflows.enabled" . }}
+{{- $useSecComp := and (not .Values.codeExecutor.securityContext) (semverCompare ">=1.33-0" .Capabilities.KubeVersion.Version) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -23,6 +24,9 @@ spec:
   template:
     metadata:
       annotations:
+{{- if $useSecComp }}
+        checksum/seccomp: {{ .Files.Get "files/nsjail-seccomp.json" | sha256sum }}
+{{- end }}
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
@@ -44,11 +48,43 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
-{{- if .Values.initContainers }}
+{{- if $useSecComp }}
+      hostUsers: false
+{{- end }}
+{{- if or $useSecComp .Values.initContainers }}
       initContainers:
+{{- if $useSecComp }}
+        - name: install-seccomp
+          image: busybox:1.37.0@sha256:b3255e7dfbcd10cb367af0d409747d511aeb66dfac98cf30e97e87e4207dd76f
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 1m
+              memory: 4Mi
+            limits:
+              cpu: 10m
+              memory: 16Mi
+          command:
+            - /bin/sh
+            - -c
+            - |
+              DEST="/host-seccomp/{{ .Values.codeExecutor.seccompLocalhostProfile }}"
+              mkdir -p "$(dirname "$DEST")"
+              cp /seccomp-profile/nsjail-seccomp.json "$DEST"
+              echo "seccomp profile installed at $DEST"
+          volumeMounts:
+            - name: seccomp-profile
+              mountPath: /seccomp-profile
+            - name: host-seccomp
+              mountPath: /host-seccomp
+{{- end }}
 {{- range $key, $value := .Values.initContainers }}
-      - name: "{{ $key }}"
-{{ toYaml $value | indent 8 }}
+        - name: "{{ $key }}"
+{{ toYaml $value | indent 10 }}
 {{- end }}
 {{- end }}
       containers:
@@ -56,11 +92,18 @@ spec:
         image: "{{ .Values.codeExecutor.image.repository }}:{{ include "retool.codeExecutor.image.tag" . }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:
-          {{ if .Values.codeExecutor.securityContext }}
+          {{- if .Values.codeExecutor.securityContext }}
 {{ toYaml .Values.codeExecutor.securityContext | indent 10 }}
-          {{ else }}
+          {{- else if $useSecComp }}
+          capabilities:
+            add: ["NET_ADMIN"]
+          procMount: Unmasked
+          seccompProfile:
+            type: Localhost
+            localhostProfile: {{ .Values.codeExecutor.seccompLocalhostProfile }}
+          {{- else }}
           privileged: true
-          {{ end }}
+          {{- end }}
           {{- if .Values.securityContext.extraContainerSecurityContext }}
 {{ toYaml .Values.securityContext.extraContainerSecurityContext | indent 10 }}
           {{- end }}
@@ -128,6 +171,15 @@ spec:
 {{ tpl . $ | indent 6 }}
 {{- end }}
       volumes:
+{{- if $useSecComp }}
+        - name: seccomp-profile
+          configMap:
+            name: {{ template "retool.fullname" . }}-code-executor-seccomp
+        - name: host-seccomp
+          hostPath:
+            path: /var/lib/kubelet/seccomp
+            type: DirectoryOrCreate
+{{- end }}
 {{- if .Values.codeExecutor.volumes }}
 {{ toYaml .Values.codeExecutor.volumes | indent 8 }}
 {{- end }}

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -798,11 +798,20 @@ codeExecutor:
       cpu: 1000m
       memory: 1024Mi
 
-  # code executor uses nsjail to sandbox code execution. nsjail requires privileged container access.
-  # If your deployment does not support privileged access, you can set `privileged` to false to not
-  # use nsjail. Without nsjail, all code is run without sandboxing within your deployment.
-  securityContext:
-    privileged: true
+  # The code executor uses nsjail to sandbox code execution.
+  # On Kubernetes >= 1.33 it runs unprivileged using a localhost seccomp profile,
+  # NET_ADMIN, an unmasked /proc, and user namespaces (the profile is installed onto
+  # the node by an init container, the same way the JS executor does it). On older
+  # clusters it falls back to privileged mode, which nsjail also requires.
+  # Uncomment securityContext below to force a specific mode regardless of cluster
+  # version (e.g. `privileged: true`, or `privileged: false` to disable nsjail
+  # sandboxing entirely).
+  # securityContext:
+  #   privileged: true
+
+  # Path (relative to the kubelet seccomp root, /var/lib/kubelet/seccomp) at which
+  # the seccomp profile is installed and referenced when running unprivileged.
+  seccompLocalhostProfile: profiles/nsjail-seccomp.json
 
 # JS Executor
 jsExecutor:

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -798,11 +798,16 @@ codeExecutor:
       cpu: 1000m
       memory: 1024Mi
 
-  # The code executor uses nsjail to sandbox code execution, which requires elevated
-  # privileges. By default the container runs privileged. Set useSeccompProfile: true
-  # to instead run unprivileged with a localhost seccomp profile, the NET_ADMIN
-  # capability, and an unmasked /proc. This requires Kubernetes 1.33 or higher; do
-  # not enable it on older clusters.
+  # The code executor runs workflow code inside nsjail sandboxes, which require
+  # elevated privileges to create. By default these are granted by running the
+  # container as privileged (securityContext.privileged: true). Set
+  # useSeccompProfile: true to instead grant only what nsjail needs, far more
+  # granularly than the privileged flag: a slightly relaxed version of Docker's
+  # default seccomp profile, the NET_ADMIN capability for network isolation, and an
+  # unmasked /proc for process resource monitoring. This requires Kubernetes 1.33 or
+  # higher (for the ProcMountType and UserNamespacesSupport feature gates) -- do not
+  # enable it on older clusters. Pinning codeExecutor.securityContext overrides both
+  # paths and is used verbatim.
   useSeccompProfile: false
   seccompLocalhostProfile: profiles/nsjail-seccomp.json
 

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -798,19 +798,6 @@ codeExecutor:
       cpu: 1000m
       memory: 1024Mi
 
-  # The code executor uses nsjail to sandbox code execution.
-  # On Kubernetes >= 1.33 it runs unprivileged using a localhost seccomp profile,
-  # NET_ADMIN, an unmasked /proc, and user namespaces (the profile is installed onto
-  # the node by an init container, the same way the JS executor does it). On older
-  # clusters it falls back to privileged mode, which nsjail also requires.
-  # Uncomment securityContext below to force a specific mode regardless of cluster
-  # version (e.g. `privileged: true`, or `privileged: false` to disable nsjail
-  # sandboxing entirely).
-  # securityContext:
-  #   privileged: true
-
-  # Path (relative to the kubelet seccomp root, /var/lib/kubelet/seccomp) at which
-  # the seccomp profile is installed and referenced when running unprivileged.
   seccompLocalhostProfile: profiles/nsjail-seccomp.json
 
 # JS Executor

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -798,6 +798,12 @@ codeExecutor:
       cpu: 1000m
       memory: 1024Mi
 
+  # The code executor uses nsjail to sandbox code execution, which requires elevated
+  # privileges. By default the container runs privileged. Set useSeccompProfile: true
+  # to instead run unprivileged with a localhost seccomp profile, the NET_ADMIN
+  # capability, and an unmasked /proc. This requires Kubernetes 1.33 or higher; do
+  # not enable it on older clusters.
+  useSeccompProfile: false
   seccompLocalhostProfile: profiles/nsjail-seccomp.json
 
 # JS Executor

--- a/values.yaml
+++ b/values.yaml
@@ -798,11 +798,20 @@ codeExecutor:
       cpu: 1000m
       memory: 1024Mi
 
-  # code executor uses nsjail to sandbox code execution. nsjail requires privileged container access.
-  # If your deployment does not support privileged access, you can set `privileged` to false to not
-  # use nsjail. Without nsjail, all code is run without sandboxing within your deployment.
-  securityContext:
-    privileged: true
+  # The code executor uses nsjail to sandbox code execution.
+  # On Kubernetes >= 1.33 it runs unprivileged using a localhost seccomp profile,
+  # NET_ADMIN, an unmasked /proc, and user namespaces (the profile is installed onto
+  # the node by an init container, the same way the JS executor does it). On older
+  # clusters it falls back to privileged mode, which nsjail also requires.
+  # Uncomment securityContext below to force a specific mode regardless of cluster
+  # version (e.g. `privileged: true`, or `privileged: false` to disable nsjail
+  # sandboxing entirely).
+  # securityContext:
+  #   privileged: true
+
+  # Path (relative to the kubelet seccomp root, /var/lib/kubelet/seccomp) at which
+  # the seccomp profile is installed and referenced when running unprivileged.
+  seccompLocalhostProfile: profiles/nsjail-seccomp.json
 
 # JS Executor
 jsExecutor:

--- a/values.yaml
+++ b/values.yaml
@@ -798,11 +798,16 @@ codeExecutor:
       cpu: 1000m
       memory: 1024Mi
 
-  # The code executor uses nsjail to sandbox code execution, which requires elevated
-  # privileges. By default the container runs privileged. Set useSeccompProfile: true
-  # to instead run unprivileged with a localhost seccomp profile, the NET_ADMIN
-  # capability, and an unmasked /proc. This requires Kubernetes 1.33 or higher; do
-  # not enable it on older clusters.
+  # The code executor runs workflow code inside nsjail sandboxes, which require
+  # elevated privileges to create. By default these are granted by running the
+  # container as privileged (securityContext.privileged: true). Set
+  # useSeccompProfile: true to instead grant only what nsjail needs, far more
+  # granularly than the privileged flag: a slightly relaxed version of Docker's
+  # default seccomp profile, the NET_ADMIN capability for network isolation, and an
+  # unmasked /proc for process resource monitoring. This requires Kubernetes 1.33 or
+  # higher (for the ProcMountType and UserNamespacesSupport feature gates) -- do not
+  # enable it on older clusters. Pinning codeExecutor.securityContext overrides both
+  # paths and is used verbatim.
   useSeccompProfile: false
   seccompLocalhostProfile: profiles/nsjail-seccomp.json
 

--- a/values.yaml
+++ b/values.yaml
@@ -798,19 +798,6 @@ codeExecutor:
       cpu: 1000m
       memory: 1024Mi
 
-  # The code executor uses nsjail to sandbox code execution.
-  # On Kubernetes >= 1.33 it runs unprivileged using a localhost seccomp profile,
-  # NET_ADMIN, an unmasked /proc, and user namespaces (the profile is installed onto
-  # the node by an init container, the same way the JS executor does it). On older
-  # clusters it falls back to privileged mode, which nsjail also requires.
-  # Uncomment securityContext below to force a specific mode regardless of cluster
-  # version (e.g. `privileged: true`, or `privileged: false` to disable nsjail
-  # sandboxing entirely).
-  # securityContext:
-  #   privileged: true
-
-  # Path (relative to the kubelet seccomp root, /var/lib/kubelet/seccomp) at which
-  # the seccomp profile is installed and referenced when running unprivileged.
   seccompLocalhostProfile: profiles/nsjail-seccomp.json
 
 # JS Executor

--- a/values.yaml
+++ b/values.yaml
@@ -798,6 +798,12 @@ codeExecutor:
       cpu: 1000m
       memory: 1024Mi
 
+  # The code executor uses nsjail to sandbox code execution, which requires elevated
+  # privileges. By default the container runs privileged. Set useSeccompProfile: true
+  # to instead run unprivileged with a localhost seccomp profile, the NET_ADMIN
+  # capability, and an unmasked /proc. This requires Kubernetes 1.33 or higher; do
+  # not enable it on older clusters.
+  useSeccompProfile: false
   seccompLocalhostProfile: profiles/nsjail-seccomp.json
 
 # JS Executor


### PR DESCRIPTION
## Summary

Adds an opt-in, less-privileged sandboxing mode for the code-executor (`ce`), mirroring how the JS executor (`jsExecutor`) sandboxes itself. Addresses [PLAT-1012](https://linear.app/retool/issue/PLAT-1012/update-blessed-helm-chart-to-use-the-less-privileged-config).

By default the code-executor continues to run privileged (`securityContext.privileged: true`), so existing deployments are unchanged and the chart still installs on any Kubernetes version. Setting the new flag **`codeExecutor.useSeccompProfile: true`** instead runs the container unprivileged with:

- a localhost seccomp profile (`nsjail-seccomp.json`, the same one `jsExecutor` uses)
- `capabilities.add: [NET_ADMIN]`
- `procMount: Unmasked`
- `hostUsers: false` (user namespaces, required for `procMount: Unmasked`)
- an `install-seccomp` init container that installs the profile onto the node (same pattern as `deployment_js_executor.yaml`)

### Behavior

| `codeExecutor.useSeccompProfile` | `codeExecutor.securityContext` | Result |
|---|---|---|
| `false` (default) | unset | `privileged: true` (unchanged) |
| `true` | unset | unprivileged seccomp sandbox (profile + `NET_ADMIN` + `procMount: Unmasked` + `hostUsers: false` + init container) |
| any | set | the pinned `securityContext` is used verbatim (no scaffolding) |

### Requirements when enabling the flag

`procMount: Unmasked` and user namespaces depend on the `ProcMountType` and `UserNamespacesSupport` feature gates, which are only enabled by default on **Kubernetes 1.33+**. The flag is opt-in precisely so operators only turn it on where it's supported; enabling it on an older cluster is unsupported (the API server will strip those fields and nsjail sandboxing will not function). This keeps the chart installable on older clusters without requiring 1.33+.

## Changes

- `charts/retool/templates/deployment_code_executor.yaml` - flag-gated securityContext, `install-seccomp` init container, `hostUsers: false`, seccomp checksum annotation, seccomp volumes
- `charts/retool/templates/configmap_code_executor.yaml` (new) - embeds the seccomp profile into a ConfigMap (rendered only when the flag is set)
- `charts/retool/values.yaml` + `values.yaml` - add `codeExecutor.useSeccompProfile` (default `false`) and `codeExecutor.seccompLocalhostProfile`
- `charts/retool/Chart.yaml` - bump `6.11.0` -> `6.12.0`

## Test plan

- [x] `helm template` default (flag false), even on `--kube-version 1.34.3` -> `privileged: true`, no seccomp scaffolding
- [x] `helm template --set codeExecutor.useSeccompProfile=true` -> full seccomp path renders regardless of cluster version
- [x] `helm template` with `codeExecutor.securityContext` pinned -> override used verbatim, no scaffolding
- [x] `helm lint` passes; root `values.yaml` and `charts/retool/values.yaml` stay identical (sync check)
- [x] Validate on a live 1.33+ cluster that, with the flag enabled, the code-executor starts and the seccomp profile is installed on the node
- [x] Validate nsjail sandboxing still functions under the seccomp profile (no denied syscalls)
