### PR TITLE
bump chart version to 6.13.0

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.12.0
+version: 6.13.0
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com


### PR DESCRIPTION
Minor version bump **6.12.0 → 6.13.0** for the published R² release.

6.12.0 is already deployed internally (the `admin` cluster's `retool` release), so we publish the R² feature set to charts.retool.com as a fresh **6.13.0** rather than reusing a number that's already in the wild.

Still a **minor** release: additive for existing published consumers, all R² switches (`rr.enabled`, `mcp.enabled`) default off, and the `rr.*` rename guard can't fire on the published line (those keys never existed there).

`helm lint` clean. Targets `r2`; folds into the r2→main merge (#326).

🤖 Generated with [Claude Code](https://claude.com/claude-code)