### PR TITLE
r2-cleanup → r2: R2 enablement polish (master switch, same-origin proxy, secrets, git-server split)

### DIFF
--- a/charts/retool/ci/test-agent-sandbox-enabled-option.yaml
+++ b/charts/retool/ci/test-agent-sandbox-enabled-option.yaml
@@ -1,0 +1,77 @@
+# Agent Sandbox — external secret + dedicated proxy domain WITH ingress.
+#
+# This is the "max surface" scenario: controller + proxy deployments, the
+# job-template ConfigMap, RBAC, headless/proxy services, proxy ingress + TLS,
+# the image-prepuller + seccomp DaemonSets, the smarter-device-manager device
+# plugin DaemonSet, the NetworkPolicies, and both PDBs.
+#
+# Secret/Postgres sourcing here uses externalSecret.name (Postgres OPTION 4:
+# the secret's postgres-url key). The other secret/Postgres precedence paths and
+# the same-origin (no-ingress) proxy mode are covered by sibling files:
+#   - test-agent-sandbox-inline-secrets-option.yaml      (inline secrets, plaintext DSN, same-origin/no ingress, hostPath tun)
+#   - test-agent-sandbox-postgres-fields-option.yaml     (assemble DSN from fields + PGPASSWORD secret)
+#   - test-agent-sandbox-postgres-url-secret-option.yaml (full DSN from an existing secret)
+#   - test-agent-sandbox-inherit-postgres-option.yaml    (zero-config inherit of the backend Postgres)
+# Overlaid on test-install-values.yaml.
+agentSandbox:
+  enabled: true
+
+  image:
+    repository: tryretool/agent-sandbox-service
+    tag: 3.123.4
+    pullPolicy: IfNotPresent
+
+  # Reference a pre-existing K8s Secret (the production-recommended path) rather
+  # than inlining JWT/encryption material into the chart. With externalSecret.name
+  # set, secret-backed env vars — including the ones injected into the sandbox
+  # job-template — resolve via secretKeyRef instead of plaintext.
+  externalSecret:
+    name: agent-sandbox-secrets
+
+  postgres:
+    schema: agent_executor
+    poolMax: 10
+
+  sandboxNetwork:
+    enabled: true
+    devicePlugin: true
+    deployDaemonSet: true
+
+  snapshotStorage:
+    s3Bucket: retool-agent-sandbox-snapshots
+    s3Endpoint: https://s3.us-east-1.amazonaws.com
+    s3Region: us-east-1
+    credentialsSecretName: agent-sandbox-s3-credentials
+
+  # replicaCount > 1 renders the controller PodDisruptionBudget.
+  controller:
+    replicaCount: 2
+
+  proxy:
+    replicaCount: 2
+    allowedDomains: api.example.com,example.com
+    backendDomainSuffixes: .example.com
+    sandboxProxyTimeoutMs: "3600000"
+    service:
+      type: ClusterIP
+    # Dedicated proxy domain → renders the proxy Ingress.
+    ingress:
+      enabled: true
+      ingressClassName: nginx
+      annotations:
+        nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+        nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+      host: sandbox.example.com
+      tls:
+        - secretName: agent-sandbox-tls
+          hosts:
+            - sandbox.example.com
+  frontendWsProxyDomain: https://sandbox.example.com
+
+  # Restrict sandbox/controller/proxy traffic → renders the NetworkPolicies.
+  networkPolicy:
+    enabled: true
+
+# Exercise the proxy PodDisruptionBudget branch.
+podDisruptionBudget:
+  maxUnavailable: 1

--- a/charts/retool/ci/test-agent-sandbox-inherit-postgres-option.yaml
+++ b/charts/retool/ci/test-agent-sandbox-inherit-postgres-option.yaml
@@ -1,0 +1,20 @@
+# Agent Sandbox — Postgres sourcing OPTION 5 (default): inherit the backend's
+# Postgres connection. With agentSandbox.postgres left entirely unset, the
+# controller/proxy reuse config.postgresql / the postgresql subchart (same
+# instance and database, separate schema) — the zero-config path for enabling
+# the sandbox on an existing deployment. PGPASSWORD mirrors the backend's
+# POSTGRES_PASSWORD secretKeyRef, and the DSN is assembled from the postgresql
+# helpers. The base test-install-values.yaml enables the postgresql subchart,
+# which is what makes inheritance resolve.
+#
+# Only the (required) JWT secrets are provided; everything else is left default.
+agentSandbox:
+  enabled: true
+
+  image:
+    repository: tryretool/agent-sandbox-service
+    tag: 3.123.4
+    pullPolicy: IfNotPresent
+
+  jwtPublicKey: '-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEljtqa2nhBwe/PqNhWgPHhj0jv8AI\nY+QUCicYtfv9wLGcEGPQuXoBQtuoIuOwXOdbEWgrQyLdIEb0YjegAW3miA==\n-----END PUBLIC KEY-----'
+  jwtPrivateKey: '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMFXLiN/YsJv89D2YkEZ6/Dj5fujghENmYTOilwdChU3oAoGCCqGSM49\nAwEHoUQDQgAEljtqa2nhBwe/PqNhWgPHhj0jv8AIY+QUCicYtfv9wLGcEGPQuXoB\nQtuoIuOwXOdbEWgrQyLdIEb0YjegAW3miA==\n-----END EC PRIVATE KEY-----'

--- a/charts/retool/ci/test-agent-sandbox-inline-secrets-option.yaml
+++ b/charts/retool/ci/test-agent-sandbox-inline-secrets-option.yaml
@@ -1,0 +1,46 @@
+# Agent Sandbox — inline secrets + plaintext DSN + same-origin proxy (no ingress).
+#
+# Complements test-agent-sandbox-enabled-option.yaml (external secret + dedicated
+# proxy ingress). Here we exercise the *other* halves of those branches:
+#   - Secrets inline (no externalSecret.name) → the chart renders its own Secret
+#     (jwt-public-key / jwt-private-key / encryption-key / api-secret). jwtPublicKey
+#     MUST be single-line: it is injected raw into the sandbox job-template JSON.
+#   - Postgres sourcing OPTION 1: plaintext DSN via postgres.url.
+#   - Same-origin proxy: no dedicated proxy domain and no proxy ingress — the
+#     backend reverse-proxies /sandbox/* (frontendWsProxyDomain left empty).
+#   - sandboxNetwork.devicePlugin=false → sandbox pods get /dev/net/tun via
+#     hostPath (the non-device-plugin branch), and no device-manager DaemonSet.
+#   - networkPolicy disabled.
+agentSandbox:
+  enabled: true
+
+  image:
+    repository: tryretool/agent-sandbox-service
+    tag: 3.123.4
+    pullPolicy: IfNotPresent
+
+  jwtPublicKey: '-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEljtqa2nhBwe/PqNhWgPHhj0jv8AI\nY+QUCicYtfv9wLGcEGPQuXoBQtuoIuOwXOdbEWgrQyLdIEb0YjegAW3miA==\n-----END PUBLIC KEY-----'
+  jwtPrivateKey: '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMFXLiN/YsJv89D2YkEZ6/Dj5fujghENmYTOilwdChU3oAoGCCqGSM49\nAwEHoUQDQgAEljtqa2nhBwe/PqNhWgPHhj0jv8AIY+QUCicYtfv9wLGcEGPQuXoB\nQtuoIuOwXOdbEWgrQyLdIEb0YjegAW3miA==\n-----END EC PRIVATE KEY-----'
+  encryptionKey: a12b01429fe0fe69a80da94e9e837ab2f1e9bda378ed8a25905a238f6fea6b7a
+  apiSecret: test-agent-sandbox-api-secret
+
+  # Option 1: plaintext DSN.
+  postgres:
+    url: postgres://retool:retool@agent-sandbox-db.example.internal:5432/agent_sandbox
+    schema: agent_executor
+    poolMax: 10
+
+  sandboxNetwork:
+    enabled: true
+    devicePlugin: false
+    deployDaemonSet: false
+
+  proxy:
+    # Same-origin: ClusterIP service, no ingress.
+    service:
+      type: ClusterIP
+    ingress:
+      enabled: false
+
+  networkPolicy:
+    enabled: false

--- a/charts/retool/ci/test-agent-sandbox-postgres-fields-option.yaml
+++ b/charts/retool/ci/test-agent-sandbox-postgres-fields-option.yaml
@@ -1,0 +1,39 @@
+# Agent Sandbox — Postgres sourcing OPTION 2: assemble the DSN from discrete
+# fields, with the password supplied via PGPASSWORD from a pre-existing Secret
+# (never embedded in the URL, so any password characters are safe).
+#
+# Also exercises:
+#   - An Azure-style "user@servername" username, which validateSecrets allows
+#     (the parser splits userinfo on the last '@').
+#   - sandboxNetwork with devicePlugin=true but deployDaemonSet=false (a
+#     smarter-device-manager already runs on the nodes, managed elsewhere) →
+#     sandbox pods request smarter-devices/net_tun but no DS is rendered.
+#   - networkPolicy enabled.
+agentSandbox:
+  enabled: true
+
+  image:
+    repository: tryretool/agent-sandbox-service
+    tag: 3.123.4
+    pullPolicy: IfNotPresent
+
+  jwtPublicKey: '-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEljtqa2nhBwe/PqNhWgPHhj0jv8AI\nY+QUCicYtfv9wLGcEGPQuXoBQtuoIuOwXOdbEWgrQyLdIEb0YjegAW3miA==\n-----END PUBLIC KEY-----'
+  jwtPrivateKey: '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMFXLiN/YsJv89D2YkEZ6/Dj5fujghENmYTOilwdChU3oAoGCCqGSM49\nAwEHoUQDQgAEljtqa2nhBwe/PqNhWgPHhj0jv8AIY+QUCicYtfv9wLGcEGPQuXoB\nQtuoIuOwXOdbEWgrQyLdIEb0YjegAW3miA==\n-----END EC PRIVATE KEY-----'
+
+  # Option 2: host + user + database, password via PGPASSWORD secretKeyRef.
+  postgres:
+    host: agentdb-prod.postgres.database.azure.com
+    port: 5432
+    database: agent_sandbox
+    user: retool@agentdb-prod
+    passwordSecretName: agent-sandbox-db-password
+    passwordSecretKey: password
+    schema: agent_executor
+
+  sandboxNetwork:
+    enabled: true
+    devicePlugin: true
+    deployDaemonSet: false
+
+  networkPolicy:
+    enabled: true

--- a/charts/retool/ci/test-agent-sandbox-postgres-url-secret-option.yaml
+++ b/charts/retool/ci/test-agent-sandbox-postgres-url-secret-option.yaml
@@ -1,0 +1,29 @@
+# Agent Sandbox — Postgres sourcing OPTION 3: the full DSN comes from a
+# pre-existing Secret (postgres.urlSecretName / urlSecretKey), while the JWT/
+# encryption secrets are provided inline. This is the "BYO DB secret, chart-
+# managed app secrets" combination.
+#
+# Also exercises S3 snapshot storage WITHOUT a dedicated credentialsSecretName,
+# so the sandbox AWS creds fall back to the default (chart-rendered) Secret.
+agentSandbox:
+  enabled: true
+
+  image:
+    repository: tryretool/agent-sandbox-service
+    tag: 3.123.4
+    pullPolicy: IfNotPresent
+
+  jwtPublicKey: '-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEljtqa2nhBwe/PqNhWgPHhj0jv8AI\nY+QUCicYtfv9wLGcEGPQuXoBQtuoIuOwXOdbEWgrQyLdIEb0YjegAW3miA==\n-----END PUBLIC KEY-----'
+  jwtPrivateKey: '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMFXLiN/YsJv89D2YkEZ6/Dj5fujghENmYTOilwdChU3oAoGCCqGSM49\nAwEHoUQDQgAEljtqa2nhBwe/PqNhWgPHhj0jv8AIY+QUCicYtfv9wLGcEGPQuXoB\nQtuoIuOwXOdbEWgrQyLdIEb0YjegAW3miA==\n-----END EC PRIVATE KEY-----'
+  encryptionKey: a12b01429fe0fe69a80da94e9e837ab2f1e9bda378ed8a25905a238f6fea6b7a
+
+  # Option 3: full DSN from an existing Secret.
+  postgres:
+    urlSecretName: agent-sandbox-db-dsn
+    urlSecretKey: connection-string
+    schema: agent_executor
+
+  snapshotStorage:
+    s3Bucket: retool-agent-sandbox-snapshots
+    s3Endpoint: https://s3.us-west-2.amazonaws.com
+    s3Region: us-west-2

--- a/charts/retool/ci/test-js-executor-enabled-option.yaml
+++ b/charts/retool/ci/test-js-executor-enabled-option.yaml
@@ -1,0 +1,37 @@
+# Exercises the JS executor workload (deployment_js_executor.yaml +
+# configmap_js_executor.yaml). Overlaid on top of test-install-values.yaml.
+jsExecutor:
+  enabled: true
+  replicaCount: 2
+  image:
+    repository: tryretool/js-executor-service
+    tag: 3.123.4
+    # Deliberately differs from the global image.pullPolicy (IfNotPresent in the
+    # base values) so the rendered deployment proves the per-workload override is
+    # honored rather than the global value.
+    pullPolicy: Always
+  # JS-executor-specific env (not inherited from top-level .Values.env).
+  env:
+    LOG_LEVEL: info
+  # Exercise the per-workload secretKeyRef branch.
+  environmentSecrets:
+    - name: JS_EXECUTOR_TOKEN
+      secretKeyRef:
+        name: js-executor-secrets
+        key: token
+  environmentVariables:
+    - name: JS_EXECUTOR_TEST_OPTION
+      value: "true"
+  # Memory request and limit are kept equal: JSE rejects requests at 80% of
+  # its limit, so the request must reserve the full amount.
+  resources:
+    limits:
+      cpu: 4000m
+      memory: 4Gi
+    requests:
+      cpu: 4000m
+      memory: 4Gi
+
+# Exercise the PDB branch shared by the JS executor deployment.
+podDisruptionBudget:
+  maxUnavailable: 1

--- a/charts/retool/ci/test-r2-agent-enabled-option.yaml
+++ b/charts/retool/ci/test-r2-agent-enabled-option.yaml
@@ -1,0 +1,25 @@
+# Exercises the R2 Agent worker (the server-side agent loop worker rendered via
+# _workers.tpl as SERVICE_TYPE=R2_AGENT_TEMPORAL_WORKER on healthcheck port 3016).
+# Renders a Deployment + Service, plus a PodDisruptionBudget when one is set.
+# Overlaid on test-install-values.yaml.
+r2Agent:
+  enabled: true
+  config:
+    nodeOptions: "--max_old_space_size=2048"
+  worker:
+    replicaCount: 2
+    resources:
+      limits:
+        cpu: 2000m
+        memory: 4096Mi
+      requests:
+        cpu: 1000m
+        memory: 2048Mi
+  labels:
+    test-pod-label: "true"
+  annotations:
+    test-pod-annotation: "true"
+
+# Exercise the worker PodDisruptionBudget branch.
+podDisruptionBudget:
+  maxUnavailable: 1

--- a/charts/retool/ci/test-r2-enabled-option.yaml
+++ b/charts/retool/ci/test-r2-enabled-option.yaml
@@ -1,0 +1,32 @@
+# R2 master switch — single flag turns on the whole R2 stack.
+#
+# Exercises the `r2.enabled: true` inherit path: r2Agent, jsExecutor,
+# agentSandbox, and mcp all leave their own `enabled` unset (null) and inherit
+# the master switch. This guards `retool.r2.componentEnabled` and the
+# helper-routed cross-component env wiring (backend/workflows/jobs/workers read
+# effective-enabled, not the raw per-component flag).
+#
+# Secrets/config below are only what each component requires to template when
+# enabled; none of them set `*.enabled`, so enablement comes solely from r2.
+r2:
+  enabled: true
+
+agentSandbox:
+  # jwtPublicKey is injected raw into the sandbox job-template JSON, so it MUST
+  # be single-line (\n-escaped) or templating breaks.
+  jwtPublicKey: '-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEljtqa2nhBwe/PqNhWgPHhj0jv8AIY+QUCicYtfv9wLGcEGPQuXoBQtuoIuOwXOdbEWgrQyLdIEb0YjegAW3miA==\n-----END PUBLIC KEY-----'
+  jwtPrivateKey: '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMFXLiN/YsJv89D2YkEZ6/Dj5fujghENmYTOilwdChU3oAoGCCqGSM49AwEHoUQDQgAEljtqa2nhBwe/PqNhWgPHhj0jv8AIY+QUCicYtfv9wLGcEGPQuXoBQtuoIuOwXOdbEWgrQyLdIEb0YjegAW3miA==\n-----END EC PRIVATE KEY-----'
+  postgres:
+    url: postgres://retool:retool@agent-sandbox-db.example.internal:5432/agent_sandbox
+    schema: agent_executor
+  proxy:
+    service:
+      type: ClusterIP
+    ingress:
+      enabled: false
+  networkPolicy:
+    enabled: false
+
+mcp:
+  config:
+    oauthIntrospectionAuthToken: test-oauth-introspection-token

--- a/charts/retool/ci/test-rr-git-server-separate-option.yaml
+++ b/charts/retool/ci/test-rr-git-server-separate-option.yaml
@@ -1,0 +1,38 @@
+podDisruptionBudget:
+  minAvailable: 1
+
+rrGitServer:
+  enabled: true
+  repackThreshold: 200
+  separate:
+    enabled: true
+    replicaCount: 2
+    port: 3010
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+    annotations:
+      test-pod-annotation: "true"
+    labels:
+      test-pod-label: "true"
+    service:
+      annotations:
+        test-service-annotation: "true"
+      labels:
+        test-service-label: "true"
+
+blobStorage:
+  s3:
+    bucket: test-rr-bucket
+    region: us-east-1
+    accessKeyId: AKIATEST
+    secretAccessKeySecretName: rr-blob-storage
+    secretAccessKeySecretKey: secret-access-key
+
+# Exercise the MCP auto-wiring to the standalone git server service.
+mcp:
+  enabled: true
+  config:
+    oauthMainDomain: https://oauth.example.com
+    oauthIntrospectionAuthToken: test-oauth-introspection-token

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -684,13 +684,21 @@ Set MCP server service name
 {{/*
 Validate that exactly one blob-storage provider is configured when rrGitServer
 is enabled. Skipped when the user has plumbed the RR_BLOB_STORAGE_PROVIDER /
-RR_DEFAULT_*_* env vars in directly via environmentVariables/environmentSecrets,
+RR_DEFAULT_*_* env vars in directly via env/environmentVariables/environmentSecrets,
 which is treated as an opt-out from the first-class blobStorage config.
+Also skipped entirely when rrGitServer.skipBlobStorageValidation is true, which
+is the escape hatch for sources we cannot inspect at template time (e.g. env
+vars injected via envFrom from a Secret/ConfigMap).
 No-op when rrGitServer is disabled.
 */}}
 {{- define "retool.rrGitServer.validateBlobStorage" -}}
-{{- if .Values.rrGitServer.enabled -}}
+{{- if and .Values.rrGitServer.enabled (not .Values.rrGitServer.skipBlobStorageValidation) -}}
 {{- $hasDirectEnv := false -}}
+{{- range $name, $value := .Values.env -}}
+{{- if or (hasPrefix "RR_DEFAULT_" $name) (eq $name "RR_BLOB_STORAGE_PROVIDER") -}}
+{{- $hasDirectEnv = true -}}
+{{- end -}}
+{{- end -}}
 {{- range .Values.environmentVariables -}}
 {{- if or (hasPrefix "RR_DEFAULT_" .name) (eq .name "RR_BLOB_STORAGE_PROVIDER") -}}
 {{- $hasDirectEnv = true -}}
@@ -708,7 +716,7 @@ No-op when rrGitServer is disabled.
 {{- if $bs.gcs }}{{ $providers = append $providers "gcs" }}{{ end -}}
 {{- if $bs.azure }}{{ $providers = append $providers "azure" }}{{ end -}}
 {{- if ne (len $providers) 1 -}}
-{{- fail "rrGitServer.enabled requires exactly one of blobStorage.s3, blobStorage.gcs, blobStorage.azure to be configured, or set RR_BLOB_STORAGE_PROVIDER / RR_DEFAULT_* directly via environmentVariables / environmentSecrets" -}}
+{{- fail "rrGitServer.enabled requires exactly one of blobStorage.s3, blobStorage.gcs, blobStorage.azure to be configured, or set RR_BLOB_STORAGE_PROVIDER / RR_DEFAULT_* directly via env / environmentVariables / environmentSecrets. If those vars are supplied another way (e.g. envFrom), set rrGitServer.skipBlobStorageValidation=true to bypass this check." -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -624,6 +624,139 @@ telemetry.retool.com/service-name: agent-sandbox-proxy
 {{- end -}}
 
 {{/*
+Validate that an enabled agent sandbox has its required secrets supplied. The
+controller and proxy fail to boot without a Postgres connection and a JWT
+public key, and the Retool backend needs the JWT private key to sign sandbox
+tokens. Each may come from a plaintext value, the per-key existing-secret refs,
+or the catch-all externalSecret.name. No-op when agentSandbox is disabled.
+*/}}
+{{- define "retool.agentSandbox.validateSecrets" -}}
+{{- if .Values.agentSandbox.enabled -}}
+{{- $as := .Values.agentSandbox -}}
+{{- $ext := $as.externalSecret.name -}}
+{{- $explicitPg := or $as.postgres.url $as.postgres.urlSecretName $as.postgres.host $ext -}}
+{{- if not $explicitPg -}}
+{{- /* No explicit source: inherit the backend's Postgres connection. */ -}}
+{{- if not (include "retool.postgresql.host" . | trimAll "\"") -}}
+{{- fail "agentSandbox.enabled defaults to reusing the backend's Postgres connection, but config.postgresql resolved no host. Set agentSandbox.postgres.url / .host / .urlSecretName / externalSecret.name, or configure config.postgresql." -}}
+{{- end -}}
+{{- if not (or .Values.postgresql.enabled .Values.config.postgresql.passwordSecretName (eq (include "shouldIncludeConfigSecretsEnvVars" . | trim) "1")) -}}
+{{- fail "agentSandbox.postgres is unset so it would inherit the backend's Postgres password, but that password is supplied via external secrets (envFrom) and cannot be referenced from a separate pod. Set agentSandbox.postgres.url / .urlSecretName / .host (+ passwordSecretName), or agentSandbox.externalSecret.name." -}}
+{{- end -}}
+{{- end -}}
+{{- if $as.postgres.host -}}
+{{- if not (and $as.postgres.user $as.postgres.database) -}}
+{{- fail "agentSandbox.postgres.host is set, so postgres.user and postgres.database are also required to assemble the DSN." -}}
+{{- end -}}
+{{- if not (or $as.postgres.password $as.postgres.passwordSecretName) -}}
+{{- fail "agentSandbox.postgres.host is set, so a password is required: set postgres.password or postgres.passwordSecretName. For a passwordless connection (e.g. IAM/trust auth), supply the full connection string via postgres.url or postgres.urlSecretName instead." -}}
+{{- end -}}
+{{- /*
+  user and database are embedded verbatim in the assembled DSN, so reject the
+  characters that would break URL parsing. '@' is allowed in user (managed
+  services like Azure use user@servername; the parser splits on the last '@'),
+  but ':' '/' and whitespace would be mis-parsed as a password/host/path. For
+  values needing other characters, supply a full DSN via postgres.url or
+  postgres.urlSecretName instead.
+*/}}
+{{- if regexMatch "[\\s:/?#]" ($as.postgres.user | toString) -}}
+{{- fail "agentSandbox.postgres.user contains a character that breaks DSN assembly (whitespace, : / ? #). '@' is fine (e.g. Azure user@server); otherwise supply a full DSN via agentSandbox.postgres.url or postgres.urlSecretName." -}}
+{{- end -}}
+{{- if regexMatch "[\\s?#]" ($as.postgres.database | toString) -}}
+{{- fail "agentSandbox.postgres.database contains a character that breaks DSN assembly (whitespace, ? #); supply a full DSN via agentSandbox.postgres.url or postgres.urlSecretName." -}}
+{{- end -}}
+{{- end -}}
+{{- if not (or $as.jwtPublicKey $ext) -}}
+{{- fail "agentSandbox.enabled requires a JWT public key. Set agentSandbox.jwtPublicKey or agentSandbox.externalSecret.name." -}}
+{{- end -}}
+{{- if not (or $as.jwtPrivateKey $ext) -}}
+{{- fail "agentSandbox.enabled requires a JWT private key (the backend signs sandbox tokens with it). Set agentSandbox.jwtPrivateKey or agentSandbox.externalSecret.name." -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Render the AGENT_SANDBOX_POSTGRES_URL env entry for the controller/proxy (plus a
+PGPASSWORD entry when assembling from fields). validateSecrets guarantees one of
+these applies, in order: postgres.url -> postgres.host -> postgres.urlSecretName
+-> externalSecret.name -> inherit the backend's config.postgresql connection
+(the default when nothing agent-specific is set).
+
+For the host path the password is passed via PGPASSWORD rather than embedded in
+the URL: node-postgres reads PGPASSWORD when the connection string omits the
+password, so it needs no URL escaping. PGPASSWORD is process-global but safe
+here because the controller/proxy open exactly one Postgres connection. user and
+database are embedded verbatim (percent-encoding doesn't round-trip here -- the
+parser decodes userinfo before splitting on ':', and runs the path through
+decodeURI); validateSecrets instead rejects the characters that would break
+parsing. An Azure-style "user@servername" is fine -- the parser splits on the
+last '@'.
+Usage: {{- include "retool.agentSandbox.postgresUrlEnv" . | nindent 12 }}
+*/}}
+{{- define "retool.agentSandbox.postgresUrlEnv" -}}
+{{- $pg := .Values.agentSandbox.postgres -}}
+{{- $ext := .Values.agentSandbox.externalSecret.name -}}
+{{- if $pg.url }}
+- name: AGENT_SANDBOX_POSTGRES_URL
+  value: {{ $pg.url | quote }}
+{{- else if $pg.host }}
+{{- $port := $pg.port | default 5432 -}}
+{{- if $pg.passwordSecretName }}
+- name: PGPASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ $pg.passwordSecretName }}
+      key: {{ $pg.passwordSecretKey | default "password" }}
+{{- else if $pg.password }}
+- name: PGPASSWORD
+  value: {{ $pg.password | quote }}
+{{- end }}
+- name: AGENT_SANDBOX_POSTGRES_URL
+  value: {{ printf "postgres://%s@%s:%v/%s" $pg.user $pg.host $port $pg.database | quote }}
+{{- else if $pg.urlSecretName }}
+- name: AGENT_SANDBOX_POSTGRES_URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ $pg.urlSecretName }}
+      key: {{ $pg.urlSecretKey | default "postgres-url" }}
+{{- else if $ext }}
+- name: AGENT_SANDBOX_POSTGRES_URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ $ext }}
+      key: postgres-url
+{{- else }}
+{{- /*
+  Default: inherit the backend's Postgres connection (config.postgresql or the
+  postgresql subchart) -- same instance/database, separate schema. The password
+  is sourced from the same secret the backend uses; this block mirrors the
+  POSTGRES_PASSWORD secretKeyRef in deployment_backend.yaml. validateSecrets
+  rejects the one combination this can't reach (external-secrets mode with no
+  discrete password key).
+*/}}
+- name: PGPASSWORD
+  valueFrom:
+    secretKeyRef:
+      {{- if .Values.postgresql.enabled }}
+      name: {{ template "retool.postgresql.fullname" . }}
+      {{- if eq .Values.postgresql.auth.username "postgres" }}
+      key: postgres-password
+      {{- else }}
+      key: password
+      {{- end }}
+      {{- else if .Values.config.postgresql.passwordSecretName }}
+      name: {{ .Values.config.postgresql.passwordSecretName }}
+      key: {{ .Values.config.postgresql.passwordSecretKey | default "postgresql-password" }}
+      {{- else }}
+      name: {{ template "retool.fullname" . }}
+      key: postgresql-password
+      {{- end }}
+- name: AGENT_SANDBOX_POSTGRES_URL
+  value: {{ printf "postgres://%s@%s:%s/%s" (include "retool.postgresql.user" . | trimAll "\"") (include "retool.postgresql.host" . | trimAll "\"") (include "retool.postgresql.port" . | trimAll "\"" | default "5432") (include "retool.postgresql.database" . | trimAll "\"") | quote }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Agent sandbox env vars for the Retool backend, workflow backend, and workers.
 Outputs env entries that tell the backend how to reach the agent sandbox services.
 Usage: {{- include "retool.agentSandbox.backendEnvVars" . | nindent 10 }}

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -420,15 +420,25 @@ Usage: (include "retool.agents.enabled" .)
 {{- end -}}
 
 {{/*
-Set R2 agent enabled
+Resolve whether an R2 component (r2Agent, jsExecutor, agentSandbox, mcp) is
+enabled. The component's own `enabled` wins when explicitly set to true/false;
+when left unset (null) it inherits the shared master switch .Values.r2.enabled.
+Usage: (include "retool.r2.componentEnabled" (dict "root" $ "component" "jsExecutor"))
+Returns "1" when enabled, "" otherwise.
+*/}}
+{{- define "retool.r2.componentEnabled" -}}
+{{- $cfg := index .root.Values .component -}}
+{{- if kindIs "invalid" $cfg.enabled -}}
+  {{- if eq (toString .root.Values.r2.enabled) "true" -}}1{{- end -}}
+{{- else if eq (toString $cfg.enabled) "true" -}}1{{- end -}}
+{{- end -}}
+
+{{/*
+Set R2 agent worker enabled. Honors the shared R2 master switch.
 Usage: (include "retool.r2Agent.enabled" .)
 */}}
 {{- define "retool.r2Agent.enabled" -}}
-{{- $output := "" -}}
-{{- if (eq (toString .Values.r2Agent.enabled) "true") -}}
-  {{- $output = "1" -}}
-{{- end -}}
-{{- $output -}}
+{{- include "retool.r2.componentEnabled" (dict "root" . "component" "r2Agent") -}}
 {{- end -}}
 
 {{/* Global Temporal configuration */}}
@@ -631,7 +641,7 @@ tokens. Each may come from a plaintext value, the per-key existing-secret refs,
 or the catch-all externalSecret.name. No-op when agentSandbox is disabled.
 */}}
 {{- define "retool.agentSandbox.validateSecrets" -}}
-{{- if .Values.agentSandbox.enabled -}}
+{{- if eq (include "retool.r2.componentEnabled" (dict "root" . "component" "agentSandbox")) "1" -}}
 {{- $as := .Values.agentSandbox -}}
 {{- $ext := $as.externalSecret.name -}}
 {{- $explicitPg := or $as.postgres.url $as.postgres.urlSecretName $as.postgres.host $ext -}}
@@ -762,7 +772,7 @@ Outputs env entries that tell the backend how to reach the agent sandbox service
 Usage: {{- include "retool.agentSandbox.backendEnvVars" . | nindent 10 }}
 */}}
 {{- define "retool.agentSandbox.backendEnvVars" -}}
-{{- if .Values.agentSandbox.enabled }}
+{{- if eq (include "retool.r2.componentEnabled" (dict "root" . "component" "agentSandbox")) "1" }}
 {{- $defaultSecretName := .Values.agentSandbox.externalSecret.name | default (include "retool.agentSandbox.name" .) -}}
 - name: RR_AGENT_PUBSUB_BACKEND
   value: "postgres"

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -672,8 +672,8 @@ or the catch-all externalSecret.name. No-op when agentSandbox is disabled.
 {{- if regexMatch "[\\s:/?#]" ($as.postgres.user | toString) -}}
 {{- fail "agentSandbox.postgres.user contains a character that breaks DSN assembly (whitespace, : / ? #). '@' is fine (e.g. Azure user@server); otherwise supply a full DSN via agentSandbox.postgres.url or postgres.urlSecretName." -}}
 {{- end -}}
-{{- if regexMatch "[\\s?#]" ($as.postgres.database | toString) -}}
-{{- fail "agentSandbox.postgres.database contains a character that breaks DSN assembly (whitespace, ? #); supply a full DSN via agentSandbox.postgres.url or postgres.urlSecretName." -}}
+{{- if regexMatch "[\\s:/?#]" ($as.postgres.database | toString) -}}
+{{- fail "agentSandbox.postgres.database contains a character that breaks DSN assembly (whitespace, : / ? #); supply a full DSN via agentSandbox.postgres.url or postgres.urlSecretName." -}}
 {{- end -}}
 {{- end -}}
 {{- if not (or $as.jwtPublicKey $ext) -}}

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -682,6 +682,112 @@ Set MCP server service name
 {{- end -}}
 
 {{/*
+Set git server deployment/service name (only used when rrGitServer.separate is enabled)
+*/}}
+{{- define "retool.rrGitServer.name" -}}
+{{ template "retool.fullname" . }}-git-server
+{{- end -}}
+
+{{/*
+Returns "1" when the git server should run as its own deployment/service
+(rrGitServer.enabled AND rrGitServer.separate.enabled), empty otherwise.
+*/}}
+{{- define "retool.rrGitServer.separateEnabled" -}}
+{{- if and .Values.rrGitServer.enabled (.Values.rrGitServer.separate | default dict).enabled -}}
+1
+{{- end -}}
+{{- end -}}
+
+{{/*
+Port the standalone git server listens on (RR_GIT_SERVER_PORT) and exposes via its service.
+*/}}
+{{- define "retool.rrGitServer.port" -}}
+{{- (.Values.rrGitServer.separate | default dict).port | default 3010 -}}
+{{- end -}}
+
+{{/*
+In-cluster URL of the standalone git server service, e.g. http://<release>-git-server:3010.
+Used to point the MCP server (and any other consumer) at the split-out git server.
+*/}}
+{{- define "retool.rrGitServer.url" -}}
+http://{{ template "retool.rrGitServer.name" . }}:{{ include "retool.rrGitServer.port" . }}
+{{- end -}}
+
+{{/*
+Blob-storage + git repack env vars shared by the in-process git server (main
+backend) and the standalone git server deployment. git_server stores all
+objects/packs in blob storage; the same RR_DEFAULT_* vars are also used by
+snapshots. Emits nothing when no blobStorage provider is configured (in which
+case the user is expected to plumb RR_BLOB_STORAGE_PROVIDER / RR_DEFAULT_*
+directly via environmentVariables / environmentSecrets).
+*/}}
+{{- define "retool.rrGitServer.commonEnv" -}}
+{{- $bs := .Values.blobStorage | default dict }}
+{{- if $bs.s3 }}
+- name: RR_BLOB_STORAGE_PROVIDER
+  value: "s3"
+- name: RR_DEFAULT_S3_BUCKET
+  value: {{ $bs.s3.bucket | quote }}
+{{- if $bs.s3.region }}
+- name: RR_DEFAULT_S3_REGION
+  value: {{ $bs.s3.region | quote }}
+{{- end }}
+{{- if $bs.s3.endpoint }}
+- name: RR_DEFAULT_S3_ENDPOINT
+  value: {{ $bs.s3.endpoint | quote }}
+{{- end }}
+{{- if $bs.s3.accessKeyId }}
+- name: RR_DEFAULT_S3_ACCESS_KEY_ID
+  value: {{ $bs.s3.accessKeyId | quote }}
+{{- end }}
+{{- if $bs.s3.secretAccessKeySecretName }}
+- name: RR_DEFAULT_S3_SECRET_ACCESS_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ $bs.s3.secretAccessKeySecretName }}
+      key: {{ $bs.s3.secretAccessKeySecretKey | default "secret-access-key" }}
+{{- else if $bs.s3.secretAccessKey }}
+- name: RR_DEFAULT_S3_SECRET_ACCESS_KEY
+  value: {{ $bs.s3.secretAccessKey | quote }}
+{{- end }}
+{{- else if $bs.gcs }}
+- name: RR_BLOB_STORAGE_PROVIDER
+  value: "gcs"
+- name: RR_DEFAULT_GCS_BUCKET
+  value: {{ $bs.gcs.bucket | quote }}
+{{- if $bs.gcs.credentialsSecretName }}
+- name: RR_DEFAULT_GCS_CREDENTIALS
+  valueFrom:
+    secretKeyRef:
+      name: {{ $bs.gcs.credentialsSecretName }}
+      key: {{ $bs.gcs.credentialsSecretKey | default "credentials.json" }}
+{{- else if $bs.gcs.credentials }}
+- name: RR_DEFAULT_GCS_CREDENTIALS
+  value: {{ $bs.gcs.credentials | quote }}
+{{- end }}
+{{- else if $bs.azure }}
+- name: RR_BLOB_STORAGE_PROVIDER
+  value: "azure"
+- name: RR_DEFAULT_AZURE_CONTAINER
+  value: {{ $bs.azure.container | quote }}
+{{- if $bs.azure.connectionStringSecretName }}
+- name: RR_DEFAULT_AZURE_CONNECTION_STRING
+  valueFrom:
+    secretKeyRef:
+      name: {{ $bs.azure.connectionStringSecretName }}
+      key: {{ $bs.azure.connectionStringSecretKey | default "connection-string" }}
+{{- else if $bs.azure.connectionString }}
+- name: RR_DEFAULT_AZURE_CONNECTION_STRING
+  value: {{ $bs.azure.connectionString | quote }}
+{{- end }}
+{{- end }}
+{{- if .Values.rrGitServer.repackThreshold }}
+- name: RR_GIT_REPACK_THRESHOLD
+  value: {{ .Values.rrGitServer.repackThreshold | quote }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Validate that exactly one blob-storage provider is configured when rrGitServer
 is enabled. Skipped when the user has plumbed the RR_BLOB_STORAGE_PROVIDER /
 RR_DEFAULT_*_* env vars in directly via env/environmentVariables/environmentSecrets,

--- a/charts/retool/templates/_workers.tpl
+++ b/charts/retool/templates/_workers.tpl
@@ -213,7 +213,7 @@ spec:
             value: {{ template "retool.postgresql.ssl_enabled" $ }}
           - name: CODE_EXECUTOR_INGRESS_DOMAIN
             value: http://{{ template "retool.codeExecutor.name" $ }}
-          {{- if $.Values.jsExecutor.enabled }}
+          {{- if eq (include "retool.r2.componentEnabled" (dict "root" $ "component" "jsExecutor")) "1" }}
           - name: JS_EXECUTOR_INGRESS_DOMAIN
             value: http://{{ template "retool.jsExecutor.name" $ }}
           {{- end }}

--- a/charts/retool/templates/agent_sandbox_device_plugin.yaml
+++ b/charts/retool/templates/agent_sandbox_device_plugin.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.agentSandbox.enabled .Values.agentSandbox.sandboxNetwork.deployDaemonSet }}
+{{- if and (eq (include "retool.r2.componentEnabled" (dict "root" $ "component" "agentSandbox")) "1") .Values.agentSandbox.sandboxNetwork.deployDaemonSet }}
 {{- $as := .Values.agentSandbox -}}
 {{- $nodeSelector := $as.nodeSelector | default .Values.nodeSelector -}}
 {{- $tolerations := $as.tolerations | default .Values.tolerations -}}

--- a/charts/retool/templates/agent_sandbox_networkpolicy.yaml
+++ b/charts/retool/templates/agent_sandbox_networkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.agentSandbox.enabled .Values.agentSandbox.networkPolicy.enabled }}
+{{- if and (eq (include "retool.r2.componentEnabled" (dict "root" $ "component" "agentSandbox")) "1") .Values.agentSandbox.networkPolicy.enabled }}
 {{- $as := .Values.agentSandbox -}}
 {{- /*
 =======================================================================

--- a/charts/retool/templates/agent_sandbox_prepuller.yaml
+++ b/charts/retool/templates/agent_sandbox_prepuller.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.agentSandbox.enabled }}
+{{- if eq (include "retool.r2.componentEnabled" (dict "root" $ "component" "agentSandbox")) "1" }}
 {{- $as := .Values.agentSandbox -}}
 {{- $nodeSelector := $as.nodeSelector | default .Values.nodeSelector -}}
 {{- $tolerations := $as.tolerations | default .Values.tolerations -}}

--- a/charts/retool/templates/agent_sandbox_seccomp.yaml
+++ b/charts/retool/templates/agent_sandbox_seccomp.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.agentSandbox.enabled }}
+{{- if eq (include "retool.r2.componentEnabled" (dict "root" $ "component" "agentSandbox")) "1" }}
 {{- $as := .Values.agentSandbox -}}
 {{- $nodeSelector := $as.nodeSelector | default .Values.nodeSelector -}}
 {{- $tolerations := $as.tolerations | default .Values.tolerations -}}

--- a/charts/retool/templates/configmap_js_executor.yaml
+++ b/charts/retool/templates/configmap_js_executor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.jsExecutor.enabled }}
+{{- if eq (include "retool.r2.componentEnabled" (dict "root" $ "component" "jsExecutor")) "1" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/retool/templates/deployment_agent_sandbox.yaml
+++ b/charts/retool/templates/deployment_agent_sandbox.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.agentSandbox.enabled }}
+{{- include "retool.agentSandbox.validateSecrets" . }}
 {{- $as := .Values.agentSandbox -}}
 {{- $defaultSecretName := $as.externalSecret.name | default (include "retool.agentSandbox.name" .) -}}
 {{- $nodeSelector := $as.nodeSelector | default .Values.nodeSelector -}}
@@ -22,7 +23,9 @@ data:
   jwt-private-key: {{ $as.jwtPrivateKey | default "" | b64enc | quote }}
   encryption-key: {{ $as.encryptionKey | default "" | b64enc | quote }}
   api-secret: {{ $as.apiSecret | default "" | b64enc | quote }}
-  postgres-url: {{ $as.postgres.url | default "" | b64enc | quote }}
+  {{- if $as.postgres.url }}
+  postgres-url: {{ $as.postgres.url | b64enc | quote }}
+  {{- end }}
 ---
 {{- end }}
 {{- /*
@@ -300,15 +303,7 @@ spec:
               value: {{ $as.controller.port | quote }}
             - name: STATE_BACKEND
               value: "postgres"
-            - name: AGENT_SANDBOX_POSTGRES_URL
-            {{- if $as.postgres.url }}
-              value: {{ $as.postgres.url | quote }}
-            {{- else }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $defaultSecretName }}
-                  key: postgres-url
-            {{- end }}
+            {{- include "retool.agentSandbox.postgresUrlEnv" . | nindent 12 }}
             - name: AGENT_SANDBOX_POSTGRES_SCHEMA
               value: {{ $as.postgres.schema | quote }}
             - name: AGENT_SANDBOX_POSTGRES_POOL_MAX
@@ -504,15 +499,7 @@ spec:
               value: {{ $as.proxy.port | quote }}
             - name: STATE_BACKEND
               value: "postgres"
-            - name: AGENT_SANDBOX_POSTGRES_URL
-            {{- if $as.postgres.url }}
-              value: {{ $as.postgres.url | quote }}
-            {{- else }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $defaultSecretName }}
-                  key: postgres-url
-            {{- end }}
+            {{- include "retool.agentSandbox.postgresUrlEnv" . | nindent 12 }}
             - name: AGENT_SANDBOX_POSTGRES_SCHEMA
               value: {{ $as.postgres.schema | quote }}
             - name: AGENT_SANDBOX_POSTGRES_POOL_MAX

--- a/charts/retool/templates/deployment_agent_sandbox.yaml
+++ b/charts/retool/templates/deployment_agent_sandbox.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.agentSandbox.enabled }}
+{{- if eq (include "retool.r2.componentEnabled" (dict "root" $ "component" "agentSandbox")) "1" }}
 {{- include "retool.agentSandbox.validateSecrets" . }}
 {{- $as := .Values.agentSandbox -}}
 {{- $defaultSecretName := $as.externalSecret.name | default (include "retool.agentSandbox.name" .) -}}

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -188,7 +188,7 @@ spec:
               {{- end }}
           {{- end }}
           {{- end }}
-          {{- if .Values.jsExecutor.enabled }}
+          {{- if eq (include "retool.r2.componentEnabled" (dict "root" $ "component" "jsExecutor")) "1" }}
           - name: JS_EXECUTOR_INGRESS_DOMAIN
             value: http://{{ template "retool.jsExecutor.name" . }}
           {{- end }}

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -101,7 +101,11 @@ spec:
           {{- if not ( include "retool.jobRunner.enabled" . ) }}
             {{- $serviceType = append $serviceType "JOBS_RUNNER" }}
           {{- end }}
-          {{- if .Values.rrGitServer.enabled }}
+          {{- /*
+            Run the git server in-process on the main backend unless it has been
+            split out into its own deployment (rrGitServer.separate.enabled).
+          */}}
+          {{- if and .Values.rrGitServer.enabled (not (include "retool.rrGitServer.separateEnabled" .)) }}
             {{- $serviceType = append $serviceType "RR_GIT_SERVER" }}
           {{- end }}
           - name: SERVICE_TYPE
@@ -257,68 +261,18 @@ spec:
           {{- end }}
           {{- end }}
           {{- if .Values.rrGitServer.enabled }}
-          {{- $bs := .Values.blobStorage }}
-          {{- if $bs.s3 }}
-          - name: RR_BLOB_STORAGE_PROVIDER
-            value: "s3"
-          - name: RR_DEFAULT_S3_BUCKET
-            value: {{ $bs.s3.bucket | quote }}
-          {{- if $bs.s3.region }}
-          - name: RR_DEFAULT_S3_REGION
-            value: {{ $bs.s3.region | quote }}
-          {{- end }}
-          {{- if $bs.s3.endpoint }}
-          - name: RR_DEFAULT_S3_ENDPOINT
-            value: {{ $bs.s3.endpoint | quote }}
-          {{- end }}
-          {{- if $bs.s3.accessKeyId }}
-          - name: RR_DEFAULT_S3_ACCESS_KEY_ID
-            value: {{ $bs.s3.accessKeyId | quote }}
-          {{- end }}
-          {{- if $bs.s3.secretAccessKeySecretName }}
-          - name: RR_DEFAULT_S3_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: {{ $bs.s3.secretAccessKeySecretName }}
-                key: {{ $bs.s3.secretAccessKeySecretKey | default "secret-access-key" }}
-          {{- else if $bs.s3.secretAccessKey }}
-          - name: RR_DEFAULT_S3_SECRET_ACCESS_KEY
-            value: {{ $bs.s3.secretAccessKey | quote }}
-          {{- end }}
-          {{- else if $bs.gcs }}
-          - name: RR_BLOB_STORAGE_PROVIDER
-            value: "gcs"
-          - name: RR_DEFAULT_GCS_BUCKET
-            value: {{ $bs.gcs.bucket | quote }}
-          {{- if $bs.gcs.credentialsSecretName }}
-          - name: RR_DEFAULT_GCS_CREDENTIALS
-            valueFrom:
-              secretKeyRef:
-                name: {{ $bs.gcs.credentialsSecretName }}
-                key: {{ $bs.gcs.credentialsSecretKey | default "credentials.json" }}
-          {{- else if $bs.gcs.credentials }}
-          - name: RR_DEFAULT_GCS_CREDENTIALS
-            value: {{ $bs.gcs.credentials | quote }}
-          {{- end }}
-          {{- else if $bs.azure }}
-          - name: RR_BLOB_STORAGE_PROVIDER
-            value: "azure"
-          - name: RR_DEFAULT_AZURE_CONTAINER
-            value: {{ $bs.azure.container | quote }}
-          {{- if $bs.azure.connectionStringSecretName }}
-          - name: RR_DEFAULT_AZURE_CONNECTION_STRING
-            valueFrom:
-              secretKeyRef:
-                name: {{ $bs.azure.connectionStringSecretName }}
-                key: {{ $bs.azure.connectionStringSecretKey | default "connection-string" }}
-          {{- else if $bs.azure.connectionString }}
-          - name: RR_DEFAULT_AZURE_CONNECTION_STRING
-            value: {{ $bs.azure.connectionString | quote }}
-          {{- end }}
-          {{- end }}
-          {{- if .Values.rrGitServer.repackThreshold }}
-          - name: RR_GIT_REPACK_THRESHOLD
-            value: {{ .Values.rrGitServer.repackThreshold | quote }}
+          {{- if include "retool.rrGitServer.separateEnabled" . }}
+          {{- /*
+            git server runs in its own deployment; point the main backend's
+            proxy (/api/ai/rr/git/v2/*) at the git-server service instead of
+            localhost.
+          */}}
+          - name: RR_GIT_SERVER_HOST
+            value: {{ template "retool.rrGitServer.name" . }}
+          - name: RR_GIT_SERVER_PORT
+            value: {{ include "retool.rrGitServer.port" . | quote }}
+          {{- else }}
+          {{- include "retool.rrGitServer.commonEnv" . | nindent 10 }}
           {{- end }}
           {{- end }}
           {{- include "retool.env" .Values.env | nindent 10 }}

--- a/charts/retool/templates/deployment_git_server.yaml
+++ b/charts/retool/templates/deployment_git_server.yaml
@@ -1,0 +1,296 @@
+{{- if include "retool.rrGitServer.separateEnabled" . }}
+{{- include "retool.rrGitServer.validateBlobStorage" . }}
+{{- $gitServerPort := include "retool.rrGitServer.port" . }}
+{{- $gitServerValues := .Values.rrGitServer.separate }}
+{{- $gitServerService := $gitServerValues.service | default dict }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "retool.rrGitServer.name" . }}
+  labels:
+    {{- include "retool.labels" . | nindent 4 }}
+  {{- with $gitServerService.labels }}
+  {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+  {{- with $gitServerService.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  selector:
+    retoolService: {{ template "retool.rrGitServer.name" . }}
+  ports:
+  - name: http-server
+    protocol: TCP
+    port: {{ $gitServerPort }}
+    targetPort: {{ $gitServerPort }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "retool.rrGitServer.name" . }}
+  labels:
+{{- include "retool.labels" . | nindent 4 }}
+{{- if .Values.deployment.annotations }}
+  annotations:
+{{ toYaml .Values.deployment.annotations | indent 4 }}
+{{- end }}
+spec:
+  replicas: {{ $gitServerValues.replicaCount | default 1 }}
+  selector:
+    matchLabels:
+      retoolService: {{ template "retool.rrGitServer.name" . }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  template:
+    metadata:
+      annotations:
+{{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
+{{- with $gitServerValues.annotations }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+      labels:
+        {{- include "retool.labels" . | nindent 8 }}
+        retoolService: {{ template "retool.rrGitServer.name" . }}
+        telemetry.retool.com/service-name: rr-git-server
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
+{{- with $gitServerValues.labels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+    spec:
+      serviceAccountName: {{ template "retool.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
+{{- if .Values.initContainers }}
+      initContainers:
+{{- range $key, $value := .Values.initContainers }}
+      - name: "{{ $key }}"
+{{ toYaml $value | indent 8 }}
+{{- end }}
+{{- end }}
+      containers:
+      - name: rr-git-server
+        image: "{{ .Values.image.repository }}:{{ required "Please set a value for .Values.image.tag" .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+          - bash
+          - -c
+          - chmod -R +x ./docker_scripts; sync; ./docker_scripts/wait-for-it.sh -t 0 {{ template "retool.postgresql.host" . }}:{{ template "retool.postgresql.port" . }}; ./docker_scripts/start_api.sh
+        {{- if .Values.commandline.args }}
+{{ toYaml .Values.commandline.args | indent 10 }}
+        {{- end }}
+        env:
+          - name: DEPLOYMENT_TEMPLATE_TYPE
+            value: {{ template "retool.deploymentTemplateType" . }}
+          - name: DEPLOYMENT_TEMPLATE_VERSION
+            value: {{ template "retool.deploymentTemplateVersion" . }}
+          - name: NODE_ENV
+            value: production
+          - name: SERVICE_TYPE
+            value: RR_GIT_SERVER
+          - name: RR_GIT_SERVER_PORT
+            value: {{ $gitServerPort | quote }}
+          # The standalone git server does not run migrations; the main backend owns them.
+          - name: DISABLE_DATABASE_MIGRATIONS
+            value: "true"
+          - name: COOKIE_INSECURE
+            value: {{ .Values.config.useInsecureCookies | quote }}
+          - name: POSTGRES_HOST
+            value: {{ template "retool.postgresql.host" . }}
+          - name: POSTGRES_PORT
+            value: {{ template "retool.postgresql.port" . }}
+          - name: POSTGRES_DB
+            value: {{ template "retool.postgresql.database" . }}
+          - name: POSTGRES_USER
+            value: {{ template "retool.postgresql.user" . }}
+          - name: POSTGRES_SSL_ENABLED
+            value: {{ template "retool.postgresql.ssl_enabled" . }}
+
+          {{- include "retool.telemetry.includeEnvVars" . | nindent 10 }}
+
+          {{- if include "shouldIncludeConfigSecretsEnvVars" . }}
+          - name: LICENSE_KEY
+            valueFrom:
+              secretKeyRef:
+                {{- if .Values.config.licenseKeySecretName }}
+                name: {{ .Values.config.licenseKeySecretName }}
+                key: {{ .Values.config.licenseKeySecretKey | default "license-key" }}
+                {{- else }}
+                name: {{ template "retool.fullname" . }}
+                key: license-key
+                {{- end }}
+          - name: JWT_SECRET
+            valueFrom:
+              secretKeyRef:
+                {{- if .Values.config.jwtSecretSecretName }}
+                name: {{ .Values.config.jwtSecretSecretName }}
+                key: {{ .Values.config.jwtSecretSecretKey | default "jwt-secret" }}
+                {{- else }}
+                name: {{ template "retool.fullname" . }}
+                key: jwt-secret
+                {{- end }}
+          - name: ENCRYPTION_KEY
+            valueFrom:
+              secretKeyRef:
+                {{- if .Values.config.encryptionKeySecretName }}
+                name: {{ .Values.config.encryptionKeySecretName }}
+                key: {{ .Values.config.encryptionKeySecretKey | default "encryption-key" }}
+                {{- else }}
+                name: {{ template "retool.fullname" . }}
+                key: encryption-key
+                {{- end }}
+          - name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+          {{- if .Values.postgresql.enabled }}
+                name: {{ template "retool.postgresql.fullname" . }}
+                # `postgres` is the default admin username for postgres in the subchart we use, so it needs the admin password
+                # if a different username is picked, then it needs the custom password instead.
+                {{- if eq .Values.postgresql.auth.username "postgres" }}
+                key: postgres-password
+                {{- else }}
+                key: password
+                {{- end }}
+          {{- else }}
+                {{- if .Values.config.postgresql.passwordSecretName }}
+                name: {{ .Values.config.postgresql.passwordSecretName }}
+                key: {{ .Values.config.postgresql.passwordSecretKey | default "postgresql-password" }}
+                {{- else }}
+                name: {{ template "retool.fullname" . }}
+                key: postgresql-password
+                {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- include "retool.rrGitServer.commonEnv" . | nindent 10 }}
+          {{- include "retool.env" .Values.env | nindent 10 }}
+          {{- range .Values.environmentSecrets }}
+          - name: {{ .name }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ .secretKeyRef.name }}
+                key: {{ .secretKeyRef.key }}
+          {{- end }}
+          {{- with .Values.environmentVariables }}
+{{ toYaml . | indent 10 }}
+          {{- end }}
+        {{- if .Values.externalSecrets.enabled }}
+        envFrom:
+        - secretRef:
+            name: {{ .Values.externalSecrets.name }}
+        {{- range .Values.externalSecrets.secrets }}
+        - secretRef:
+            name: {{ .name }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.externalSecrets.externalSecretsOperator.enabled }}
+        envFrom:
+        {{- range .Values.externalSecrets.externalSecretsOperator.secretRef }}
+        - secretRef:
+            name: {{ .name }}
+            optional: {{ .optional | default false }}
+        {{- end }}
+        {{- end }}
+        ports:
+        - containerPort: {{ $gitServerPort }}
+          name: http-server
+          protocol: TCP
+        readinessProbe:
+          tcpSocket:
+            port: {{ $gitServerPort }}
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: {{ $gitServerPort }}
+          initialDelaySeconds: 30
+          failureThreshold: 10
+          timeoutSeconds: 10
+          periodSeconds: 20
+        resources:
+{{ toYaml ($gitServerValues.resources | default .Values.resources) | indent 10 }}
+        volumeMounts:
+        {{- range $configFile := (keys .Values.files) }}
+        - name: {{ template "retool.name" $ }}
+          mountPath: "/usr/share/retool/config/{{ $configFile }}"
+          subPath: {{ $configFile }}
+        {{- end }}
+        {{if and .Values.persistentVolumeClaim.enabled .Values.persistentVolumeClaim.mountPath }}
+        - name: retool-pv
+          mountPath: {{ .Values.persistentVolumeClaim.mountPath }}
+        {{- end }}
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 8 }}
+{{- end }}
+{{- if .Values.securityContext.extraContainerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.securityContext.extraContainerSecurityContext | indent 10 }}
+{{- end }}
+{{- with .Values.extraContainers }}
+{{ tpl . $ | indent 6 }}
+{{- end }}
+{{- range .Values.extraConfigMapMounts }}
+        - name: {{ .name }}
+          mountPath: {{ .mountPath }}
+          subPath: {{ .subPath }}
+{{- end }}
+    {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.image.pullSecrets | indent 8 }}
+    {{- end }}
+    {{- $affinity := $gitServerValues.affinity | default .Values.affinity }}
+    {{- if $affinity }}
+      affinity:
+{{ toYaml $affinity | indent 8 }}
+    {{- end }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+{{- if .Values.securityContext.enabled }}
+      securityContext:
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+{{- if .Values.securityContext.extraSecurityContext }}
+{{ toYaml .Values.securityContext.extraSecurityContext | indent 8 }}
+{{- end }}
+{{- end }}
+      volumes:
+{{- range .Values.extraConfigMapMounts }}
+        - name: {{ .name }}
+          configMap:
+            name: {{ .configMap }}
+{{- end }}
+      {{- if .Values.persistentVolumeClaim.enabled }}
+        - name: retool-pv
+          persistentVolumeClaim:
+            claimName: {{ default (include "retool.fullname" .) .Values.persistentVolumeClaim.existingClaim }}
+      {{- end }}
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 8 }}
+{{- end }}
+{{- if .Values.podDisruptionBudget }}
+---
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.Version }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "retool.rrGitServer.name" . }}
+spec:
+  {{- toYaml .Values.podDisruptionBudget | nindent 2 }}
+  selector:
+    matchLabels:
+      retoolService: {{ template "retool.rrGitServer.name" . }}
+{{- end }}
+{{- end }}

--- a/charts/retool/templates/deployment_jobs.yaml
+++ b/charts/retool/templates/deployment_jobs.yaml
@@ -93,7 +93,7 @@ spec:
 
           {{- include "retool.telemetry.includeEnvVars" . | nindent 10 }}
 
-          {{- if .Values.agentSandbox.enabled }}
+          {{- if eq (include "retool.r2.componentEnabled" (dict "root" $ "component" "agentSandbox")) "1" }}
           - name: RR_AGENT_PUBSUB_BACKEND
             value: "postgres"
           {{- end }}

--- a/charts/retool/templates/deployment_js_executor.yaml
+++ b/charts/retool/templates/deployment_js_executor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.jsExecutor.enabled }}
+{{- if eq (include "retool.r2.componentEnabled" (dict "root" $ "component" "jsExecutor")) "1" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/retool/templates/deployment_js_executor.yaml
+++ b/charts/retool/templates/deployment_js_executor.yaml
@@ -82,7 +82,7 @@ spec:
       containers:
       - name: js-executor
         image: "{{ .Values.jsExecutor.image.repository }}:{{ include "retool.jsExecutor.image.tag" . }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        imagePullPolicy: {{ .Values.jsExecutor.image.pullPolicy | default .Values.image.pullPolicy }}
         securityContext:
           capabilities:
             add: ["NET_ADMIN"]

--- a/charts/retool/templates/deployment_js_executor.yaml
+++ b/charts/retool/templates/deployment_js_executor.yaml
@@ -97,18 +97,15 @@ spec:
           - name: NODE_ENV
             value: production
           {{- include "retool.telemetry.includeEnvVars" . | nindent 10 }}
-          {{- range $key, $value := .Values.env }}
-          - name: "{{ $key }}"
-            value: "{{ $value }}"
-          {{- end }}
-          {{- range .Values.environmentSecrets }}
+          {{- include "retool.env" .Values.jsExecutor.env | nindent 10 }}
+          {{- range .Values.jsExecutor.environmentSecrets }}
           - name: {{ .name }}
             valueFrom:
               secretKeyRef:
                 name: {{ .secretKeyRef.name }}
                 key: {{ .secretKeyRef.key }}
           {{- end }}
-          {{- with .Values.environmentVariables }}
+          {{- with .Values.jsExecutor.environmentVariables }}
 {{ toYaml . | indent 10 }}
           {{- end }}
         ports:

--- a/charts/retool/templates/deployment_mcp.yaml
+++ b/charts/retool/templates/deployment_mcp.yaml
@@ -115,9 +115,17 @@ spec:
             value: {{ $mcpInternalPort | quote }}
           - name: RETOOL_BACKEND_URL
             value: {{ $mcpConfig.retoolBackendUrl | default (printf "http://%s:%v" (include "retool.fullname" .) .Values.service.externalPort) | quote }}
-          {{- if $mcpConfig.retoolGitServerUrl }}
+          {{- /*
+            Prefer an explicit mcp.config.retoolGitServerUrl; otherwise, when the
+            git server is split into its own deployment, auto-point MCP at it.
+          */}}
+          {{- $retoolGitServerUrl := $mcpConfig.retoolGitServerUrl }}
+          {{- if and (not $retoolGitServerUrl) (include "retool.rrGitServer.separateEnabled" .) }}
+          {{- $retoolGitServerUrl = include "retool.rrGitServer.url" . }}
+          {{- end }}
+          {{- if $retoolGitServerUrl }}
           - name: RETOOL_GIT_SERVER_URL
-            value: {{ $mcpConfig.retoolGitServerUrl | quote }}
+            value: {{ $retoolGitServerUrl | quote }}
           {{- end }}
           {{- if $mcpConfig.retoolUrl }}
           - name: RETOOL_URL

--- a/charts/retool/templates/deployment_mcp.yaml
+++ b/charts/retool/templates/deployment_mcp.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.mcp.enabled }}
+{{- if eq (include "retool.r2.componentEnabled" (dict "root" $ "component" "mcp")) "1" }}
 {{- $mcpConfig := .Values.mcp.config | default dict }}
 {{- $hasOAuthIntrospectionAuthTokenEnv := false }}
 {{- range .Values.mcp.environmentVariables }}
@@ -7,7 +7,7 @@
 {{- end }}
 {{- end }}
 {{- if not (or $mcpConfig.oauthIntrospectionAuthTokenSecretName $mcpConfig.oauthIntrospectionAuthToken $hasOAuthIntrospectionAuthTokenEnv) }}
-{{- fail "Please set .Values.mcp.config.oauthIntrospectionAuthTokenSecretName, .Values.mcp.config.oauthIntrospectionAuthToken, or an OAUTH_INTROSPECTION_AUTH_TOKEN entry in .Values.mcp.environmentVariables when .Values.mcp.enabled is true" }}
+{{- fail "Please set .Values.mcp.config.oauthIntrospectionAuthTokenSecretName, .Values.mcp.config.oauthIntrospectionAuthToken, or an OAUTH_INTROSPECTION_AUTH_TOKEN entry in .Values.mcp.environmentVariables when the MCP server is enabled (.Values.mcp.enabled, or inherited from .Values.r2.enabled)" }}
 {{- end }}
 {{- $mcpInternalPort := .Values.mcp.service.internalPort | default 4010 }}
 apiVersion: v1

--- a/charts/retool/templates/deployment_workflows.yaml
+++ b/charts/retool/templates/deployment_workflows.yaml
@@ -153,7 +153,7 @@ spec:
               {{- end }}
           {{- end }}
           {{- end }}
-          {{- if .Values.jsExecutor.enabled }}
+          {{- if eq (include "retool.r2.componentEnabled" (dict "root" $ "component" "jsExecutor")) "1" }}
           - name: JS_EXECUTOR_INGRESS_DOMAIN
             value: http://{{ template "retool.jsExecutor.name" . }}
           {{- end }}

--- a/charts/retool/templates/httproute.yaml
+++ b/charts/retool/templates/httproute.yaml
@@ -56,7 +56,7 @@ spec:
         - name: {{ $fullName }}
           port: {{ $svcPort }}
     {{- end }}
-{{- if and .Values.agentSandbox.enabled .Values.agentSandbox.frontendWsProxyDomain }}
+{{- if and (eq (include "retool.r2.componentEnabled" (dict "root" $ "component" "agentSandbox")) "1") .Values.agentSandbox.frontendWsProxyDomain }}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -971,33 +971,57 @@ agentSandbox:
   # Labels for agent sandbox pods
   labels: {}
 
-  # Pre-existing K8s Secret containing keys: jwt-public-key, jwt-private-key,
-  # encryption-key, api-secret, postgres-url. When set, the chart references
-  # this secret by default for all secret-backed env vars.
-  #
-  # Individual keys can still be overridden by setting the corresponding
-  # plaintext values below (e.g. jwtPublicKey, postgres.url). When a plaintext
-  # value is provided alongside externalSecret.name, the plaintext value takes
-  # precedence for that key and the external secret is used for the rest.
+  # === Secrets ============================================================
+  # Provide each secret as a plaintext value below, OR set externalSecret.name
+  # to a pre-existing Secret with keys jwt-public-key, jwt-private-key,
+  # encryption-key, api-secret, postgres-url. A plaintext value always wins over
+  # the external secret for that key.
   externalSecret:
-    name: ''
+    name: ''                 # optional: existing Secret holding all keys below
 
-  # Secrets — used directly when externalSecret.name is not set, or as
-  # per-key overrides when externalSecret.name IS set.
-  # JWT key pair (ES256) for sandbox token authentication.
-  jwtPublicKey: ''
-  jwtPrivateKey: ''
-  # Hex-encoded 256-bit key for encrypting credentials stored in state backend.
-  # Must match the backend's AGENT_SANDBOX_ENCRYPTION_KEY.
-  encryptionKey: ''
-  # API secret for admin/test endpoints.
-  apiSecret: ''
+  jwtPublicKey: ''           # REQUIRED (ES256) unless provided via externalSecret
+  jwtPrivateKey: ''          # REQUIRED (ES256) unless provided via externalSecret
+  encryptionKey: ''          # optional: hex 256-bit; must match backend AGENT_SANDBOX_ENCRYPTION_KEY
+  apiSecret: ''              # optional: admin/test endpoints
 
-  # Postgres state backend (shared by controller and proxy for state coordination).
-  # Connection string for the agent sandbox's state database. When set, takes
-  # precedence over the postgres-url key in externalSecret.
+  # === Postgres state backend =============================================
+  # By DEFAULT (all options below left blank) the agent sandbox reuses the
+  # backend's Postgres connection from config.postgresql / the postgresql
+  # subchart -- same instance and database, separate schema (see schema below).
+  # So enabling it on an existing deployment needs nothing here. (Exception:
+  # if the backend's DB password is supplied via external secrets / envFrom, it
+  # can't be inherited by a separate pod -- set an option below in that case.)
+  # To point the sandbox at a different database, set exactly ONE option:
   postgres:
+    # -- Option 1: plaintext DSN --
     url: ''
+
+    # -- Option 2: assemble from fields --
+    # The password is passed via PGPASSWORD (never embedded in the URL), so any
+    # characters are safe and a password-only secret can be reused as-is.
+    # Set either password or passwordSecretName.
+    # user/database are embedded in the DSN verbatim (user may contain '@', e.g.
+    # Azure user@servername); for values with : / ? # use Option 1 or 3.
+    host: ''
+    port: 5432
+    database: ''
+    user: ''
+    password: ''
+    passwordSecretName: ''
+    passwordSecretKey: 'password'
+
+    # -- Option 3: existing Secret holding the full DSN --
+    urlSecretName: ''
+    urlSecretKey: 'postgres-url'
+
+    # -- Option 4: reuse externalSecret.name (its postgres-url key) --
+    # Selected by setting agentSandbox.externalSecret.name (in the Secrets
+    # section above), not by anything here. Used when options 1-3 are blank.
+    #
+    # If options 1-4 are ALL unset, the default (inherit config.postgresql)
+    # applies -- see the note at the top of this block.
+
+    # -- Optional tuning (defaults shown) --
     schema: 'agent_executor'
     poolMax: 10
     sweeperIntervalMs: 60000

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -735,6 +735,34 @@ rrGitServer:
   # RR_DEFAULT_* are provided that way.
   skipBlobStorageValidation: false
 
+  # Optionally split the git server out of the main backend into its own
+  # deployment + service (mirrors how the workload is split in Retool Cloud).
+  # Requires rrGitServer.enabled: true. When enabled:
+  #   - a dedicated <release>-git-server Deployment runs SERVICE_TYPE=RR_GIT_SERVER
+  #   - the main backend drops RR_GIT_SERVER from its SERVICE_TYPE and proxies git
+  #     traffic to the service via RR_GIT_SERVER_HOST / RR_GIT_SERVER_PORT
+  #   - the MCP server (if enabled) is auto-pointed at the same service unless
+  #     mcp.config.retoolGitServerUrl is set explicitly
+  # The blobStorage config below is rendered onto the git-server pod instead of
+  # the main backend in this mode.
+  separate:
+    enabled: false
+    replicaCount: 1
+    # Port the git server listens on (RR_GIT_SERVER_PORT) and that its service exposes.
+    port: 3010
+    # Pod resource requests/limits. Falls back to top-level `resources` if unset.
+    resources: {}
+    # Falls back to top-level `affinity` if unset.
+    affinity: {}
+    # Annotations/labels applied to the git-server pod template.
+    annotations: {}
+    labels: {}
+    # Annotations/labels applied to the git-server Service (kept separate from
+    # the pod ones above).
+    service:
+      annotations: {}
+      labels: {}
+
 # Shared blob-storage config used by git_server (and other features that
 # need object storage, e.g. snapshots). Set exactly one of s3, gcs, azure.
 # Renders RR_BLOB_STORAGE_PROVIDER + RR_DEFAULT_<provider>_* env vars on

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -564,8 +564,9 @@ multiplayer:
     labels: {}
 
 mcp:
-  # Enable this to run Retool's MCP server as a separate deployment.
-  enabled: false
+  # Run Retool's MCP server as a separate deployment. Inherits .Values.r2.enabled
+  # when left unset (null); set true/false to override.
+  enabled: null
 
   replicaCount: 1
 
@@ -839,9 +840,20 @@ codeExecutor:
   securityContext:
     privileged: true
 
+# === R2 (Retool agent runtime) =============================================
+# Master switch for the whole R2 stack: the r2Agent worker, jsExecutor,
+# agentSandbox, and mcp server. Set `r2.enabled: true` to turn them all on with
+# one line. Each component's own `enabled` (left null by default) inherits this
+# switch; set a component's `enabled` to true/false to override the master for
+# that component only. Shared R2 configuration can be added under this block
+# later.
+r2:
+  enabled: false
+
 # JS Executor
 jsExecutor:
-  enabled: false
+  # Inherits .Values.r2.enabled when left unset (null); set true/false to override.
+  enabled: null
 
   image:
     repository: tryretool/js-executor-service
@@ -921,7 +933,8 @@ agents:
 
 # R2 Agent: server-side agent loop worker (independent from agents above).
 r2Agent:
-  enabled: false
+  # Inherits .Values.r2.enabled when left unset (null); set true/false to override.
+  enabled: null
 
   # Labels for R2 agent worker pods
   labels: {}
@@ -948,7 +961,8 @@ r2Agent:
 # Deploys a controller (manages sandbox lifecycle), proxy (HTTP proxy for sandbox egress),
 # and ephemeral Job-based sandboxes. Uses Postgres for controller/proxy state.
 agentSandbox:
-  enabled: false
+  # Inherits .Values.r2.enabled when left unset (null); set true/false to override.
+  enabled: null
 
   image:
     repository: tryretool/agent-sandbox-service

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -728,6 +728,13 @@ rrGitServer:
   # Backend default is 100; unset to inherit it.
   repackThreshold: ~
 
+  # Escape hatch for the blob-storage validation below. The chart can only
+  # inspect blobStorage, env, environmentVariables, and environmentSecrets at
+  # template time; it cannot see env vars injected via envFrom (Secret/ConfigMap
+  # splat). Set this to true to bypass the check when RR_BLOB_STORAGE_PROVIDER /
+  # RR_DEFAULT_* are provided that way.
+  skipBlobStorageValidation: false
+
 # Shared blob-storage config used by git_server (and other features that
 # need object storage, e.g. snapshots). Set exactly one of s3, gcs, azure.
 # Renders RR_BLOB_STORAGE_PROVIDER + RR_DEFAULT_<provider>_* env vars on

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -818,6 +818,12 @@ jsExecutor:
 
   seccompLocalhostProfile: profiles/nsjail-seccomp.json
 
+  # JS-executor-specific environment; not inherited from the top-level
+  # .Values.env / .Values.environmentSecrets / .Values.environmentVariables.
+  env: {}
+  environmentSecrets: []
+  environmentVariables: []
+
   # Annotations for JS executor pods
   annotations: {}
 
@@ -830,14 +836,16 @@ jsExecutor:
   # Config affinity and anti-affinity rules for the JS executor pods
   affinity: {}
 
-  # Resources for the JS executor
+  # Resources for the JS executor. Memory request and limit are kept equal:
+  # JSE reads its memory limit and rejects requests at 80% of it, so the
+  # request must reserve the full amount to avoid premature rejections.
   resources:
     limits:
-      cpu: 2000m
-      memory: 8192Mi
+      cpu: 6000m
+      memory: 6Gi
     requests:
-      cpu: 1000m
-      memory: 4096Mi
+      cpu: 6000m
+      memory: 6Gi
 
 agents:
   # Enable AI Agents

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -1111,8 +1111,13 @@ agentSandbox:
   # controllerUrl and proxyUrl default to internal service URLs when empty.
   controllerUrl: ''
   proxyUrl: ''
-  # Required: public URL for frontend browsers to reach the proxy via WebSocket.
-  # e.g. https://sandbox.yourdomain.com
+  # Public URL for frontend browsers to reach the proxy via WebSocket.
+  # Leave EMPTY for self-hosted: the backend then serves the sandbox same-origin
+  # as the editor (your Retool base URL) and the front server reverse-proxies the
+  # /sandbox/* WS+Vite paths to the in-cluster proxy Service — so no dedicated
+  # proxy domain or ingress is required, and your catch-all ingress is untouched.
+  # Only set this (e.g. https://sandbox.yourdomain.com) if you deliberately want
+  # the proxy on a separate domain, in which case also enable proxy.ingress above.
   frontendWsProxyDomain: ''
   # Public URL for proxy domain. Defaults to frontendWsProxyDomain if empty.
   proxyDomain: ''

--- a/values.yaml
+++ b/values.yaml
@@ -971,33 +971,57 @@ agentSandbox:
   # Labels for agent sandbox pods
   labels: {}
 
-  # Pre-existing K8s Secret containing keys: jwt-public-key, jwt-private-key,
-  # encryption-key, api-secret, postgres-url. When set, the chart references
-  # this secret by default for all secret-backed env vars.
-  #
-  # Individual keys can still be overridden by setting the corresponding
-  # plaintext values below (e.g. jwtPublicKey, postgres.url). When a plaintext
-  # value is provided alongside externalSecret.name, the plaintext value takes
-  # precedence for that key and the external secret is used for the rest.
+  # === Secrets ============================================================
+  # Provide each secret as a plaintext value below, OR set externalSecret.name
+  # to a pre-existing Secret with keys jwt-public-key, jwt-private-key,
+  # encryption-key, api-secret, postgres-url. A plaintext value always wins over
+  # the external secret for that key.
   externalSecret:
-    name: ''
+    name: ''                 # optional: existing Secret holding all keys below
 
-  # Secrets — used directly when externalSecret.name is not set, or as
-  # per-key overrides when externalSecret.name IS set.
-  # JWT key pair (ES256) for sandbox token authentication.
-  jwtPublicKey: ''
-  jwtPrivateKey: ''
-  # Hex-encoded 256-bit key for encrypting credentials stored in state backend.
-  # Must match the backend's AGENT_SANDBOX_ENCRYPTION_KEY.
-  encryptionKey: ''
-  # API secret for admin/test endpoints.
-  apiSecret: ''
+  jwtPublicKey: ''           # REQUIRED (ES256) unless provided via externalSecret
+  jwtPrivateKey: ''          # REQUIRED (ES256) unless provided via externalSecret
+  encryptionKey: ''          # optional: hex 256-bit; must match backend AGENT_SANDBOX_ENCRYPTION_KEY
+  apiSecret: ''              # optional: admin/test endpoints
 
-  # Postgres state backend (shared by controller and proxy for state coordination).
-  # Connection string for the agent sandbox's state database. When set, takes
-  # precedence over the postgres-url key in externalSecret.
+  # === Postgres state backend =============================================
+  # By DEFAULT (all options below left blank) the agent sandbox reuses the
+  # backend's Postgres connection from config.postgresql / the postgresql
+  # subchart -- same instance and database, separate schema (see schema below).
+  # So enabling it on an existing deployment needs nothing here. (Exception:
+  # if the backend's DB password is supplied via external secrets / envFrom, it
+  # can't be inherited by a separate pod -- set an option below in that case.)
+  # To point the sandbox at a different database, set exactly ONE option:
   postgres:
+    # -- Option 1: plaintext DSN --
     url: ''
+
+    # -- Option 2: assemble from fields --
+    # The password is passed via PGPASSWORD (never embedded in the URL), so any
+    # characters are safe and a password-only secret can be reused as-is.
+    # Set either password or passwordSecretName.
+    # user/database are embedded in the DSN verbatim (user may contain '@', e.g.
+    # Azure user@servername); for values with : / ? # use Option 1 or 3.
+    host: ''
+    port: 5432
+    database: ''
+    user: ''
+    password: ''
+    passwordSecretName: ''
+    passwordSecretKey: 'password'
+
+    # -- Option 3: existing Secret holding the full DSN --
+    urlSecretName: ''
+    urlSecretKey: 'postgres-url'
+
+    # -- Option 4: reuse externalSecret.name (its postgres-url key) --
+    # Selected by setting agentSandbox.externalSecret.name (in the Secrets
+    # section above), not by anything here. Used when options 1-3 are blank.
+    #
+    # If options 1-4 are ALL unset, the default (inherit config.postgresql)
+    # applies -- see the note at the top of this block.
+
+    # -- Optional tuning (defaults shown) --
     schema: 'agent_executor'
     poolMax: 10
     sweeperIntervalMs: 60000

--- a/values.yaml
+++ b/values.yaml
@@ -735,6 +735,34 @@ rrGitServer:
   # RR_DEFAULT_* are provided that way.
   skipBlobStorageValidation: false
 
+  # Optionally split the git server out of the main backend into its own
+  # deployment + service (mirrors how the workload is split in Retool Cloud).
+  # Requires rrGitServer.enabled: true. When enabled:
+  #   - a dedicated <release>-git-server Deployment runs SERVICE_TYPE=RR_GIT_SERVER
+  #   - the main backend drops RR_GIT_SERVER from its SERVICE_TYPE and proxies git
+  #     traffic to the service via RR_GIT_SERVER_HOST / RR_GIT_SERVER_PORT
+  #   - the MCP server (if enabled) is auto-pointed at the same service unless
+  #     mcp.config.retoolGitServerUrl is set explicitly
+  # The blobStorage config below is rendered onto the git-server pod instead of
+  # the main backend in this mode.
+  separate:
+    enabled: false
+    replicaCount: 1
+    # Port the git server listens on (RR_GIT_SERVER_PORT) and that its service exposes.
+    port: 3010
+    # Pod resource requests/limits. Falls back to top-level `resources` if unset.
+    resources: {}
+    # Falls back to top-level `affinity` if unset.
+    affinity: {}
+    # Annotations/labels applied to the git-server pod template.
+    annotations: {}
+    labels: {}
+    # Annotations/labels applied to the git-server Service (kept separate from
+    # the pod ones above).
+    service:
+      annotations: {}
+      labels: {}
+
 # Shared blob-storage config used by git_server (and other features that
 # need object storage, e.g. snapshots). Set exactly one of s3, gcs, azure.
 # Renders RR_BLOB_STORAGE_PROVIDER + RR_DEFAULT_<provider>_* env vars on

--- a/values.yaml
+++ b/values.yaml
@@ -564,8 +564,9 @@ multiplayer:
     labels: {}
 
 mcp:
-  # Enable this to run Retool's MCP server as a separate deployment.
-  enabled: false
+  # Run Retool's MCP server as a separate deployment. Inherits .Values.r2.enabled
+  # when left unset (null); set true/false to override.
+  enabled: null
 
   replicaCount: 1
 
@@ -839,9 +840,20 @@ codeExecutor:
   securityContext:
     privileged: true
 
+# === R2 (Retool agent runtime) =============================================
+# Master switch for the whole R2 stack: the r2Agent worker, jsExecutor,
+# agentSandbox, and mcp server. Set `r2.enabled: true` to turn them all on with
+# one line. Each component's own `enabled` (left null by default) inherits this
+# switch; set a component's `enabled` to true/false to override the master for
+# that component only. Shared R2 configuration can be added under this block
+# later.
+r2:
+  enabled: false
+
 # JS Executor
 jsExecutor:
-  enabled: false
+  # Inherits .Values.r2.enabled when left unset (null); set true/false to override.
+  enabled: null
 
   image:
     repository: tryretool/js-executor-service
@@ -921,7 +933,8 @@ agents:
 
 # R2 Agent: server-side agent loop worker (independent from agents above).
 r2Agent:
-  enabled: false
+  # Inherits .Values.r2.enabled when left unset (null); set true/false to override.
+  enabled: null
 
   # Labels for R2 agent worker pods
   labels: {}
@@ -948,7 +961,8 @@ r2Agent:
 # Deploys a controller (manages sandbox lifecycle), proxy (HTTP proxy for sandbox egress),
 # and ephemeral Job-based sandboxes. Uses Postgres for controller/proxy state.
 agentSandbox:
-  enabled: false
+  # Inherits .Values.r2.enabled when left unset (null); set true/false to override.
+  enabled: null
 
   image:
     repository: tryretool/agent-sandbox-service

--- a/values.yaml
+++ b/values.yaml
@@ -728,6 +728,13 @@ rrGitServer:
   # Backend default is 100; unset to inherit it.
   repackThreshold: ~
 
+  # Escape hatch for the blob-storage validation below. The chart can only
+  # inspect blobStorage, env, environmentVariables, and environmentSecrets at
+  # template time; it cannot see env vars injected via envFrom (Secret/ConfigMap
+  # splat). Set this to true to bypass the check when RR_BLOB_STORAGE_PROVIDER /
+  # RR_DEFAULT_* are provided that way.
+  skipBlobStorageValidation: false
+
 # Shared blob-storage config used by git_server (and other features that
 # need object storage, e.g. snapshots). Set exactly one of s3, gcs, azure.
 # Renders RR_BLOB_STORAGE_PROVIDER + RR_DEFAULT_<provider>_* env vars on

--- a/values.yaml
+++ b/values.yaml
@@ -818,6 +818,12 @@ jsExecutor:
 
   seccompLocalhostProfile: profiles/nsjail-seccomp.json
 
+  # JS-executor-specific environment; not inherited from the top-level
+  # .Values.env / .Values.environmentSecrets / .Values.environmentVariables.
+  env: {}
+  environmentSecrets: []
+  environmentVariables: []
+
   # Annotations for JS executor pods
   annotations: {}
 
@@ -830,14 +836,16 @@ jsExecutor:
   # Config affinity and anti-affinity rules for the JS executor pods
   affinity: {}
 
-  # Resources for the JS executor
+  # Resources for the JS executor. Memory request and limit are kept equal:
+  # JSE reads its memory limit and rejects requests at 80% of it, so the
+  # request must reserve the full amount to avoid premature rejections.
   resources:
     limits:
-      cpu: 2000m
-      memory: 8192Mi
+      cpu: 6000m
+      memory: 6Gi
     requests:
-      cpu: 1000m
-      memory: 4096Mi
+      cpu: 6000m
+      memory: 6Gi
 
 agents:
   # Enable AI Agents

--- a/values.yaml
+++ b/values.yaml
@@ -1111,8 +1111,13 @@ agentSandbox:
   # controllerUrl and proxyUrl default to internal service URLs when empty.
   controllerUrl: ''
   proxyUrl: ''
-  # Required: public URL for frontend browsers to reach the proxy via WebSocket.
-  # e.g. https://sandbox.yourdomain.com
+  # Public URL for frontend browsers to reach the proxy via WebSocket.
+  # Leave EMPTY for self-hosted: the backend then serves the sandbox same-origin
+  # as the editor (your Retool base URL) and the front server reverse-proxies the
+  # /sandbox/* WS+Vite paths to the in-cluster proxy Service — so no dedicated
+  # proxy domain or ingress is required, and your catch-all ingress is untouched.
+  # Only set this (e.g. https://sandbox.yourdomain.com) if you deliberately want
+  # the proxy on a separate domain, in which case also enable proxy.ingress above.
   frontendWsProxyDomain: ''
   # Public URL for proxy domain. Defaults to frontendWsProxyDomain if empty.
   proxyDomain: ''


### PR DESCRIPTION
## Summary

Merges the `r2-cleanup` integration branch into the `r2` preview branch. This batches up the polish work that meaningfully simplifies how R² is enabled on existing self-hosted deployments.

### Headline changes
- **Single `r2.enabled` master switch** (#313) — one toggle turns on `r2Agent`, `jsExecutor`, `agentSandbox`, and `mcp`. Each component's `enabled` defaults to `null` and inherits the switch; set it explicitly to override.
- **Same-origin agent-sandbox proxy / no extra ingress** (#302) — leaving `agentSandbox.frontendWsProxyDomain` empty makes the backend serve the sandbox same-origin via the main ingress. No dedicated `agent-proxy.*` domain, ingress, or extra HTTPRoute required; the catch-all ingress is untouched.
- **Agent-sandbox secrets + Postgres** (#308) — only the JWT keypair is required; `encryptionKey`/`apiSecret` are optional. Postgres is inherited from the backend by default (separate `agent_executor` schema), with explicit DSN / fields / existing-secret options for the cases where it can't be inherited. Adds required-secret validation and existing-secret DSN refs.
- **Optional split git server** (#309) — `rrGitServer.separate.enabled` runs the git server as its own Deployment + Service; backend proxies to it and MCP auto-points at it.
- **rrGitServer blob-storage env** (#307) — accepts blob-storage env vars from `.Values.env`, plus a `skipBlobStorageValidation` escape hatch for `envFrom`-injected vars.
- **js-executor** (#304) — drops backend-shared env inheritance (own `env`/`environmentSecrets`/`environmentVariables`) and resizes resources (equal memory request/limit so JSE's 80%-of-limit rejection works correctly).

### Included commits
- `52a1d01` [feat][r2] add single r2.enabled master switch for R2 components (#313)
- `b049145` ci: test coverage for r2 workloads (js-executor, agent-sandbox, r2Agent) (#312)
- `480fb81` agent-sandbox: validate required secrets + existing-secret DSN ref (#308)
- `8b0d492` [feat][r2] optionally split rrGitServer into its own deployment (#309)
- `7675ccf` re-sync values.yaml with chart copy after #302
- `50c91c0` Document self-hosted same-origin agent-sandbox proxy (no extra ingress) (#302)
- `b88cfdd` rrGitServer: accept blob-storage env vars from .Values.env (#307)
- `015e98f` js-executor: drop backend-shared env inheritance + resize resources (#304)

### Notes
- Values changes are mirrored in both `charts/retool/values.yaml` and the root `values.yaml` per chart convention.
- New CI test fixtures cover the enable options (r2-enabled, per-component enables, agent-sandbox secret/postgres variants, rr-git-server separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)