### PR TITLE
[codex] Set agent sandbox proxy URL default

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.11.0
+version: 6.11.1
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -646,6 +646,26 @@ telemetry.retool.com/service-name: agent-sandbox-proxy
 {{- end -}}
 
 {{/*
+Internal URL for server-side callers to reach the agent sandbox proxy Service.
+The fully-qualified cluster DNS name keeps this default valid even when callers
+run outside the proxy Service's namespace.
+*/}}
+{{- define "retool.agentSandbox.proxyUrl" -}}
+{{- .Values.rr.agentSandbox.proxyUrl | default (printf "http://%s.%s.svc.cluster.local:%s" (include "retool.agentSandbox.proxy.name" .) .Release.Namespace (toString .Values.rr.agentSandbox.proxy.port)) -}}
+{{- end -}}
+
+{{/*
+Agent sandbox proxy env var for server-side callers. Keep this separate from
+AGENT_*_FRONTEND_WS_PROXY_DOMAIN, which is browser-facing public config.
+*/}}
+{{- define "retool.agentSandbox.proxyEnvVars" -}}
+{{- if eq (include "retool.rr.componentEnabled" (dict "root" . "component" "agentSandbox")) "1" }}
+- name: AGENT_SANDBOX_PROXY_INGRESS_DOMAIN
+  value: {{ include "retool.agentSandbox.proxyUrl" . | quote }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Validate that an enabled agent sandbox has its required secrets supplied. The
 controller and proxy fail to boot without a Postgres connection and a JWT
 public key, and the Retool backend needs the JWT private key to sign sandbox
@@ -790,8 +810,7 @@ Usage: {{- include "retool.agentSandbox.backendEnvVars" . | nindent 10 }}
   value: "postgres"
 - name: AGENT_SANDBOX_CONTROLLER_INGRESS_DOMAIN
   value: {{ .Values.rr.agentSandbox.controllerUrl | default (printf "http://%s:%s" (include "retool.agentSandbox.controller.name" .) (toString .Values.rr.agentSandbox.controller.port)) | quote }}
-- name: AGENT_SANDBOX_PROXY_INGRESS_DOMAIN
-  value: {{ .Values.rr.agentSandbox.proxyUrl | default (printf "http://%s:%s" (include "retool.agentSandbox.proxy.name" .) (toString .Values.rr.agentSandbox.proxy.port)) | quote }}
+{{- include "retool.agentSandbox.proxyEnvVars" . }}
 {{- if .Values.rr.agentSandbox.frontendWsProxyDomain }}
 - name: AGENT_SANDBOX_FRONTEND_WS_PROXY_DOMAIN
   value: {{ .Values.rr.agentSandbox.frontendWsProxyDomain | quote }}

--- a/charts/retool/templates/deployment_mcp.yaml
+++ b/charts/retool/templates/deployment_mcp.yaml
@@ -115,6 +115,7 @@ spec:
             value: {{ $mcpInternalPort | quote }}
           - name: RETOOL_BACKEND_URL
             value: {{ $mcpConfig.retoolBackendUrl | default (printf "http://%s:%v" (include "retool.fullname" .) .Values.service.externalPort) | quote }}
+          {{- include "retool.agentSandbox.proxyEnvVars" . | nindent 10 }}
           {{- /*
             Prefer an explicit mcp.config.retoolGitServerUrl; otherwise, when the
             git server is split into its own deployment, auto-point MCP at it.

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -1067,8 +1067,10 @@ rr:
         #   hosts:
         #     - sandbox.yourdomain.com
 
-    # Backend integration: these tell the Retool backend how to reach agent executor.
-    # controllerUrl and proxyUrl default to internal service URLs when empty.
+    # Backend integration: these tell server-side Retool callers how to reach agent executor.
+    # controllerUrl defaults to the internal controller service URL when empty.
+    # proxyUrl defaults to the namespace-qualified in-cluster proxy Service URL:
+    # http://<release-fullname>-agent-sandbox-proxy.<namespace>.svc.cluster.local:<proxy.port>
     controllerUrl: ''
     proxyUrl: ''
     # Public URL for frontend browsers to reach the proxy via WebSocket.

--- a/values.yaml
+++ b/values.yaml
@@ -1067,8 +1067,10 @@ rr:
         #   hosts:
         #     - sandbox.yourdomain.com
 
-    # Backend integration: these tell the Retool backend how to reach agent executor.
-    # controllerUrl and proxyUrl default to internal service URLs when empty.
+    # Backend integration: these tell server-side Retool callers how to reach agent executor.
+    # controllerUrl defaults to the internal controller service URL when empty.
+    # proxyUrl defaults to the namespace-qualified in-cluster proxy Service URL:
+    # http://<release-fullname>-agent-sandbox-proxy.<namespace>.svc.cluster.local:<proxy.port>
     controllerUrl: ''
     proxyUrl: ''
     # Public URL for frontend browsers to reach the proxy via WebSocket.


### PR DESCRIPTION
## Summary
- Defaults the Agent Sandbox proxy URL to the namespace-qualified in-cluster Service DNS name for server-side callers.
- Exposes that URL through AGENT_SANDBOX_PROXY_INGRESS_DOMAIN for backend/workflow callers and MCP, without adding backend-only secrets to MCP.
- Keeps frontend WebSocket proxy configuration separate and documents the new same-cluster default, with rr.agentSandbox.proxyUrl available for explicit overrides.

## Validation
- helm template for Agent Sandbox enabled and disabled cases
- helm template for MCP + Agent Sandbox and explicit proxyUrl override cases
- helm lint charts/retool with test-install-values.yaml
