### PR TITLE
[fix][r2] drop mcp from the r2.enabled master switch

### DIFF
--- a/charts/retool/ci/test-r2-enabled-option.yaml
+++ b/charts/retool/ci/test-r2-enabled-option.yaml
@@ -1,10 +1,12 @@
 # R2 master switch — single flag turns on the whole R2 stack.
 #
-# Exercises the `r2.enabled: true` inherit path: r2Agent, jsExecutor,
-# agentSandbox, and mcp all leave their own `enabled` unset (null) and inherit
-# the master switch. This guards `retool.r2.componentEnabled` and the
-# helper-routed cross-component env wiring (backend/workflows/jobs/workers read
-# effective-enabled, not the raw per-component flag).
+# Exercises the `r2.enabled: true` inherit path: r2Agent, jsExecutor, and
+# agentSandbox all leave their own `enabled` unset (null) and inherit the master
+# switch. This guards `retool.r2.componentEnabled` and the helper-routed
+# cross-component env wiring (backend/workflows/jobs/workers read
+# effective-enabled, not the raw per-component flag). mcp is intentionally NOT
+# part of the master switch (it is opt-in via mcp.enabled, since it needs its
+# own OAuth config), so it must not render from r2.enabled alone.
 #
 # Secrets/config below are only what each component requires to template when
 # enabled; none of them set `*.enabled`, so enablement comes solely from r2.
@@ -26,7 +28,3 @@ agentSandbox:
       enabled: false
   networkPolicy:
     enabled: false
-
-mcp:
-  config:
-    oauthIntrospectionAuthToken: test-oauth-introspection-token

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -420,7 +420,7 @@ Usage: (include "retool.agents.enabled" .)
 {{- end -}}
 
 {{/*
-Resolve whether an R2 component (r2Agent, jsExecutor, agentSandbox, mcp) is
+Resolve whether an R2 component (r2Agent, jsExecutor, agentSandbox) is
 enabled. The component's own `enabled` wins when explicitly set to true/false;
 when left unset (null) it inherits the shared master switch .Values.r2.enabled.
 Usage: (include "retool.r2.componentEnabled" (dict "root" $ "component" "jsExecutor"))

--- a/charts/retool/templates/deployment_mcp.yaml
+++ b/charts/retool/templates/deployment_mcp.yaml
@@ -1,4 +1,4 @@
-{{- if eq (include "retool.r2.componentEnabled" (dict "root" $ "component" "mcp")) "1" }}
+{{- if .Values.mcp.enabled }}
 {{- $mcpConfig := .Values.mcp.config | default dict }}
 {{- $hasOAuthIntrospectionAuthTokenEnv := false }}
 {{- range .Values.mcp.environmentVariables }}
@@ -7,7 +7,7 @@
 {{- end }}
 {{- end }}
 {{- if not (or $mcpConfig.oauthIntrospectionAuthTokenSecretName $mcpConfig.oauthIntrospectionAuthToken $hasOAuthIntrospectionAuthTokenEnv) }}
-{{- fail "Please set .Values.mcp.config.oauthIntrospectionAuthTokenSecretName, .Values.mcp.config.oauthIntrospectionAuthToken, or an OAUTH_INTROSPECTION_AUTH_TOKEN entry in .Values.mcp.environmentVariables when the MCP server is enabled (.Values.mcp.enabled, or inherited from .Values.r2.enabled)" }}
+{{- fail "Please set .Values.mcp.config.oauthIntrospectionAuthTokenSecretName, .Values.mcp.config.oauthIntrospectionAuthToken, or an OAUTH_INTROSPECTION_AUTH_TOKEN entry in .Values.mcp.environmentVariables when the MCP server is enabled (.Values.mcp.enabled)" }}
 {{- end }}
 {{- $mcpInternalPort := .Values.mcp.service.internalPort | default 4010 }}
 apiVersion: v1

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -564,9 +564,10 @@ multiplayer:
     labels: {}
 
 mcp:
-  # Run Retool's MCP server as a separate deployment. Inherits .Values.r2.enabled
-  # when left unset (null); set true/false to override.
-  enabled: null
+  # Run Retool's MCP server as a separate deployment. Independent of the
+  # .Values.r2.enabled master switch (the MCP server needs its own OAuth
+  # introspection config, so it is opt-in): set true to enable.
+  enabled: false
 
   replicaCount: 1
 

--- a/values.yaml
+++ b/values.yaml
@@ -564,9 +564,10 @@ multiplayer:
     labels: {}
 
 mcp:
-  # Run Retool's MCP server as a separate deployment. Inherits .Values.r2.enabled
-  # when left unset (null); set true/false to override.
-  enabled: null
+  # Run Retool's MCP server as a separate deployment. Independent of the
+  # .Values.r2.enabled master switch (the MCP server needs its own OAuth
+  # introspection config, so it is opt-in): set true to enable.
+  enabled: false
 
   replicaCount: 1
 


### PR DESCRIPTION
## Summary

Follow-up to #315. Found while balloon-testing the simplified R2 config: `r2.enabled: true` (the one-line master switch) **hard-fails to template** out of the box —

```
deployment_mcp.yaml: Please set .Values.mcp.config.oauthIntrospectionAuthTokenSecretName,
.Values.mcp.config.oauthIntrospectionAuthToken, or an OAUTH_INTROSPECTION_AUTH_TOKEN entry
... when the MCP server is enabled (.Values.mcp.enabled, or inherited from .Values.r2.enabled)
```

The master switch made `mcp` inherit `enabled: true`, but mcp requires an OAuth introspection token that the other three R2 components (r2Agent/jsExecutor/agentSandbox) don't. So enabling R2 with one line failed unless the user also configured mcp. No balloon had ever enabled mcp, so this combination was never exercised until now.

## Change

Make **mcp independent of the master switch** (opt-in):
- `mcp.enabled` defaults to `false` (was `null`/inherit) in both `values.yaml` copies.
- `deployment_mcp.yaml` gates on `.Values.mcp.enabled` directly instead of `retool.r2.componentEnabled`.
- `r2.enabled` now governs only `r2Agent`/`jsExecutor`/`agentSandbox`.
- Updated the `componentEnabled` doc, the OAuth fail message, and `ci/test-r2-enabled-option.yaml` (mcp must no longer render from `r2.enabled` alone; the explicit `test-mcp-enabled-option.yaml` still covers mcp).

## Verification
- `helm template` with `r2.enabled: true`: renders r2Agent + agentSandbox + js-executor, **mcp absent**.
- Balloon `jatin-r2-cleanup` (master-switch config) now templates cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)