### PR TITLE
[fix] [plat-1293] Set appArmorProfile Unconfined for js-executor

### DIFF
--- a/charts/retool/templates/deployment_js_executor.yaml
+++ b/charts/retool/templates/deployment_js_executor.yaml
@@ -24,6 +24,7 @@ spec:
     metadata:
       annotations:
         checksum/seccomp: {{ .Files.Get "files/nsjail-seccomp.json" | sha256sum }}
+        container.apparmor.security.beta.kubernetes.io/js-executor: unconfined
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
@@ -89,8 +90,6 @@ spec:
           seccompProfile:
             type: Localhost
             localhostProfile: {{ .Values.jsExecutor.seccompLocalhostProfile }}
-          appArmorProfile:
-            type: Unconfined
         env:
           - name: DEPLOYMENT_TEMPLATE_TYPE
             value: {{ template "retool.deploymentTemplateType" . }}

--- a/charts/retool/templates/deployment_js_executor.yaml
+++ b/charts/retool/templates/deployment_js_executor.yaml
@@ -89,6 +89,14 @@ spec:
           seccompProfile:
             type: Localhost
             localhostProfile: {{ .Values.jsExecutor.seccompLocalhostProfile }}
+          # nsjail remounts the rootfs/proc inside its mount namespace. On nodes
+          # where the container runtime applies an AppArmor profile (e.g. GKE
+          # Container-Optimized OS, where containerd attaches
+          # cri-containerd.apparmor.d with `deny mount`), that mount is rejected
+          # with EPERM. Run unconfined so nsjail can set up its sandbox; the
+          # Localhost seccomp profile above provides the syscall isolation.
+          appArmorProfile:
+            type: Unconfined
         env:
           - name: DEPLOYMENT_TEMPLATE_TYPE
             value: {{ template "retool.deploymentTemplateType" . }}

--- a/charts/retool/templates/deployment_js_executor.yaml
+++ b/charts/retool/templates/deployment_js_executor.yaml
@@ -89,12 +89,6 @@ spec:
           seccompProfile:
             type: Localhost
             localhostProfile: {{ .Values.jsExecutor.seccompLocalhostProfile }}
-          # nsjail remounts the rootfs/proc inside its mount namespace. On nodes
-          # where the container runtime applies an AppArmor profile (e.g. GKE
-          # Container-Optimized OS, where containerd attaches
-          # cri-containerd.apparmor.d with `deny mount`), that mount is rejected
-          # with EPERM. Run unconfined so nsjail can set up its sandbox; the
-          # Localhost seccomp profile above provides the syscall isolation.
           appArmorProfile:
             type: Unconfined
         env:


### PR DESCRIPTION
## Summary

Adds `appArmorProfile: { type: Unconfined }` to the `js-executor` container's `securityContext`, mirroring the existing `agent-sandbox` container.

## Why

`js-executor` runs user code inside an [nsjail](https://github.com/google/nsjail) sandbox. At startup nsjail creates a new mount namespace and remounts the rootfs (`mount('/', '/', MS_REC|MS_PRIVATE)`). On nodes where the container runtime attaches an AppArmor profile to non-privileged containers, that mount is denied:

- **GKE / Container-Optimized OS**: containerd applies its default profile `cri-containerd.apparmor.d`, which contains `deny mount,`. nsjail fails with `mount('/', '/', NULL, MS_REC|MS_PRIVATE, NULL): Permission denied` and the sandbox never launches.
- **EKS / Amazon Linux 2023**: uses SELinux, no AppArmor profile is attached, so the mount succeeds — which is why this was never observed on EKS.

This is the same class of failure as [google/nsjail#236](https://github.com/google/nsjail/issues/236) (AppArmor's `unprivileged_userns` profile on Ubuntu 24.04), just sourced from containerd's default profile instead.

Running the container `Unconfined` lets nsjail set up its sandbox. The `Localhost` seccomp profile (`nsjail-seccomp.json`) continues to provide syscall-level isolation, and this matches the posture EKS already runs with (no AppArmor) and the existing `agent-sandbox` container in this chart.

## Verification

On a GKE 1.35 / COS cluster, with the container patched to AppArmor `Unconfined`:

- `cat /proc/self/attr/current` → `unconfined` (was `cri-containerd.apparmor.d (enforce)`)
- nsjail no longer hits the `MS_PRIVATE` mount denial; js-executor executes user code end-to-end.

(js-executor invokes nsjail with `--disable_proc`, so it does not require `procMount: Unmasked` / `hostUsers`.)

## Test plan

- [ ] `helm template` renders the js-executor `securityContext` with `appArmorProfile.type: Unconfined`
- [ ] Deploy to a COS-backed cluster and confirm js-executor runs user code without the nsjail mount error
- [ ] Confirm no regression on EKS (Unconfined is a no-op where no AppArmor profile is attached)

Made with [Cursor](https://cursor.com)