### PR TITLE
Add controller.scaling.perUserSandboxLimit and sandbox.sandboxGlobalLifetimeMs

### DIFF
--- a/charts/retool/templates/deployment_agent_sandbox.yaml
+++ b/charts/retool/templates/deployment_agent_sandbox.yaml
@@ -175,6 +175,7 @@ data:
                   ,{"name": "POD_IP", "valueFrom": {"fieldRef": {"fieldPath": "status.podIP"}}}
                   ,{"name": "SANDBOX_NETWORK_ENABLED", "value": "{{ $as.sandboxNetwork.enabled }}"}
                   ,{"name": "SANDBOX_IDLE_TIMEOUT_MS", "value": "{{ $as.sandbox.sandboxIdleTimeoutMs }}"}
+                  ,{"name": "SANDBOX_GLOBAL_LIFETIME_MS", "value": "{{ $as.sandbox.sandboxGlobalLifetimeMs }}"}
                   {{- if $as.jwtPublicKey }}
                   ,{"name": "AGENT_SANDBOX_JWT_PUBLIC_KEY", "value": "{{ $as.jwtPublicKey }}"}
                   {{- else if $as.externalSecret.name }}

--- a/charts/retool/templates/deployment_agent_sandbox.yaml
+++ b/charts/retool/templates/deployment_agent_sandbox.yaml
@@ -326,18 +326,6 @@ spec:
               value: {{ include "retool.agentSandbox.name" . }}
             - name: EXECUTOR_SERVICE_NAME
               value: {{ include "retool.agentSandbox.name" . }}-pods
-            - name: SLOTS_PER_POD
-              value: {{ $as.controller.scaling.slotsPerPod | quote }}
-            - name: EXECUTOR_MIN_REPLICAS
-              value: {{ $as.controller.scaling.minReplicas | quote }}
-            - name: EXECUTOR_MAX_REPLICAS
-              value: {{ $as.controller.scaling.maxReplicas | quote }}
-            - name: SCALE_UP_THRESHOLD
-              value: {{ $as.controller.scaling.scaleUpThreshold | quote }}
-            - name: SCALE_DOWN_THRESHOLD
-              value: {{ $as.controller.scaling.scaleDownThreshold | quote }}
-            - name: SCALE_DOWN_GRACE_PERIOD_MS
-              value: {{ $as.controller.scaling.scaleDownGracePeriodMs | quote }}
             - name: PREWARM_POOL_SIZE
               value: {{ $as.controller.scaling.prewarmPoolSize | quote }}
             - name: MAX_TOTAL_JOBS
@@ -354,6 +342,8 @@ spec:
               value: {{ $as.controller.scaling.leaderTtlMs | quote }}
             - name: LEADER_RENEW_MS
               value: {{ $as.controller.scaling.leaderRenewMs | quote }}
+            - name: PER_USER_CONCURRENCY_PAID
+              value: {{ $as.controller.scaling.perUserSandboxLimit | quote }}
             - name: DEPLOYED_IMAGE_TAG
               value: {{ $as.image.tag | default .Values.image.tag | quote }}
             - name: JOB_TEMPLATE_CONFIGMAP

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -1101,6 +1101,10 @@ agentSandbox:
         memory: 4Gi
     # Idle timeout (ms) before an unassigned sandbox self-terminates.
     sandboxIdleTimeoutMs: 600000
+    # Hard ceiling (ms) on total sandbox lifetime, regardless of activity. When
+    # reached, the sandbox is destroyed (deferred until the current agent loop
+    # ends). Defaults to 2.5 hours.
+    sandboxGlobalLifetimeMs: 9000000
     tmpDirSizeLimit: 20Gi
     # Separate limit for the rootfs-appjob volume — the sandbox root filesystem
     # is a static ~600MB extraction, so 2Gi provides headroom without the 20Gi

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -1121,12 +1121,6 @@ agentSandbox:
         cpu: 500m
         memory: 512Mi
     scaling:
-      slotsPerPod: 4
-      minReplicas: 1
-      maxReplicas: 10
-      scaleUpThreshold: 2
-      scaleDownThreshold: 8
-      scaleDownGracePeriodMs: 300000
       prewarmPoolSize: 5
       maxTotalJobs: 50
       maxConcurrentCreates: 3
@@ -1135,6 +1129,7 @@ agentSandbox:
       reconcileIntervalMs: 5000
       leaderTtlMs: 10000
       leaderRenewMs: 3000
+      perUserSandboxLimit: 5
 
   # Proxy: HTTP proxy for sandbox egress with credential injection.
   # The proxy must be reachable by frontend browsers for WebSocket connections.

--- a/values.yaml
+++ b/values.yaml
@@ -1101,6 +1101,10 @@ agentSandbox:
         memory: 4Gi
     # Idle timeout (ms) before an unassigned sandbox self-terminates.
     sandboxIdleTimeoutMs: 600000
+    # Hard ceiling (ms) on total sandbox lifetime, regardless of activity. When
+    # reached, the sandbox is destroyed (deferred until the current agent loop
+    # ends). Defaults to 2.5 hours.
+    sandboxGlobalLifetimeMs: 9000000
     tmpDirSizeLimit: 20Gi
     # Separate limit for the rootfs-appjob volume — the sandbox root filesystem
     # is a static ~600MB extraction, so 2Gi provides headroom without the 20Gi

--- a/values.yaml
+++ b/values.yaml
@@ -1121,12 +1121,6 @@ agentSandbox:
         cpu: 500m
         memory: 512Mi
     scaling:
-      slotsPerPod: 4
-      minReplicas: 1
-      maxReplicas: 10
-      scaleUpThreshold: 2
-      scaleDownThreshold: 8
-      scaleDownGracePeriodMs: 300000
       prewarmPoolSize: 5
       maxTotalJobs: 50
       maxConcurrentCreates: 3
@@ -1135,6 +1129,7 @@ agentSandbox:
       reconcileIntervalMs: 5000
       leaderTtlMs: 10000
       leaderRenewMs: 3000
+      perUserSandboxLimit: 5
 
   # Proxy: HTTP proxy for sandbox egress with credential injection.
   # The proxy must be reachable by frontend browsers for WebSocket connections.


### PR DESCRIPTION
Wire up `controller.scaling.perUserSandboxLimit` config option (default 5) and `sandbox.sandboxGlobalLifetimeMs` (default 2.5 hrs).

Remove environment variables that are no longer used: `SLOTS_PER_POD`, `EXECUTOR_{MIN,MAX}_REPLICAS`, `SCALE_{UP,DOWN}_THRESHOLD`, `SCALE_DOWN_GRACE_PERIOD_MS`.