### PR TITLE
set chart version to 6.11.0

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.12.0
+version: 6.11.0
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com


### PR DESCRIPTION
Sets the chart version to **6.11.0** — one minor bump after the latest **public** release on charts.retool.com:

- Latest **stable** published: `6.10.5`
- Published pre-release: `6.11.0-rc1`

So the R² feature set ships as **6.11.0**, graduating the existing `6.11.0-rc1` to final. The `6.12.0` that was carried on the `r2` branch was an internal number that was never published, so we don't bump from it.

Minor release: additive for existing published consumers, all R² switches (`rr.enabled`, `mcp.enabled`) default off.

`helm lint` clean. Targets `r2`; folds into the r2→main merge (#326). Replaces #328 (which bumped from the internal 6.12.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)