### PR TITLE
[feat][r2] add single r2.enabled master switch for R2 components

### DIFF
--- a/charts/retool/ci/test-r2-enabled-option.yaml
+++ b/charts/retool/ci/test-r2-enabled-option.yaml
@@ -1,0 +1,32 @@
+# R2 master switch — single flag turns on the whole R2 stack.
+#
+# Exercises the `r2.enabled: true` inherit path: r2Agent, jsExecutor,
+# agentSandbox, and mcp all leave their own `enabled` unset (null) and inherit
+# the master switch. This guards `retool.r2.componentEnabled` and the
+# helper-routed cross-component env wiring (backend/workflows/jobs/workers read
+# effective-enabled, not the raw per-component flag).
+#
+# Secrets/config below are only what each component requires to template when
+# enabled; none of them set `*.enabled`, so enablement comes solely from r2.
+r2:
+  enabled: true
+
+agentSandbox:
+  # jwtPublicKey is injected raw into the sandbox job-template JSON, so it MUST
+  # be single-line (\n-escaped) or templating breaks.
+  jwtPublicKey: '-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEljtqa2nhBwe/PqNhWgPHhj0jv8AIY+QUCicYtfv9wLGcEGPQuXoBQtuoIuOwXOdbEWgrQyLdIEb0YjegAW3miA==\n-----END PUBLIC KEY-----'
+  jwtPrivateKey: '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMFXLiN/YsJv89D2YkEZ6/Dj5fujghENmYTOilwdChU3oAoGCCqGSM49AwEHoUQDQgAEljtqa2nhBwe/PqNhWgPHhj0jv8AIY+QUCicYtfv9wLGcEGPQuXoBQtuoIuOwXOdbEWgrQyLdIEb0YjegAW3miA==\n-----END EC PRIVATE KEY-----'
+  postgres:
+    url: postgres://retool:retool@agent-sandbox-db.example.internal:5432/agent_sandbox
+    schema: agent_executor
+  proxy:
+    service:
+      type: ClusterIP
+    ingress:
+      enabled: false
+  networkPolicy:
+    enabled: false
+
+mcp:
+  config:
+    oauthIntrospectionAuthToken: test-oauth-introspection-token

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -420,15 +420,25 @@ Usage: (include "retool.agents.enabled" .)
 {{- end -}}
 
 {{/*
-Set R2 agent enabled
+Resolve whether an R2 component (r2Agent, jsExecutor, agentSandbox, mcp) is
+enabled. The component's own `enabled` wins when explicitly set to true/false;
+when left unset (null) it inherits the shared master switch .Values.r2.enabled.
+Usage: (include "retool.r2.componentEnabled" (dict "root" $ "component" "jsExecutor"))
+Returns "1" when enabled, "" otherwise.
+*/}}
+{{- define "retool.r2.componentEnabled" -}}
+{{- $cfg := index .root.Values .component -}}
+{{- if kindIs "invalid" $cfg.enabled -}}
+  {{- if eq (toString .root.Values.r2.enabled) "true" -}}1{{- end -}}
+{{- else if eq (toString $cfg.enabled) "true" -}}1{{- end -}}
+{{- end -}}
+
+{{/*
+Set R2 agent worker enabled. Honors the shared R2 master switch.
 Usage: (include "retool.r2Agent.enabled" .)
 */}}
 {{- define "retool.r2Agent.enabled" -}}
-{{- $output := "" -}}
-{{- if (eq (toString .Values.r2Agent.enabled) "true") -}}
-  {{- $output = "1" -}}
-{{- end -}}
-{{- $output -}}
+{{- include "retool.r2.componentEnabled" (dict "root" . "component" "r2Agent") -}}
 {{- end -}}
 
 {{/* Global Temporal configuration */}}
@@ -631,7 +641,7 @@ tokens. Each may come from a plaintext value, the per-key existing-secret refs,
 or the catch-all externalSecret.name. No-op when agentSandbox is disabled.
 */}}
 {{- define "retool.agentSandbox.validateSecrets" -}}
-{{- if .Values.agentSandbox.enabled -}}
+{{- if eq (include "retool.r2.componentEnabled" (dict "root" . "component" "agentSandbox")) "1" -}}
 {{- $as := .Values.agentSandbox -}}
 {{- $ext := $as.externalSecret.name -}}
 {{- $explicitPg := or $as.postgres.url $as.postgres.urlSecretName $as.postgres.host $ext -}}
@@ -762,7 +772,7 @@ Outputs env entries that tell the backend how to reach the agent sandbox service
 Usage: {{- include "retool.agentSandbox.backendEnvVars" . | nindent 10 }}
 */}}
 {{- define "retool.agentSandbox.backendEnvVars" -}}
-{{- if .Values.agentSandbox.enabled }}
+{{- if eq (include "retool.r2.componentEnabled" (dict "root" . "component" "agentSandbox")) "1" }}
 {{- $defaultSecretName := .Values.agentSandbox.externalSecret.name | default (include "retool.agentSandbox.name" .) -}}
 - name: RR_AGENT_PUBSUB_BACKEND
   value: "postgres"

--- a/charts/retool/templates/_workers.tpl
+++ b/charts/retool/templates/_workers.tpl
@@ -213,7 +213,7 @@ spec:
             value: {{ template "retool.postgresql.ssl_enabled" $ }}
           - name: CODE_EXECUTOR_INGRESS_DOMAIN
             value: http://{{ template "retool.codeExecutor.name" $ }}
-          {{- if $.Values.jsExecutor.enabled }}
+          {{- if eq (include "retool.r2.componentEnabled" (dict "root" $ "component" "jsExecutor")) "1" }}
           - name: JS_EXECUTOR_INGRESS_DOMAIN
             value: http://{{ template "retool.jsExecutor.name" $ }}
           {{- end }}

--- a/charts/retool/templates/agent_sandbox_device_plugin.yaml
+++ b/charts/retool/templates/agent_sandbox_device_plugin.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.agentSandbox.enabled .Values.agentSandbox.sandboxNetwork.deployDaemonSet }}
+{{- if and (eq (include "retool.r2.componentEnabled" (dict "root" $ "component" "agentSandbox")) "1") .Values.agentSandbox.sandboxNetwork.deployDaemonSet }}
 {{- $as := .Values.agentSandbox -}}
 {{- $nodeSelector := $as.nodeSelector | default .Values.nodeSelector -}}
 {{- $tolerations := $as.tolerations | default .Values.tolerations -}}

--- a/charts/retool/templates/agent_sandbox_networkpolicy.yaml
+++ b/charts/retool/templates/agent_sandbox_networkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.agentSandbox.enabled .Values.agentSandbox.networkPolicy.enabled }}
+{{- if and (eq (include "retool.r2.componentEnabled" (dict "root" $ "component" "agentSandbox")) "1") .Values.agentSandbox.networkPolicy.enabled }}
 {{- $as := .Values.agentSandbox -}}
 {{- /*
 =======================================================================

--- a/charts/retool/templates/agent_sandbox_prepuller.yaml
+++ b/charts/retool/templates/agent_sandbox_prepuller.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.agentSandbox.enabled }}
+{{- if eq (include "retool.r2.componentEnabled" (dict "root" $ "component" "agentSandbox")) "1" }}
 {{- $as := .Values.agentSandbox -}}
 {{- $nodeSelector := $as.nodeSelector | default .Values.nodeSelector -}}
 {{- $tolerations := $as.tolerations | default .Values.tolerations -}}

--- a/charts/retool/templates/agent_sandbox_seccomp.yaml
+++ b/charts/retool/templates/agent_sandbox_seccomp.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.agentSandbox.enabled }}
+{{- if eq (include "retool.r2.componentEnabled" (dict "root" $ "component" "agentSandbox")) "1" }}
 {{- $as := .Values.agentSandbox -}}
 {{- $nodeSelector := $as.nodeSelector | default .Values.nodeSelector -}}
 {{- $tolerations := $as.tolerations | default .Values.tolerations -}}

--- a/charts/retool/templates/configmap_js_executor.yaml
+++ b/charts/retool/templates/configmap_js_executor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.jsExecutor.enabled }}
+{{- if eq (include "retool.r2.componentEnabled" (dict "root" $ "component" "jsExecutor")) "1" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/retool/templates/deployment_agent_sandbox.yaml
+++ b/charts/retool/templates/deployment_agent_sandbox.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.agentSandbox.enabled }}
+{{- if eq (include "retool.r2.componentEnabled" (dict "root" $ "component" "agentSandbox")) "1" }}
 {{- include "retool.agentSandbox.validateSecrets" . }}
 {{- $as := .Values.agentSandbox -}}
 {{- $defaultSecretName := $as.externalSecret.name | default (include "retool.agentSandbox.name" .) -}}

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -188,7 +188,7 @@ spec:
               {{- end }}
           {{- end }}
           {{- end }}
-          {{- if .Values.jsExecutor.enabled }}
+          {{- if eq (include "retool.r2.componentEnabled" (dict "root" $ "component" "jsExecutor")) "1" }}
           - name: JS_EXECUTOR_INGRESS_DOMAIN
             value: http://{{ template "retool.jsExecutor.name" . }}
           {{- end }}

--- a/charts/retool/templates/deployment_jobs.yaml
+++ b/charts/retool/templates/deployment_jobs.yaml
@@ -93,7 +93,7 @@ spec:
 
           {{- include "retool.telemetry.includeEnvVars" . | nindent 10 }}
 
-          {{- if .Values.agentSandbox.enabled }}
+          {{- if eq (include "retool.r2.componentEnabled" (dict "root" $ "component" "agentSandbox")) "1" }}
           - name: RR_AGENT_PUBSUB_BACKEND
             value: "postgres"
           {{- end }}

--- a/charts/retool/templates/deployment_js_executor.yaml
+++ b/charts/retool/templates/deployment_js_executor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.jsExecutor.enabled }}
+{{- if eq (include "retool.r2.componentEnabled" (dict "root" $ "component" "jsExecutor")) "1" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/retool/templates/deployment_mcp.yaml
+++ b/charts/retool/templates/deployment_mcp.yaml
@@ -7,7 +7,7 @@
 {{- end }}
 {{- end }}
 {{- if not (or $mcpConfig.oauthIntrospectionAuthTokenSecretName $mcpConfig.oauthIntrospectionAuthToken $hasOAuthIntrospectionAuthTokenEnv) }}
-{{- fail "Please set .Values.mcp.config.oauthIntrospectionAuthTokenSecretName, .Values.mcp.config.oauthIntrospectionAuthToken, or an OAUTH_INTROSPECTION_AUTH_TOKEN entry in .Values.mcp.environmentVariables when .Values.mcp.enabled is true" }}
+{{- fail "Please set .Values.mcp.config.oauthIntrospectionAuthTokenSecretName, .Values.mcp.config.oauthIntrospectionAuthToken, or an OAUTH_INTROSPECTION_AUTH_TOKEN entry in .Values.mcp.environmentVariables when the MCP server is enabled (.Values.mcp.enabled, or inherited from .Values.r2.enabled)" }}
 {{- end }}
 {{- $mcpInternalPort := .Values.mcp.service.internalPort | default 4010 }}
 apiVersion: v1

--- a/charts/retool/templates/deployment_mcp.yaml
+++ b/charts/retool/templates/deployment_mcp.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.mcp.enabled }}
+{{- if eq (include "retool.r2.componentEnabled" (dict "root" $ "component" "mcp")) "1" }}
 {{- $mcpConfig := .Values.mcp.config | default dict }}
 {{- $hasOAuthIntrospectionAuthTokenEnv := false }}
 {{- range .Values.mcp.environmentVariables }}

--- a/charts/retool/templates/deployment_workflows.yaml
+++ b/charts/retool/templates/deployment_workflows.yaml
@@ -153,7 +153,7 @@ spec:
               {{- end }}
           {{- end }}
           {{- end }}
-          {{- if .Values.jsExecutor.enabled }}
+          {{- if eq (include "retool.r2.componentEnabled" (dict "root" $ "component" "jsExecutor")) "1" }}
           - name: JS_EXECUTOR_INGRESS_DOMAIN
             value: http://{{ template "retool.jsExecutor.name" . }}
           {{- end }}

--- a/charts/retool/templates/httproute.yaml
+++ b/charts/retool/templates/httproute.yaml
@@ -56,7 +56,7 @@ spec:
         - name: {{ $fullName }}
           port: {{ $svcPort }}
     {{- end }}
-{{- if and .Values.agentSandbox.enabled .Values.agentSandbox.frontendWsProxyDomain }}
+{{- if and (eq (include "retool.r2.componentEnabled" (dict "root" $ "component" "agentSandbox")) "1") .Values.agentSandbox.frontendWsProxyDomain }}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -564,8 +564,9 @@ multiplayer:
     labels: {}
 
 mcp:
-  # Enable this to run Retool's MCP server as a separate deployment.
-  enabled: false
+  # Run Retool's MCP server as a separate deployment. Inherits .Values.r2.enabled
+  # when left unset (null); set true/false to override.
+  enabled: null
 
   replicaCount: 1
 
@@ -839,9 +840,20 @@ codeExecutor:
   securityContext:
     privileged: true
 
+# === R2 (Retool agent runtime) =============================================
+# Master switch for the whole R2 stack: the r2Agent worker, jsExecutor,
+# agentSandbox, and mcp server. Set `r2.enabled: true` to turn them all on with
+# one line. Each component's own `enabled` (left null by default) inherits this
+# switch; set a component's `enabled` to true/false to override the master for
+# that component only. Shared R2 configuration can be added under this block
+# later.
+r2:
+  enabled: false
+
 # JS Executor
 jsExecutor:
-  enabled: false
+  # Inherits .Values.r2.enabled when left unset (null); set true/false to override.
+  enabled: null
 
   image:
     repository: tryretool/js-executor-service
@@ -921,7 +933,8 @@ agents:
 
 # R2 Agent: server-side agent loop worker (independent from agents above).
 r2Agent:
-  enabled: false
+  # Inherits .Values.r2.enabled when left unset (null); set true/false to override.
+  enabled: null
 
   # Labels for R2 agent worker pods
   labels: {}
@@ -948,7 +961,8 @@ r2Agent:
 # Deploys a controller (manages sandbox lifecycle), proxy (HTTP proxy for sandbox egress),
 # and ephemeral Job-based sandboxes. Uses Postgres for controller/proxy state.
 agentSandbox:
-  enabled: false
+  # Inherits .Values.r2.enabled when left unset (null); set true/false to override.
+  enabled: null
 
   image:
     repository: tryretool/agent-sandbox-service

--- a/values.yaml
+++ b/values.yaml
@@ -564,8 +564,9 @@ multiplayer:
     labels: {}
 
 mcp:
-  # Enable this to run Retool's MCP server as a separate deployment.
-  enabled: false
+  # Run Retool's MCP server as a separate deployment. Inherits .Values.r2.enabled
+  # when left unset (null); set true/false to override.
+  enabled: null
 
   replicaCount: 1
 
@@ -839,9 +840,20 @@ codeExecutor:
   securityContext:
     privileged: true
 
+# === R2 (Retool agent runtime) =============================================
+# Master switch for the whole R2 stack: the r2Agent worker, jsExecutor,
+# agentSandbox, and mcp server. Set `r2.enabled: true` to turn them all on with
+# one line. Each component's own `enabled` (left null by default) inherits this
+# switch; set a component's `enabled` to true/false to override the master for
+# that component only. Shared R2 configuration can be added under this block
+# later.
+r2:
+  enabled: false
+
 # JS Executor
 jsExecutor:
-  enabled: false
+  # Inherits .Values.r2.enabled when left unset (null); set true/false to override.
+  enabled: null
 
   image:
     repository: tryretool/js-executor-service
@@ -921,7 +933,8 @@ agents:
 
 # R2 Agent: server-side agent loop worker (independent from agents above).
 r2Agent:
-  enabled: false
+  # Inherits .Values.r2.enabled when left unset (null); set true/false to override.
+  enabled: null
 
   # Labels for R2 agent worker pods
   labels: {}
@@ -948,7 +961,8 @@ r2Agent:
 # Deploys a controller (manages sandbox lifecycle), proxy (HTTP proxy for sandbox egress),
 # and ephemeral Job-based sandboxes. Uses Postgres for controller/proxy state.
 agentSandbox:
-  enabled: false
+  # Inherits .Values.r2.enabled when left unset (null); set true/false to override.
+  enabled: null
 
   image:
     repository: tryretool/agent-sandbox-service


### PR DESCRIPTION
## Summary

Turning on the R2 stack previously meant flipping **four** independent flags (`r2Agent`, `jsExecutor`, `agentSandbox`, `mcp`). This adds a single top-level **`r2.enabled`** master switch that toggles them all collectively, with room for shared R2 config under the block later.

```yaml
r2:
  enabled: true     # r2Agent + jsExecutor + agentSandbox + mcp, one line
mcp:
  enabled: false    # ...carve one out when you want (explicit override wins)
```

## Semantics — inherit + override

- Each component's `enabled` default changes `false` → `null`.
- When `null`, the component **inherits** `r2.enabled`.
- When set to `true`/`false` explicitly, the component **overrides** the master for itself only.
- **Backward compatible:** existing configs that set the per-component flags explicitly behave identically.

## Implementation

- New generic helper `retool.r2.componentEnabled` (returns `"1"`/`""`); `retool.r2Agent.enabled` now delegates to it.
- **Every** read of these flags is routed through the helper — not just the deployment guards, but the cross-component env wiring in `deployment_backend` / `deployment_workflows` / `deployment_jobs` / `_workers.tpl` and the `agentSandbox.validateSecrets` / `backendEnvVars` / `httproute` helpers. Otherwise an inherited (`null`) flag reads as false and silently skips injecting `JS_EXECUTOR_INGRESS_DOMAIN` / `RR_AGENT_PUBSUB_BACKEND` / `AGENT_SANDBOX_CONTROLLER_INGRESS_DOMAIN`.
- `values.yaml` and `charts/retool/values.yaml` updated identically (sync check passes).

## Tests

- Added `ci/test-r2-enabled-option.yaml` exercising the master-switch inherit path (auto-discovered by `kubeconform.sh`).
- Verified manually: **inherit** (all four render + cross-component env present), **override-off** (`mcp`/`agentSandbox` drop, rest stay), **override-on** (master off + one component on), and **default** (nothing renders).
- `helm lint` clean; kubeconform clean across all option files × bases × k8s 1.27.16/1.32.2; no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)