### PR TITLE
ci: test coverage for r2 workloads (js-executor, agent-sandbox, r2Agent)

### DIFF
--- a/charts/retool/ci/test-agent-sandbox-enabled-option.yaml
+++ b/charts/retool/ci/test-agent-sandbox-enabled-option.yaml
@@ -1,7 +1,18 @@
-# Exercises the Agent Sandbox workload: controller + proxy deployments, the
-# job-template ConfigMap, RBAC, headless/proxy services, proxy ingress, the
-# image-prepuller + seccomp DaemonSets, the smarter-device-manager device
-# plugin DaemonSet, and the NetworkPolicies. Overlaid on test-install-values.yaml.
+# Agent Sandbox — external secret + dedicated proxy domain WITH ingress.
+#
+# This is the "max surface" scenario: controller + proxy deployments, the
+# job-template ConfigMap, RBAC, headless/proxy services, proxy ingress + TLS,
+# the image-prepuller + seccomp DaemonSets, the smarter-device-manager device
+# plugin DaemonSet, the NetworkPolicies, and both PDBs.
+#
+# Secret/Postgres sourcing here uses externalSecret.name (Postgres OPTION 4:
+# the secret's postgres-url key). The other secret/Postgres precedence paths and
+# the same-origin (no-ingress) proxy mode are covered by sibling files:
+#   - test-agent-sandbox-inline-secrets-option.yaml      (inline secrets, plaintext DSN, same-origin/no ingress, hostPath tun)
+#   - test-agent-sandbox-postgres-fields-option.yaml     (assemble DSN from fields + PGPASSWORD secret)
+#   - test-agent-sandbox-postgres-url-secret-option.yaml (full DSN from an existing secret)
+#   - test-agent-sandbox-inherit-postgres-option.yaml    (zero-config inherit of the backend Postgres)
+# Overlaid on test-install-values.yaml.
 agentSandbox:
   enabled: true
 

--- a/charts/retool/ci/test-agent-sandbox-enabled-option.yaml
+++ b/charts/retool/ci/test-agent-sandbox-enabled-option.yaml
@@ -1,0 +1,66 @@
+# Exercises the Agent Sandbox workload: controller + proxy deployments, the
+# job-template ConfigMap, RBAC, headless/proxy services, proxy ingress, the
+# image-prepuller + seccomp DaemonSets, the smarter-device-manager device
+# plugin DaemonSet, and the NetworkPolicies. Overlaid on test-install-values.yaml.
+agentSandbox:
+  enabled: true
+
+  image:
+    repository: tryretool/agent-sandbox-service
+    tag: 3.123.4
+    pullPolicy: IfNotPresent
+
+  # Reference a pre-existing K8s Secret (the production-recommended path) rather
+  # than inlining JWT/encryption material into the chart. With externalSecret.name
+  # set, secret-backed env vars — including the ones injected into the sandbox
+  # job-template — resolve via secretKeyRef instead of plaintext.
+  externalSecret:
+    name: agent-sandbox-secrets
+
+  postgres:
+    schema: agent_executor
+    poolMax: 10
+
+  sandboxNetwork:
+    enabled: true
+    devicePlugin: true
+    deployDaemonSet: true
+
+  snapshotStorage:
+    s3Bucket: retool-agent-sandbox-snapshots
+    s3Endpoint: https://s3.us-east-1.amazonaws.com
+    s3Region: us-east-1
+    credentialsSecretName: agent-sandbox-s3-credentials
+
+  # replicaCount > 1 renders the controller PodDisruptionBudget.
+  controller:
+    replicaCount: 2
+
+  proxy:
+    replicaCount: 2
+    allowedDomains: api.example.com,example.com
+    backendDomainSuffixes: .example.com
+    sandboxProxyTimeoutMs: "3600000"
+    service:
+      type: ClusterIP
+    # Dedicated proxy domain → renders the proxy Ingress.
+    ingress:
+      enabled: true
+      ingressClassName: nginx
+      annotations:
+        nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+        nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+      host: sandbox.example.com
+      tls:
+        - secretName: agent-sandbox-tls
+          hosts:
+            - sandbox.example.com
+  frontendWsProxyDomain: https://sandbox.example.com
+
+  # Restrict sandbox/controller/proxy traffic → renders the NetworkPolicies.
+  networkPolicy:
+    enabled: true
+
+# Exercise the proxy PodDisruptionBudget branch.
+podDisruptionBudget:
+  maxUnavailable: 1

--- a/charts/retool/ci/test-agent-sandbox-inherit-postgres-option.yaml
+++ b/charts/retool/ci/test-agent-sandbox-inherit-postgres-option.yaml
@@ -1,0 +1,20 @@
+# Agent Sandbox — Postgres sourcing OPTION 5 (default): inherit the backend's
+# Postgres connection. With agentSandbox.postgres left entirely unset, the
+# controller/proxy reuse config.postgresql / the postgresql subchart (same
+# instance and database, separate schema) — the zero-config path for enabling
+# the sandbox on an existing deployment. PGPASSWORD mirrors the backend's
+# POSTGRES_PASSWORD secretKeyRef, and the DSN is assembled from the postgresql
+# helpers. The base test-install-values.yaml enables the postgresql subchart,
+# which is what makes inheritance resolve.
+#
+# Only the (required) JWT secrets are provided; everything else is left default.
+agentSandbox:
+  enabled: true
+
+  image:
+    repository: tryretool/agent-sandbox-service
+    tag: 3.123.4
+    pullPolicy: IfNotPresent
+
+  jwtPublicKey: '-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEljtqa2nhBwe/PqNhWgPHhj0jv8AI\nY+QUCicYtfv9wLGcEGPQuXoBQtuoIuOwXOdbEWgrQyLdIEb0YjegAW3miA==\n-----END PUBLIC KEY-----'
+  jwtPrivateKey: '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMFXLiN/YsJv89D2YkEZ6/Dj5fujghENmYTOilwdChU3oAoGCCqGSM49\nAwEHoUQDQgAEljtqa2nhBwe/PqNhWgPHhj0jv8AIY+QUCicYtfv9wLGcEGPQuXoB\nQtuoIuOwXOdbEWgrQyLdIEb0YjegAW3miA==\n-----END EC PRIVATE KEY-----'

--- a/charts/retool/ci/test-agent-sandbox-inline-secrets-option.yaml
+++ b/charts/retool/ci/test-agent-sandbox-inline-secrets-option.yaml
@@ -1,0 +1,46 @@
+# Agent Sandbox — inline secrets + plaintext DSN + same-origin proxy (no ingress).
+#
+# Complements test-agent-sandbox-enabled-option.yaml (external secret + dedicated
+# proxy ingress). Here we exercise the *other* halves of those branches:
+#   - Secrets inline (no externalSecret.name) → the chart renders its own Secret
+#     (jwt-public-key / jwt-private-key / encryption-key / api-secret). jwtPublicKey
+#     MUST be single-line: it is injected raw into the sandbox job-template JSON.
+#   - Postgres sourcing OPTION 1: plaintext DSN via postgres.url.
+#   - Same-origin proxy: no dedicated proxy domain and no proxy ingress — the
+#     backend reverse-proxies /sandbox/* (frontendWsProxyDomain left empty).
+#   - sandboxNetwork.devicePlugin=false → sandbox pods get /dev/net/tun via
+#     hostPath (the non-device-plugin branch), and no device-manager DaemonSet.
+#   - networkPolicy disabled.
+agentSandbox:
+  enabled: true
+
+  image:
+    repository: tryretool/agent-sandbox-service
+    tag: 3.123.4
+    pullPolicy: IfNotPresent
+
+  jwtPublicKey: '-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEljtqa2nhBwe/PqNhWgPHhj0jv8AI\nY+QUCicYtfv9wLGcEGPQuXoBQtuoIuOwXOdbEWgrQyLdIEb0YjegAW3miA==\n-----END PUBLIC KEY-----'
+  jwtPrivateKey: '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMFXLiN/YsJv89D2YkEZ6/Dj5fujghENmYTOilwdChU3oAoGCCqGSM49\nAwEHoUQDQgAEljtqa2nhBwe/PqNhWgPHhj0jv8AIY+QUCicYtfv9wLGcEGPQuXoB\nQtuoIuOwXOdbEWgrQyLdIEb0YjegAW3miA==\n-----END EC PRIVATE KEY-----'
+  encryptionKey: a12b01429fe0fe69a80da94e9e837ab2f1e9bda378ed8a25905a238f6fea6b7a
+  apiSecret: test-agent-sandbox-api-secret
+
+  # Option 1: plaintext DSN.
+  postgres:
+    url: postgres://retool:retool@agent-sandbox-db.example.internal:5432/agent_sandbox
+    schema: agent_executor
+    poolMax: 10
+
+  sandboxNetwork:
+    enabled: true
+    devicePlugin: false
+    deployDaemonSet: false
+
+  proxy:
+    # Same-origin: ClusterIP service, no ingress.
+    service:
+      type: ClusterIP
+    ingress:
+      enabled: false
+
+  networkPolicy:
+    enabled: false

--- a/charts/retool/ci/test-agent-sandbox-postgres-fields-option.yaml
+++ b/charts/retool/ci/test-agent-sandbox-postgres-fields-option.yaml
@@ -1,0 +1,39 @@
+# Agent Sandbox — Postgres sourcing OPTION 2: assemble the DSN from discrete
+# fields, with the password supplied via PGPASSWORD from a pre-existing Secret
+# (never embedded in the URL, so any password characters are safe).
+#
+# Also exercises:
+#   - An Azure-style "user@servername" username, which validateSecrets allows
+#     (the parser splits userinfo on the last '@').
+#   - sandboxNetwork with devicePlugin=true but deployDaemonSet=false (a
+#     smarter-device-manager already runs on the nodes, managed elsewhere) →
+#     sandbox pods request smarter-devices/net_tun but no DS is rendered.
+#   - networkPolicy enabled.
+agentSandbox:
+  enabled: true
+
+  image:
+    repository: tryretool/agent-sandbox-service
+    tag: 3.123.4
+    pullPolicy: IfNotPresent
+
+  jwtPublicKey: '-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEljtqa2nhBwe/PqNhWgPHhj0jv8AI\nY+QUCicYtfv9wLGcEGPQuXoBQtuoIuOwXOdbEWgrQyLdIEb0YjegAW3miA==\n-----END PUBLIC KEY-----'
+  jwtPrivateKey: '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMFXLiN/YsJv89D2YkEZ6/Dj5fujghENmYTOilwdChU3oAoGCCqGSM49\nAwEHoUQDQgAEljtqa2nhBwe/PqNhWgPHhj0jv8AIY+QUCicYtfv9wLGcEGPQuXoB\nQtuoIuOwXOdbEWgrQyLdIEb0YjegAW3miA==\n-----END EC PRIVATE KEY-----'
+
+  # Option 2: host + user + database, password via PGPASSWORD secretKeyRef.
+  postgres:
+    host: agentdb-prod.postgres.database.azure.com
+    port: 5432
+    database: agent_sandbox
+    user: retool@agentdb-prod
+    passwordSecretName: agent-sandbox-db-password
+    passwordSecretKey: password
+    schema: agent_executor
+
+  sandboxNetwork:
+    enabled: true
+    devicePlugin: true
+    deployDaemonSet: false
+
+  networkPolicy:
+    enabled: true

--- a/charts/retool/ci/test-agent-sandbox-postgres-url-secret-option.yaml
+++ b/charts/retool/ci/test-agent-sandbox-postgres-url-secret-option.yaml
@@ -1,0 +1,29 @@
+# Agent Sandbox — Postgres sourcing OPTION 3: the full DSN comes from a
+# pre-existing Secret (postgres.urlSecretName / urlSecretKey), while the JWT/
+# encryption secrets are provided inline. This is the "BYO DB secret, chart-
+# managed app secrets" combination.
+#
+# Also exercises S3 snapshot storage WITHOUT a dedicated credentialsSecretName,
+# so the sandbox AWS creds fall back to the default (chart-rendered) Secret.
+agentSandbox:
+  enabled: true
+
+  image:
+    repository: tryretool/agent-sandbox-service
+    tag: 3.123.4
+    pullPolicy: IfNotPresent
+
+  jwtPublicKey: '-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEljtqa2nhBwe/PqNhWgPHhj0jv8AI\nY+QUCicYtfv9wLGcEGPQuXoBQtuoIuOwXOdbEWgrQyLdIEb0YjegAW3miA==\n-----END PUBLIC KEY-----'
+  jwtPrivateKey: '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMFXLiN/YsJv89D2YkEZ6/Dj5fujghENmYTOilwdChU3oAoGCCqGSM49\nAwEHoUQDQgAEljtqa2nhBwe/PqNhWgPHhj0jv8AIY+QUCicYtfv9wLGcEGPQuXoB\nQtuoIuOwXOdbEWgrQyLdIEb0YjegAW3miA==\n-----END EC PRIVATE KEY-----'
+  encryptionKey: a12b01429fe0fe69a80da94e9e837ab2f1e9bda378ed8a25905a238f6fea6b7a
+
+  # Option 3: full DSN from an existing Secret.
+  postgres:
+    urlSecretName: agent-sandbox-db-dsn
+    urlSecretKey: connection-string
+    schema: agent_executor
+
+  snapshotStorage:
+    s3Bucket: retool-agent-sandbox-snapshots
+    s3Endpoint: https://s3.us-west-2.amazonaws.com
+    s3Region: us-west-2

--- a/charts/retool/ci/test-js-executor-enabled-option.yaml
+++ b/charts/retool/ci/test-js-executor-enabled-option.yaml
@@ -1,0 +1,28 @@
+# Exercises the JS executor workload (deployment_js_executor.yaml +
+# configmap_js_executor.yaml). Overlaid on top of test-install-values.yaml.
+jsExecutor:
+  enabled: true
+  replicaCount: 2
+  image:
+    repository: tryretool/js-executor-service
+    tag: 3.123.4
+    pullPolicy: IfNotPresent
+  # JS-executor-specific env (not inherited from top-level .Values.env).
+  env:
+    LOG_LEVEL: info
+  environmentVariables:
+    - name: JS_EXECUTOR_TEST_OPTION
+      value: "true"
+  # Memory request and limit are kept equal: JSE rejects requests at 80% of
+  # its limit, so the request must reserve the full amount.
+  resources:
+    limits:
+      cpu: 4000m
+      memory: 4Gi
+    requests:
+      cpu: 4000m
+      memory: 4Gi
+
+# Exercise the PDB branch shared by the JS executor deployment.
+podDisruptionBudget:
+  maxUnavailable: 1

--- a/charts/retool/ci/test-js-executor-enabled-option.yaml
+++ b/charts/retool/ci/test-js-executor-enabled-option.yaml
@@ -10,6 +10,12 @@ jsExecutor:
   # JS-executor-specific env (not inherited from top-level .Values.env).
   env:
     LOG_LEVEL: info
+  # Exercise the per-workload secretKeyRef branch.
+  environmentSecrets:
+    - name: JS_EXECUTOR_TOKEN
+      secretKeyRef:
+        name: js-executor-secrets
+        key: token
   environmentVariables:
     - name: JS_EXECUTOR_TEST_OPTION
       value: "true"

--- a/charts/retool/ci/test-js-executor-enabled-option.yaml
+++ b/charts/retool/ci/test-js-executor-enabled-option.yaml
@@ -6,7 +6,10 @@ jsExecutor:
   image:
     repository: tryretool/js-executor-service
     tag: 3.123.4
-    pullPolicy: IfNotPresent
+    # Deliberately differs from the global image.pullPolicy (IfNotPresent in the
+    # base values) so the rendered deployment proves the per-workload override is
+    # honored rather than the global value.
+    pullPolicy: Always
   # JS-executor-specific env (not inherited from top-level .Values.env).
   env:
     LOG_LEVEL: info

--- a/charts/retool/ci/test-r2-agent-enabled-option.yaml
+++ b/charts/retool/ci/test-r2-agent-enabled-option.yaml
@@ -1,0 +1,25 @@
+# Exercises the R2 Agent worker (the server-side agent loop worker rendered via
+# _workers.tpl as SERVICE_TYPE=R2_AGENT_TEMPORAL_WORKER on healthcheck port 3016).
+# Renders a Deployment + Service, plus a PodDisruptionBudget when one is set.
+# Overlaid on test-install-values.yaml.
+r2Agent:
+  enabled: true
+  config:
+    nodeOptions: "--max_old_space_size=2048"
+  worker:
+    replicaCount: 2
+    resources:
+      limits:
+        cpu: 2000m
+        memory: 4096Mi
+      requests:
+        cpu: 1000m
+        memory: 2048Mi
+  labels:
+    test-pod-label: "true"
+  annotations:
+    test-pod-annotation: "true"
+
+# Exercise the worker PodDisruptionBudget branch.
+podDisruptionBudget:
+  maxUnavailable: 1

--- a/charts/retool/templates/deployment_js_executor.yaml
+++ b/charts/retool/templates/deployment_js_executor.yaml
@@ -82,7 +82,7 @@ spec:
       containers:
       - name: js-executor
         image: "{{ .Values.jsExecutor.image.repository }}:{{ include "retool.jsExecutor.image.tag" . }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        imagePullPolicy: {{ .Values.jsExecutor.image.pullPolicy | default .Values.image.pullPolicy }}
         securityContext:
           capabilities:
             add: ["NET_ADMIN"]


### PR DESCRIPTION
## What

Adds CI test values for the R2 workloads and configuration surface that had no coverage under `charts/retool/ci/`. Rebased onto the latest `r2-cleanup`, which merged #308 (agent-sandbox `validateSecrets` + flexible Postgres sourcing) and #309 (split rrGitServer).

**agent-sandbox** — one option file per secret/Postgres precedence path, so every branch of `postgresUrlEnv` / `validateSecrets` gets templated, plus both proxy-exposure modes:
- `test-agent-sandbox-enabled-option.yaml` — `externalSecret.name` (Postgres **option 4**) + dedicated proxy domain **with ingress + TLS** + networkPolicy + device plugin + controller & proxy PDBs (max surface).
- `test-agent-sandbox-inline-secrets-option.yaml` — inline secrets (chart renders its own Secret) + plaintext DSN (**option 1**) + **same-origin proxy / NO ingress** + hostPath `/dev/net/tun` (devicePlugin off).
- `test-agent-sandbox-postgres-fields-option.yaml` — assemble DSN from fields + `PGPASSWORD` secretKeyRef (**option 2**), Azure-style `user@server`, external device-manager (`deployDaemonSet: false`).
- `test-agent-sandbox-postgres-url-secret-option.yaml` — full DSN from an existing Secret via `urlSecretName` (**option 3**).
- `test-agent-sandbox-inherit-postgres-option.yaml` — zero-config inherit of the backend Postgres connection (**option 5**, the default).

**r2Agent** — `test-r2-agent-enabled-option.yaml`: the server-side agent loop worker (`R2_AGENT_TEMPORAL_WORKER`, port 3016) Deployment/Service/PDB, previously untested.

**js-executor** — `test-js-executor-enabled-option.yaml`: enabled with realistic config; added `environmentSecrets` to cover the per-workload `secretKeyRef` branch.

## Why

A workload (or config branch) that's never templated in CI can break silently on a values change. The #308 secret/Postgres matrix in particular has five precedence paths and install-time `fail` guards — each now has a test that pays for itself.

## How it wires into CI

No workflow change: `.github/kubeconform.sh` (the `kubeconform-chart` matrix job) auto-discovers `*option.yaml` files and overlays each onto every base values file. (`ct lint`/`ct install` only consume `*-values.yaml`, matching existing convention.)

## Validation

Every `ci/*option.yaml` (new + pre-existing) passes `helm template` + `kubeconform --strict` against all three base values files on k8s 1.27.16 and 1.31.6 — **108 combinations**, 0 errors. Spot-checked that each Postgres branch emits the expected env (plaintext URL / `PGPASSWORD` secretKeyRef + assembled Azure DSN / `urlSecretName` ref / inherited subchart secret).

> Base is `r2-cleanup` (not `main`) — the R2 workloads only exist there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)