### PR TITLE
[TEST - DO NOT MERGE] Force seccomp path regardless of k8s version

### DIFF
--- a/charts/retool/templates/configmap_code_executor.yaml
+++ b/charts/retool/templates/configmap_code_executor.yaml
@@ -1,5 +1,6 @@
 {{- if include "retool.workflows.enabled" . }}
-{{- if and (not .Values.codeExecutor.securityContext) (semverCompare ">=1.33-0" .Capabilities.KubeVersion.Version) }}
+{{- /* TEMP(PLAT-1012 TEST BRANCH): >=1.33 version gate removed to force the seccomp path on a <1.33 cluster for testing. DO NOT MERGE. */ -}}
+{{- if (not .Values.codeExecutor.securityContext) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/retool/templates/deployment_code_executor.yaml
+++ b/charts/retool/templates/deployment_code_executor.yaml
@@ -12,7 +12,8 @@
   To use the more fine-grained privileges, please upgrade your k8s cluster to 1.33
   or higher.
 */ -}}
-{{- $useSecComp := and (not .Values.codeExecutor.securityContext) (semverCompare ">=1.33-0" .Capabilities.KubeVersion.Version) -}}
+{{- /* TEMP(PLAT-1012 TEST BRANCH): >=1.33 version gate removed to force the seccomp path on a <1.33 cluster for testing. DO NOT MERGE. */ -}}
+{{- $useSecComp := (not .Values.codeExecutor.securityContext) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
## DO NOT MERGE - testing only

Throwaway branch off the real PR (#311) used to test the code-executor seccomp path on a **< 1.33** cluster (internal-onprem balloon `seccomp-ce`, currently k8s v1.30.14).

The only change vs the PR branch: the `>=1.33` version check is removed from `$useSecComp` in both the code-executor deployment and the seccomp ConfigMap, so the seccomp path renders regardless of cluster version. This lets us deploy and smoke-test the scaffolding (init container, profile install, Localhost seccomp profile, NET_ADMIN) on the existing 1.30 cluster.

### Caveat
On a < 1.33 cluster the API server will strip `procMount: Unmasked` and `hostUsers: false` (feature gates off pre-1.33), so nsjail sandboxing won't fully function at runtime — this branch validates rendering + profile install + pod startup, not runtime sandboxing.

### Revert
Delete this branch after testing. The real change lives in #311.

Made with [Cursor](https://cursor.com)