### PR TITLE
[agent-sandbox] fix jwtPublicKey breaking job-template JSON (use toJson)

### DIFF
--- a/charts/retool/ci/test-agent-sandbox-inline-secrets-option.yaml
+++ b/charts/retool/ci/test-agent-sandbox-inline-secrets-option.yaml
@@ -6,7 +6,9 @@ rr:
   # proxy ingress). Here we exercise the *other* halves of those branches:
   #   - Secrets inline (no externalSecret.name) → the chart renders its own Secret
   #     (jwt-public-key / jwt-private-key / encryption-key / api-secret). jwtPublicKey
-  #     MUST be single-line: it is injected raw into the sandbox job-template JSON.
+  #     is injected into the sandbox job-template JSON via `toJson`, so a genuine
+  #     multi-line PEM (real newlines, as below) is escaped correctly — no need to
+  #     pre-flatten it to a single `\n`-escaped line.
   #   - Postgres sourcing OPTION 1: plaintext DSN via postgres.url.
   #   - Same-origin proxy: no dedicated proxy domain and no proxy ingress — the
   #     backend reverse-proxies /sandbox/* (frontendWsProxyDomain left empty).
@@ -21,8 +23,19 @@ rr:
       tag: 3.123.4
       pullPolicy: IfNotPresent
 
-    jwtPublicKey: '-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEljtqa2nhBwe/PqNhWgPHhj0jv8AI\nY+QUCicYtfv9wLGcEGPQuXoBQtuoIuOwXOdbEWgrQyLdIEb0YjegAW3miA==\n-----END PUBLIC KEY-----'
-    jwtPrivateKey: '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMFXLiN/YsJv89D2YkEZ6/Dj5fujghENmYTOilwdChU3oAoGCCqGSM49\nAwEHoUQDQgAEljtqa2nhBwe/PqNhWgPHhj0jv8AIY+QUCicYtfv9wLGcEGPQuXoB\nQtuoIuOwXOdbEWgrQyLdIEb0YjegAW3miA==\n-----END EC PRIVATE KEY-----'
+    # Real multi-line PEM (block scalar) — exercises the toJson newline escaping in
+    # the job-template JSON. A raw "{{ . }}" would produce invalid JSON here.
+    jwtPublicKey: |-
+      -----BEGIN PUBLIC KEY-----
+      MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEljtqa2nhBwe/PqNhWgPHhj0jv8AI
+      Y+QUCicYtfv9wLGcEGPQuXoBQtuoIuOwXOdbEWgrQyLdIEb0YjegAW3miA==
+      -----END PUBLIC KEY-----
+    jwtPrivateKey: |-
+      -----BEGIN EC PRIVATE KEY-----
+      MHcCAQEEIMFXLiN/YsJv89D2YkEZ6/Dj5fujghENmYTOilwdChU3oAoGCCqGSM49
+      AwEHoUQDQgAEljtqa2nhBwe/PqNhWgPHhj0jv8AIY+QUCicYtfv9wLGcEGPQuXoB
+      QtuoIuOwXOdbEWgrQyLdIEb0YjegAW3miA==
+      -----END EC PRIVATE KEY-----
     encryptionKey: a12b01429fe0fe69a80da94e9e837ab2f1e9bda378ed8a25905a238f6fea6b7a
     apiSecret: test-agent-sandbox-api-secret
 

--- a/charts/retool/templates/deployment_agent_sandbox.yaml
+++ b/charts/retool/templates/deployment_agent_sandbox.yaml
@@ -178,7 +178,7 @@ data:
                   ,{"name": "SANDBOX_GLOBAL_LIFETIME_MS", "value": "{{ $as.sandbox.sandboxGlobalLifetimeMs }}"}
                   ,{"name": "SANDBOX_READY_TIMEOUT_MS", "value": "{{ $as.sandbox.sandboxReadyTimeoutMs }}"}
                   {{- if $as.jwtPublicKey }}
-                  ,{"name": "AGENT_SANDBOX_JWT_PUBLIC_KEY", "value": "{{ $as.jwtPublicKey }}"}
+                  ,{"name": "AGENT_SANDBOX_JWT_PUBLIC_KEY", "value": {{ $as.jwtPublicKey | toJson }}}
                   {{- else if $as.externalSecret.name }}
                   ,{"name": "AGENT_SANDBOX_JWT_PUBLIC_KEY", "valueFrom": {"secretKeyRef": {"name": "{{ $defaultSecretName }}", "key": "jwt-public-key"}}}
                   {{- end }}


### PR DESCRIPTION
## Bug

`charts/retool/templates/deployment_agent_sandbox.yaml:181` embeds the JWT public key into the sandbox **job-template JSON** as a string literal:

```
,{"name": "AGENT_SANDBOX_JWT_PUBLIC_KEY", "value": "{{ $as.jwtPublicKey }}"}
```

ES256 keys are ECDSA/P-256, normally stored as **multi-line PEM** (`-----BEGIN/END PUBLIC KEY-----` + newlines). A raw newline inside a JSON string literal is **invalid JSON**, so the controller fails when reading the job-template ConfigMap to spawn sandbox Jobs. A compact JWK would break it too (embedded `"`).

This only worked if the operator pre-flattened the key to a single `\n`-escaped line — the workaround the inline-secrets CI fixture happened to rely on.

## Fix

```diff
-,{"name": "AGENT_SANDBOX_JWT_PUBLIC_KEY", "value": "{{ $as.jwtPublicKey }}"}
+,{"name": "AGENT_SANDBOX_JWT_PUBLIC_KEY", "value": {{ $as.jwtPublicKey | toJson }}}
```

`toJson` emits the quoted, fully-escaped JSON string (newlines → `\n`, quotes → `\"`). This also makes the JSON path consistent with the env-var injection paths, which already use `| quote`.

## Test

Updated `ci/test-agent-sandbox-inline-secrets-option.yaml` to use a **genuine multi-line PEM** (block scalar) instead of a pre-flattened `\n` line, and corrected its now-obsolete "MUST be single-line" comment.

Verified by rendering the fixture and parsing the embedded `job-template.json`:
- **with the fix:** valid JSON ✅
- **without the fix:** `json.JSONDecodeError`

`helm lint` clean.

## Note

Targets `r2` (consumers pin `ref=r2`). The r2→main PR #324 will need `r2` re-merged to pick this up before it lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)