### PR TITLE
[agent-sandbox] guard device-plugin priorityClassName (fix null opt-out)

### DIFF
--- a/charts/retool/ci/test-agent-sandbox-deviceplugin-no-priorityclass-option.yaml
+++ b/charts/retool/ci/test-agent-sandbox-deviceplugin-no-priorityclass-option.yaml
@@ -1,0 +1,27 @@
+rr:
+
+  # Agent Sandbox — device-plugin DaemonSet with priorityClassName opted OUT.
+  #
+  # Regression guard for the GKE path documented in values.yaml: GKE doesn't allow
+  # the `system-node-critical` PriorityClass in user namespaces, so operators set
+  #   rr.agentSandbox.devicePlugin.priorityClassName: null
+  # to drop it. The DaemonSet template must OMIT the priorityClassName field in that
+  # case — a bare `{{ ... }}` on a nil value would render the literal `<no value>`,
+  # producing an invalid manifest that the kubelet rejects (and that kubeconform
+  # rejects here in CI).
+  #
+  # Overlaid on test-install-values.yaml.
+  agentSandbox:
+    enabled: true
+
+    externalSecret:
+      name: agent-sandbox-secrets
+
+    sandboxNetwork:
+      enabled: true
+      devicePlugin: true
+      deployDaemonSet: true
+
+    devicePlugin:
+      # The GKE opt-out — DaemonSet must render with no priorityClassName field.
+      priorityClassName: null

--- a/charts/retool/templates/agent_sandbox_device_plugin.yaml
+++ b/charts/retool/templates/agent_sandbox_device_plugin.yaml
@@ -39,7 +39,9 @@ spec:
 {{- end }}
     spec:
       automountServiceAccountToken: false
+      {{- if $as.devicePlugin.priorityClassName }}
       priorityClassName: {{ $as.devicePlugin.priorityClassName }}
+      {{- end }}
 {{- if $nodeSelector }}
       nodeSelector:
 {{ toYaml $nodeSelector | indent 8 }}


### PR DESCRIPTION
## Bug

`charts/retool/templates/agent_sandbox_device_plugin.yaml:42` renders the device-plugin DaemonSet's priorityClassName **unconditionally**:

```yaml
priorityClassName: {{ $as.devicePlugin.priorityClassName }}
```

The documented GKE opt-out (in `values.yaml` and the customer guide) is to set:

```yaml
rr:
  agentSandbox:
    devicePlugin:
      priorityClassName: null
```

…because GKE rejects `system-node-critical` in user namespaces. But a bare `{{ ... }}` on a nil value renders the literal string `<no value>`, so the DaemonSet is submitted with `priorityClassName: <no value>` — a class that doesn't exist. The kubelet rejects it, which blocks the entire agent sandbox from scheduling.

Every other workload already guards this (`{{- if .Values.priorityClassName }}`); the device-plugin DaemonSet was the one that didn't.

## Fix

```diff
+      {{- if $as.devicePlugin.priorityClassName }}
       priorityClassName: {{ $as.devicePlugin.priorityClassName }}
+      {{- end }}
```

## Test

New `ci/test-agent-sandbox-deviceplugin-no-priorityclass-option.yaml` — device-plugin DaemonSet with `priorityClassName: null`. kubeconform rejects `<no value>`, so this guards the regression directly.

Verified:
- `priorityClassName: null` → field **omitted**, zero `<no value>`
- default → `priorityClassName: system-node-critical` still renders
- `helm lint` clean

Targets `r2` (consumers pin `ref=r2`); folds into the r2→main merge (#326).

🤖 Generated with [Claude Code](https://claude.com/claude-code)