### PR TITLE
[fix] [plat] Sync nsjail seccomp profile with retool-k8s (source of truth)

### DIFF
--- a/charts/retool/files/nsjail-seccomp.json
+++ b/charts/retool/files/nsjail-seccomp.json
@@ -415,8 +415,52 @@
       "args": [
         {
           "index": 0,
-          "value": 40,
-          "op": "SCMP_CMP_NE"
+          "value": 1,
+          "op": "SCMP_CMP_EQ"
+        }
+      ]
+    },
+    {
+      "names": ["socket"],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 2,
+          "op": "SCMP_CMP_EQ"
+        }
+      ]
+    },
+    {
+      "names": ["socket"],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 10,
+          "op": "SCMP_CMP_EQ"
+        }
+      ]
+    },
+    {
+      "names": ["socket"],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 16,
+          "op": "SCMP_CMP_EQ"
+        }
+      ]
+    },
+    {
+      "names": ["socket"],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 17,
+          "op": "SCMP_CMP_EQ"
         }
       ]
     },


### PR DESCRIPTION
## Summary

Ports ports the Copy Fail vulnerability fix to the helm chart
