### PR TITLE
[agent-sandbox] expose sandboxReadyTimeoutMs -> SANDBOX_READY_TIMEOUT_MS

### DIFF
--- a/charts/retool/templates/deployment_agent_sandbox.yaml
+++ b/charts/retool/templates/deployment_agent_sandbox.yaml
@@ -176,6 +176,7 @@ data:
                   ,{"name": "SANDBOX_NETWORK_ENABLED", "value": "{{ $as.sandboxNetwork.enabled }}"}
                   ,{"name": "SANDBOX_IDLE_TIMEOUT_MS", "value": "{{ $as.sandbox.sandboxIdleTimeoutMs }}"}
                   ,{"name": "SANDBOX_GLOBAL_LIFETIME_MS", "value": "{{ $as.sandbox.sandboxGlobalLifetimeMs }}"}
+                  ,{"name": "SANDBOX_READY_TIMEOUT_MS", "value": "{{ $as.sandbox.sandboxReadyTimeoutMs }}"}
                   {{- if $as.jwtPublicKey }}
                   ,{"name": "AGENT_SANDBOX_JWT_PUBLIC_KEY", "value": "{{ $as.jwtPublicKey }}"}
                   {{- else if $as.externalSecret.name }}

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -994,6 +994,11 @@ rr:
       # reached, the sandbox is destroyed (deferred until the current agent loop
       # ends). Defaults to 2.5 hours.
       sandboxGlobalLifetimeMs: 9000000
+      # Time (ms) the controller waits for a freshly-started sandbox to connect
+      # before failing the request. Interactive sandbox boot (gVisor + bundle
+      # load) can take ~20-25s; raise this (e.g. 45000) if you see "did not
+      # connect within <n>ms" errors on cold starts.
+      sandboxReadyTimeoutMs: 20000
       tmpDirSizeLimit: 20Gi
       # Separate limit for the rootfs-appjob volume — the sandbox root filesystem
       # is a static ~600MB extraction, so 2Gi provides headroom without the 20Gi

--- a/values.yaml
+++ b/values.yaml
@@ -994,6 +994,11 @@ rr:
       # reached, the sandbox is destroyed (deferred until the current agent loop
       # ends). Defaults to 2.5 hours.
       sandboxGlobalLifetimeMs: 9000000
+      # Time (ms) the controller waits for a freshly-started sandbox to connect
+      # before failing the request. Interactive sandbox boot (gVisor + bundle
+      # load) can take ~20-25s; raise this (e.g. 45000) if you see "did not
+      # connect within <n>ms" errors on cold starts.
+      sandboxReadyTimeoutMs: 20000
       tmpDirSizeLimit: 20Gi
       # Separate limit for the rootfs-appjob volume — the sandbox root filesystem
       # is a static ~600MB extraction, so 2Gi provides headroom without the 20Gi


### PR DESCRIPTION
## What
Adds `agentSandbox.sandbox.sandboxReadyTimeoutMs` (default `20000`) and emits `SANDBOX_READY_TIMEOUT_MS` in the agent-sandbox job-template env, alongside `SANDBOX_IDLE_TIMEOUT_MS` / `SANDBOX_GLOBAL_LIFETIME_MS`.

## Why
The agent-executor made the sandbox connect timeout env-configurable (`config.ts` `readyTimeoutMs` ← `SANDBOX_READY_TIMEOUT_MS`, in retool_development #79287/#79443), but the chart never set it — so the job-template used the image default of 20s. Interactive sandbox boot (gVisor + bundle load) can take ~20–25s, surfacing `agent sandbox <id> did not connect within 20000ms`. Until now the only workaround was a manual `readytimeout-patch` initContainer that sed-ed the bundle — this replaces that with a first-class knob.

## Default
`20000`, matching the code default (no behavior change on upgrade). Operators who need more set e.g. `45000`.

## Notes
- Both `values.yaml` and `charts/retool/values.yaml` updated identically (sync gate).
- Verified `helm template` renders `SANDBOX_READY_TIMEOUT_MS` in the job-template.
- Internal-onprem balloons need a separate retool-k8s values override to actually raise it (chart default stays conservative).