### PR TITLE
[rr] make legacy-values guard message spell out the fix

### DIFF
--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -1025,7 +1025,7 @@ Two classes of stale config are caught:
 {{- end -}}
 {{- end -}}
 {{- if $found -}}
-{{- fail (printf "\n\nThe RR (formerly \"r2\") values layout changed: the master switch and every component it needs now live under the top-level `rr:` block. These keys in your values are NO LONGER READ and would silently disable RR. Rename / move them as shown:\n\n%s\n\nThe master switch is now `rr.enabled`. See values.yaml for the new layout." (join "\n" $found)) -}}
+{{- fail (printf "\n\nACTION REQUIRED: update your Helm values file.\n\nThe RR (formerly \"r2\") values layout changed: the master switch and every component it needs now live under the top-level `rr:` block. The keys below are still set in your values but are NO LONGER READ, which would silently disable RR. This deploy is blocked until you fix it.\n\nTo fix: edit your values file (values.yaml / your Helm values overrides) and rename / move these keys:\n\n%s\n\nThe master switch is now `rr.enabled`. See the chart's values.yaml for the full new layout." (join "\n" $found)) -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
## What

Makes the `retool.rr.validateLegacyValues` guard message (added in #321) more obviously tell the operator they need to **update their values file** to fix the deploy.

Before, the message led with chart-internal context ("The RR values layout changed…"). Now it leads with the action:

```
ACTION REQUIRED: update your Helm values file.

The RR (formerly "r2") values layout changed: ... The keys below are
still set in your values but are NO LONGER READ, which would silently
disable RR. This deploy is blocked until you fix it.

To fix: edit your values file (values.yaml / your Helm values overrides)
and rename / move these keys:

  r2:  ->  rr:

The master switch is now `rr.enabled`. See the chart's values.yaml for the full new layout.
```

## Why

The guard intentionally fails the deploy when stale `r2.*` / top-level component keys are present (they'd otherwise silently disable RR). Customers upgrading hit this and the original wording didn't make the required action — editing their values file — obvious enough.

## Scope

Message-only change inside the existing `fail` string. No new values keys, no behavior change, no values.yaml or CI changes.

## Testing

- `helm template` with a legacy key (`--set r2.enabled=true`) → guard fires with the new message.
- Clean `rr.*` render (master switch + gitServer + blobStorage + agentSandbox secrets) → guard stays silent, renders fine.
- `helm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)