### PR TITLE
fix(rr): decouple agentSandbox postgres from externalSecret (use postgres.urlSecretName); require encryption key

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.11.2
+version: 6.11.3
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/ci/test-agent-sandbox-enabled-option.yaml
+++ b/charts/retool/ci/test-agent-sandbox-enabled-option.yaml
@@ -31,6 +31,9 @@ rr:
       name: agent-sandbox-secrets
 
     postgres:
+      # Option 4 is opt-in: route Postgres to the external secret's postgres-url key.
+      # externalSecret.name alone only covers the JWT/encryption keys, not Postgres.
+      fromExternalSecret: true
       schema: agent_executor
       poolMax: 10
 

--- a/charts/retool/ci/test-agent-sandbox-enabled-option.yaml
+++ b/charts/retool/ci/test-agent-sandbox-enabled-option.yaml
@@ -7,9 +7,10 @@ rr:
   # the image-prepuller + seccomp DaemonSets, the smarter-device-manager device
   # plugin DaemonSet, the NetworkPolicies, and both PDBs.
   #
-  # Secret/Postgres sourcing here uses externalSecret.name (Postgres OPTION 4:
-  # the secret's postgres-url key). The other secret/Postgres precedence paths and
-  # the same-origin (no-ingress) proxy mode are covered by sibling files:
+  # Secrets come from externalSecret.name (JWT/encryption); Postgres reads its DSN
+  # from that same Secret via postgres.urlSecretName (Option 3). The other
+  # secret/Postgres precedence paths and the same-origin (no-ingress) proxy mode
+  # are covered by sibling files:
   #   - test-agent-sandbox-inline-secrets-option.yaml      (inline secrets, plaintext DSN, same-origin/no ingress, hostPath tun)
   #   - test-agent-sandbox-postgres-fields-option.yaml     (assemble DSN from fields + PGPASSWORD secret)
   #   - test-agent-sandbox-postgres-url-secret-option.yaml (full DSN from an existing secret)
@@ -31,9 +32,11 @@ rr:
       name: agent-sandbox-secrets
 
     postgres:
-      # Option 4 is opt-in: route Postgres to the external secret's postgres-url key.
-      # externalSecret.name alone only covers the JWT/encryption keys, not Postgres.
-      fromExternalSecret: true
+      # Option 3: read the DSN from the same Secret that holds the JWT/encryption
+      # keys by pointing urlSecretName at it. externalSecret.name itself never
+      # sources Postgres.
+      urlSecretName: agent-sandbox-secrets
+      urlSecretKey: postgres-url
       schema: agent_executor
       poolMax: 10
 

--- a/charts/retool/ci/test-agent-sandbox-inherit-postgres-option.yaml
+++ b/charts/retool/ci/test-agent-sandbox-inherit-postgres-option.yaml
@@ -20,3 +20,5 @@ rr:
 
     jwtPublicKey: '-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEljtqa2nhBwe/PqNhWgPHhj0jv8AI\nY+QUCicYtfv9wLGcEGPQuXoBQtuoIuOwXOdbEWgrQyLdIEb0YjegAW3miA==\n-----END PUBLIC KEY-----'
     jwtPrivateKey: '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMFXLiN/YsJv89D2YkEZ6/Dj5fujghENmYTOilwdChU3oAoGCCqGSM49\nAwEHoUQDQgAEljtqa2nhBwe/PqNhWgPHhj0jv8AIY+QUCicYtfv9wLGcEGPQuXoB\nQtuoIuOwXOdbEWgrQyLdIEb0YjegAW3miA==\n-----END EC PRIVATE KEY-----'
+    # encryption key is required (proxy derives the asset-token HMAC key from it)
+    encryptionKey: a12b01429fe0fe69a80da94e9e837ab2f1e9bda378ed8a25905a238f6fea6b7a

--- a/charts/retool/ci/test-agent-sandbox-postgres-fields-option.yaml
+++ b/charts/retool/ci/test-agent-sandbox-postgres-fields-option.yaml
@@ -21,6 +21,8 @@ rr:
 
     jwtPublicKey: '-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEljtqa2nhBwe/PqNhWgPHhj0jv8AI\nY+QUCicYtfv9wLGcEGPQuXoBQtuoIuOwXOdbEWgrQyLdIEb0YjegAW3miA==\n-----END PUBLIC KEY-----'
     jwtPrivateKey: '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMFXLiN/YsJv89D2YkEZ6/Dj5fujghENmYTOilwdChU3oAoGCCqGSM49\nAwEHoUQDQgAEljtqa2nhBwe/PqNhWgPHhj0jv8AIY+QUCicYtfv9wLGcEGPQuXoB\nQtuoIuOwXOdbEWgrQyLdIEb0YjegAW3miA==\n-----END EC PRIVATE KEY-----'
+    # encryption key is required (proxy derives the asset-token HMAC key from it)
+    encryptionKey: a12b01429fe0fe69a80da94e9e837ab2f1e9bda378ed8a25905a238f6fea6b7a
 
     # Option 2: host + user + database, password via PGPASSWORD secretKeyRef.
     postgres:

--- a/charts/retool/ci/test-rr-enabled-option.yaml
+++ b/charts/retool/ci/test-rr-enabled-option.yaml
@@ -18,6 +18,8 @@ rr:
     # be single-line (\n-escaped) or templating breaks.
     jwtPublicKey: '-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEljtqa2nhBwe/PqNhWgPHhj0jv8AIY+QUCicYtfv9wLGcEGPQuXoBQtuoIuOwXOdbEWgrQyLdIEb0YjegAW3miA==\n-----END PUBLIC KEY-----'
     jwtPrivateKey: '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMFXLiN/YsJv89D2YkEZ6/Dj5fujghENmYTOilwdChU3oAoGCCqGSM49AwEHoUQDQgAEljtqa2nhBwe/PqNhWgPHhj0jv8AIY+QUCicYtfv9wLGcEGPQuXoBQtuoIuOwXOdbEWgrQyLdIEb0YjegAW3miA==\n-----END EC PRIVATE KEY-----'
+    # encryption key is required (proxy derives the asset-token HMAC key from it)
+    encryptionKey: a12b01429fe0fe69a80da94e9e837ab2f1e9bda378ed8a25905a238f6fea6b7a
     postgres:
       url: postgres://retool:retool@agent-sandbox-db.example.internal:5432/agent_sandbox
       schema: agent_executor

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -676,14 +676,14 @@ or the catch-all externalSecret.name. No-op when agentSandbox is disabled.
 {{- if eq (include "retool.rr.componentEnabled" (dict "root" . "component" "agentSandbox")) "1" -}}
 {{- $as := .Values.rr.agentSandbox -}}
 {{- $ext := $as.externalSecret.name -}}
-{{- $explicitPg := or $as.postgres.url $as.postgres.urlSecretName $as.postgres.host $ext -}}
+{{- $explicitPg := or $as.postgres.url $as.postgres.urlSecretName $as.postgres.host (and $ext $as.postgres.fromExternalSecret) -}}
 {{- if not $explicitPg -}}
 {{- /* No explicit source: inherit the backend's Postgres connection. */ -}}
 {{- if not (include "retool.postgresql.host" . | trimAll "\"") -}}
-{{- fail "agentSandbox.enabled defaults to reusing the backend's Postgres connection, but config.postgresql resolved no host. Set agentSandbox.postgres.url / .host / .urlSecretName / externalSecret.name, or configure config.postgresql." -}}
+{{- fail "agentSandbox.enabled defaults to reusing the backend's Postgres connection, but config.postgresql resolved no host. Set agentSandbox.postgres.url / .host / .urlSecretName, or agentSandbox.externalSecret.name together with agentSandbox.postgres.fromExternalSecret: true (externalSecret.name alone is only used for the JWT/encryption keys, not Postgres), or configure config.postgresql." -}}
 {{- end -}}
 {{- if not (or .Values.postgresql.enabled .Values.config.postgresql.passwordSecretName (eq (include "shouldIncludeConfigSecretsEnvVars" . | trim) "1")) -}}
-{{- fail "agentSandbox.postgres is unset so it would inherit the backend's Postgres password, but that password is supplied via external secrets (envFrom) and cannot be referenced from a separate pod. Set agentSandbox.postgres.url / .urlSecretName / .host (+ passwordSecretName), or agentSandbox.externalSecret.name." -}}
+{{- fail "agentSandbox.postgres is unset so it would inherit the backend's Postgres password, but that password is supplied via external secrets (envFrom) and cannot be referenced from a separate pod. Set agentSandbox.postgres.url / .urlSecretName / .host (+ passwordSecretName), or agentSandbox.externalSecret.name together with agentSandbox.postgres.fromExternalSecret: true (externalSecret.name alone is only used for the JWT/encryption keys, not Postgres)." -}}
 {{- end -}}
 {{- end -}}
 {{- if $as.postgres.host -}}
@@ -714,6 +714,9 @@ or the catch-all externalSecret.name. No-op when agentSandbox is disabled.
 {{- if not (or $as.jwtPrivateKey $ext) -}}
 {{- fail "agentSandbox.enabled requires a JWT private key (the backend signs sandbox tokens with it). Set agentSandbox.jwtPrivateKey or agentSandbox.externalSecret.name." -}}
 {{- end -}}
+{{- if not (or $as.encryptionKey $ext) -}}
+{{- fail "agentSandbox.enabled requires an encryption key: the proxy derives the sandbox-iframe asset-token HMAC key from it and throws when serving a sandbox without it, and the backend must use the same value. Set agentSandbox.encryptionKey (64 hex chars, openssl rand -hex 32) or agentSandbox.externalSecret.name (with an encryption-key entry)." -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 
@@ -721,8 +724,10 @@ or the catch-all externalSecret.name. No-op when agentSandbox is disabled.
 Render the AGENT_SANDBOX_POSTGRES_URL env entry for the controller/proxy (plus a
 PGPASSWORD entry when assembling from fields). validateSecrets guarantees one of
 these applies, in order: postgres.url -> postgres.host -> postgres.urlSecretName
--> externalSecret.name -> inherit the backend's config.postgresql connection
-(the default when nothing agent-specific is set).
+-> externalSecret.name (only when postgres.fromExternalSecret is true) -> inherit
+the backend's config.postgresql connection (the default when nothing
+agent-specific is set, including when externalSecret.name is set only for the JWT
+keypair -- it must NOT silently hijack the Postgres source).
 
 For the host path the password is passed via PGPASSWORD rather than embedded in
 the URL: node-postgres reads PGPASSWORD when the connection string omits the
@@ -761,7 +766,7 @@ Usage: {{- include "retool.agentSandbox.postgresUrlEnv" . | nindent 12 }}
     secretKeyRef:
       name: {{ $pg.urlSecretName }}
       key: {{ $pg.urlSecretKey | default "postgres-url" }}
-{{- else if $ext }}
+{{- else if and $ext $pg.fromExternalSecret }}
 - name: AGENT_SANDBOX_POSTGRES_URL
   valueFrom:
     secretKeyRef:

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -676,14 +676,14 @@ or the catch-all externalSecret.name. No-op when agentSandbox is disabled.
 {{- if eq (include "retool.rr.componentEnabled" (dict "root" . "component" "agentSandbox")) "1" -}}
 {{- $as := .Values.rr.agentSandbox -}}
 {{- $ext := $as.externalSecret.name -}}
-{{- $explicitPg := or $as.postgres.url $as.postgres.urlSecretName $as.postgres.host (and $ext $as.postgres.fromExternalSecret) -}}
+{{- $explicitPg := or $as.postgres.url $as.postgres.urlSecretName $as.postgres.host -}}
 {{- if not $explicitPg -}}
 {{- /* No explicit source: inherit the backend's Postgres connection. */ -}}
 {{- if not (include "retool.postgresql.host" . | trimAll "\"") -}}
-{{- fail "agentSandbox.enabled defaults to reusing the backend's Postgres connection, but config.postgresql resolved no host. Set agentSandbox.postgres.url / .host / .urlSecretName, or agentSandbox.externalSecret.name together with agentSandbox.postgres.fromExternalSecret: true (externalSecret.name alone is only used for the JWT/encryption keys, not Postgres), or configure config.postgresql." -}}
+{{- fail "agentSandbox.enabled defaults to reusing the backend's Postgres connection, but config.postgresql resolved no host. Set agentSandbox.postgres.url / .host / .urlSecretName (point .urlSecretName at your externalSecret to reuse its postgres-url key; externalSecret.name alone only covers the JWT/encryption keys), or configure config.postgresql." -}}
 {{- end -}}
 {{- if not (or .Values.postgresql.enabled .Values.config.postgresql.passwordSecretName (eq (include "shouldIncludeConfigSecretsEnvVars" . | trim) "1")) -}}
-{{- fail "agentSandbox.postgres is unset so it would inherit the backend's Postgres password, but that password is supplied via external secrets (envFrom) and cannot be referenced from a separate pod. Set agentSandbox.postgres.url / .urlSecretName / .host (+ passwordSecretName), or agentSandbox.externalSecret.name together with agentSandbox.postgres.fromExternalSecret: true (externalSecret.name alone is only used for the JWT/encryption keys, not Postgres)." -}}
+{{- fail "agentSandbox.postgres is unset so it would inherit the backend's Postgres password, but that password is supplied via external secrets (envFrom) and cannot be referenced from a separate pod. Set agentSandbox.postgres.url / .urlSecretName / .host (+ passwordSecretName) -- .urlSecretName can point at your externalSecret's postgres-url key (externalSecret.name alone only covers the JWT/encryption keys)." -}}
 {{- end -}}
 {{- end -}}
 {{- if $as.postgres.host -}}
@@ -724,10 +724,10 @@ or the catch-all externalSecret.name. No-op when agentSandbox is disabled.
 Render the AGENT_SANDBOX_POSTGRES_URL env entry for the controller/proxy (plus a
 PGPASSWORD entry when assembling from fields). validateSecrets guarantees one of
 these applies, in order: postgres.url -> postgres.host -> postgres.urlSecretName
--> externalSecret.name (only when postgres.fromExternalSecret is true) -> inherit
-the backend's config.postgresql connection (the default when nothing
-agent-specific is set, including when externalSecret.name is set only for the JWT
-keypair -- it must NOT silently hijack the Postgres source).
+-> inherit the backend's config.postgresql connection (the default when nothing
+agent-specific is set). externalSecret.name covers only the JWT/encryption keys
+-- it never sources Postgres. To read a DSN from that same secret, point
+postgres.urlSecretName at it (its postgres-url key is the urlSecretKey default).
 
 For the host path the password is passed via PGPASSWORD rather than embedded in
 the URL: node-postgres reads PGPASSWORD when the connection string omits the
@@ -742,7 +742,6 @@ Usage: {{- include "retool.agentSandbox.postgresUrlEnv" . | nindent 12 }}
 */}}
 {{- define "retool.agentSandbox.postgresUrlEnv" -}}
 {{- $pg := .Values.rr.agentSandbox.postgres -}}
-{{- $ext := .Values.rr.agentSandbox.externalSecret.name -}}
 {{- if $pg.url }}
 - name: AGENT_SANDBOX_POSTGRES_URL
   value: {{ $pg.url | quote }}
@@ -766,12 +765,11 @@ Usage: {{- include "retool.agentSandbox.postgresUrlEnv" . | nindent 12 }}
     secretKeyRef:
       name: {{ $pg.urlSecretName }}
       key: {{ $pg.urlSecretKey | default "postgres-url" }}
-{{- else if and $ext $pg.fromExternalSecret }}
-- name: AGENT_SANDBOX_POSTGRES_URL
-  valueFrom:
-    secretKeyRef:
-      name: {{ $ext }}
-      key: postgres-url
+{{- /*
+  The DSN may omit the password; supply it separately via passwordSecretName so
+  an auto-rotated password (e.g. the backend's RDS secret) isn't duplicated into
+  the DSN secret. node-postgres reads PGPASSWORD when the URL omits the password.
+*/}}
 {{- if $pg.passwordSecretName }}
 - name: PGPASSWORD
   valueFrom:

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -772,6 +772,13 @@ Usage: {{- include "retool.agentSandbox.postgresUrlEnv" . | nindent 12 }}
     secretKeyRef:
       name: {{ $ext }}
       key: postgres-url
+{{- if $pg.passwordSecretName }}
+- name: PGPASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ $pg.passwordSecretName }}
+      key: {{ $pg.passwordSecretKey | default "password" }}
+{{- end }}
 {{- else }}
 {{- /*
   Default: inherit the backend's Postgres connection (config.postgresql or the

--- a/charts/retool/templates/_workers.tpl
+++ b/charts/retool/templates/_workers.tpl
@@ -230,6 +230,17 @@ spec:
             value: http://{{ template "retool.jsExecutor.name" $ }}
           {{- end }}
           {{- include "retool.agentSandbox.backendEnvVars" $ | nindent 10 }}
+          {{- if $.Values.rr.gitServer.enabled }}
+          {{- /*
+            Snapshot blob storage: the agentExecutor / snapshotRetention temporal
+            activities run on this worker and read RR_SNAPSHOTS_* with an
+            RR_DEFAULT_* fallback (backend getBlobStoreForSnapshots). Render the
+            same blobStorage env the backend and git-server get, so the fallback
+            resolves here too. No git-server host/port split is needed -- the
+            worker is a blob-storage client, not the git server itself.
+          */}}
+          {{- include "retool.gitServer.commonEnv" $ | nindent 10 }}
+          {{- end }}
 
           {{- include "retool.telemetry.includeEnvVars" $ | nindent 10 }}
 

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -887,12 +887,12 @@ rr:
     # === Secrets ============================================================
     # Provide each secret as a plaintext value below, OR set externalSecret.name
     # to a pre-existing Secret with keys jwt-public-key, jwt-private-key,
-    # encryption-key, api-secret, postgres-url. A plaintext value always wins
-    # over the external secret for that key. The postgres-url key can either
-    # include or omit an embedded password; if the password is omitted, it can
-    # be provided separately via rr.agentSandbox.postgres.passwordSecretName.
+    # encryption-key, api-secret. A plaintext value always wins over the external
+    # secret for that key. externalSecret.name covers ONLY these app secrets --
+    # it does not source Postgres. To read a DSN from that same Secret, point
+    # postgres.urlSecretName at it (see Postgres Option 3 below).
     externalSecret:
-      name: ''                 # optional: existing Secret holding all keys below
+      name: ''                 # optional: existing Secret holding the keys below
 
     jwtPublicKey: ''           # REQUIRED (ES256) unless provided via externalSecret
     jwtPrivateKey: ''          # REQUIRED (ES256) unless provided via externalSecret
@@ -925,18 +925,16 @@ rr:
       passwordSecretName: ''
       passwordSecretKey: 'password'
 
-      # -- Option 3: existing Secret holding the full DSN --
+      # -- Option 3: DSN from an existing Secret --
+      # Set urlSecretName (urlSecretKey defaults to postgres-url). To reuse the
+      # Secret in rr.agentSandbox.externalSecret.name, just point urlSecretName at
+      # it -- externalSecret.name itself never sources Postgres.
+      # The DSN may omit the password; supply it separately via passwordSecretName
+      # (above) so an auto-rotated password isn't duplicated into the DSN secret.
       urlSecretName: ''
       urlSecretKey: 'postgres-url'
 
-      # -- Option 4: reuse externalSecret.name (its postgres-url key) --
-      # Opt-in ONLY: set fromExternalSecret: true to read postgres-url from the
-      # Secret named in rr.agentSandbox.externalSecret.name. Setting externalSecret.name
-      # for the JWT keypair alone does NOT route Postgres here -- it still inherits
-      # config.postgresql (below), so an existing deployment needs no DB config.
-      fromExternalSecret: false
-
-      # If options 1-4 are ALL unset, the default (inherit config.postgresql)
+      # If options 1-3 are ALL unset, the default (inherit config.postgresql)
       # applies -- see the note at the top of this block.
 
       # -- Optional tuning (defaults shown) --

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -887,8 +887,10 @@ rr:
     # === Secrets ============================================================
     # Provide each secret as a plaintext value below, OR set externalSecret.name
     # to a pre-existing Secret with keys jwt-public-key, jwt-private-key,
-    # encryption-key, api-secret, postgres-url. A plaintext value always wins over
-    # the external secret for that key.
+    # encryption-key, api-secret, postgres-url. A plaintext value always wins
+    # over the external secret for that key. The postgres-url key can either
+    # include or omit an embedded password; if the password is omitted, it can
+    # be provided separately via rr.agentSandbox.postgres.passwordSecretName.
     externalSecret:
       name: ''                 # optional: existing Secret holding all keys below
 

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -894,7 +894,7 @@ rr:
 
     jwtPublicKey: ''           # REQUIRED (ES256) unless provided via externalSecret
     jwtPrivateKey: ''          # REQUIRED (ES256) unless provided via externalSecret
-    encryptionKey: ''          # optional: hex 256-bit; must match backend AGENT_SANDBOX_ENCRYPTION_KEY
+    encryptionKey: ''          # REQUIRED: 64 hex chars (openssl rand -hex 32, NOT base64). Proxy throws when serving a sandbox without it; must match the backend's AGENT_SANDBOX_ENCRYPTION_KEY. May instead be supplied via externalSecret.name (encryption-key entry).
     apiSecret: ''              # optional: admin/test endpoints
 
     # === Postgres state backend =============================================
@@ -928,9 +928,12 @@ rr:
       urlSecretKey: 'postgres-url'
 
       # -- Option 4: reuse externalSecret.name (its postgres-url key) --
-      # Selected by setting rr.agentSandbox.externalSecret.name (in the Secrets
-      # section above), not by anything here. Used when options 1-3 are blank.
-      #
+      # Opt-in ONLY: set fromExternalSecret: true to read postgres-url from the
+      # Secret named in rr.agentSandbox.externalSecret.name. Setting externalSecret.name
+      # for the JWT keypair alone does NOT route Postgres here -- it still inherits
+      # config.postgresql (below), so an existing deployment needs no DB config.
+      fromExternalSecret: false
+
       # If options 1-4 are ALL unset, the default (inherit config.postgresql)
       # applies -- see the note at the top of this block.
 

--- a/values.yaml
+++ b/values.yaml
@@ -887,12 +887,12 @@ rr:
     # === Secrets ============================================================
     # Provide each secret as a plaintext value below, OR set externalSecret.name
     # to a pre-existing Secret with keys jwt-public-key, jwt-private-key,
-    # encryption-key, api-secret, postgres-url. A plaintext value always wins
-    # over the external secret for that key. The postgres-url key can either
-    # include or omit an embedded password; if the password is omitted, it can
-    # be provided separately via rr.agentSandbox.postgres.passwordSecretName.
+    # encryption-key, api-secret. A plaintext value always wins over the external
+    # secret for that key. externalSecret.name covers ONLY these app secrets --
+    # it does not source Postgres. To read a DSN from that same Secret, point
+    # postgres.urlSecretName at it (see Postgres Option 3 below).
     externalSecret:
-      name: ''                 # optional: existing Secret holding all keys below
+      name: ''                 # optional: existing Secret holding the keys below
 
     jwtPublicKey: ''           # REQUIRED (ES256) unless provided via externalSecret
     jwtPrivateKey: ''          # REQUIRED (ES256) unless provided via externalSecret
@@ -925,18 +925,16 @@ rr:
       passwordSecretName: ''
       passwordSecretKey: 'password'
 
-      # -- Option 3: existing Secret holding the full DSN --
+      # -- Option 3: DSN from an existing Secret --
+      # Set urlSecretName (urlSecretKey defaults to postgres-url). To reuse the
+      # Secret in rr.agentSandbox.externalSecret.name, just point urlSecretName at
+      # it -- externalSecret.name itself never sources Postgres.
+      # The DSN may omit the password; supply it separately via passwordSecretName
+      # (above) so an auto-rotated password isn't duplicated into the DSN secret.
       urlSecretName: ''
       urlSecretKey: 'postgres-url'
 
-      # -- Option 4: reuse externalSecret.name (its postgres-url key) --
-      # Opt-in ONLY: set fromExternalSecret: true to read postgres-url from the
-      # Secret named in rr.agentSandbox.externalSecret.name. Setting externalSecret.name
-      # for the JWT keypair alone does NOT route Postgres here -- it still inherits
-      # config.postgresql (below), so an existing deployment needs no DB config.
-      fromExternalSecret: false
-
-      # If options 1-4 are ALL unset, the default (inherit config.postgresql)
+      # If options 1-3 are ALL unset, the default (inherit config.postgresql)
       # applies -- see the note at the top of this block.
 
       # -- Optional tuning (defaults shown) --

--- a/values.yaml
+++ b/values.yaml
@@ -887,8 +887,10 @@ rr:
     # === Secrets ============================================================
     # Provide each secret as a plaintext value below, OR set externalSecret.name
     # to a pre-existing Secret with keys jwt-public-key, jwt-private-key,
-    # encryption-key, api-secret, postgres-url. A plaintext value always wins over
-    # the external secret for that key.
+    # encryption-key, api-secret, postgres-url. A plaintext value always wins
+    # over the external secret for that key. The postgres-url key can either
+    # include or omit an embedded password; if the password is omitted, it can
+    # be provided separately via rr.agentSandbox.postgres.passwordSecretName.
     externalSecret:
       name: ''                 # optional: existing Secret holding all keys below
 

--- a/values.yaml
+++ b/values.yaml
@@ -894,7 +894,7 @@ rr:
 
     jwtPublicKey: ''           # REQUIRED (ES256) unless provided via externalSecret
     jwtPrivateKey: ''          # REQUIRED (ES256) unless provided via externalSecret
-    encryptionKey: ''          # optional: hex 256-bit; must match backend AGENT_SANDBOX_ENCRYPTION_KEY
+    encryptionKey: ''          # REQUIRED: 64 hex chars (openssl rand -hex 32, NOT base64). Proxy throws when serving a sandbox without it; must match the backend's AGENT_SANDBOX_ENCRYPTION_KEY. May instead be supplied via externalSecret.name (encryption-key entry).
     apiSecret: ''              # optional: admin/test endpoints
 
     # === Postgres state backend =============================================
@@ -928,9 +928,12 @@ rr:
       urlSecretKey: 'postgres-url'
 
       # -- Option 4: reuse externalSecret.name (its postgres-url key) --
-      # Selected by setting rr.agentSandbox.externalSecret.name (in the Secrets
-      # section above), not by anything here. Used when options 1-3 are blank.
-      #
+      # Opt-in ONLY: set fromExternalSecret: true to read postgres-url from the
+      # Secret named in rr.agentSandbox.externalSecret.name. Setting externalSecret.name
+      # for the JWT keypair alone does NOT route Postgres here -- it still inherits
+      # config.postgresql (below), so an existing deployment needs no DB config.
+      fromExternalSecret: false
+
       # If options 1-4 are ALL unset, the default (inherit config.postgresql)
       # applies -- see the note at the top of this block.
 


### PR DESCRIPTION
## what

setting `rr.agentSandbox.externalSecret.name` (intended just for the JWT keypair) silently overloaded two unrelated things, breaking enablement on a deployment that only wanted to reuse its existing backend postgres:

- **postgres hijack** — `postgresUrlEnv` routed `AGENT_SANDBOX_POSTGRES_URL` to the external secret's `postgres-url` key. missing key → `getaddrinfo ENOTFOUND` at runtime. the inherit-the-backend path was unreachable whenever `externalSecret.name` was set, and `validateSecrets` counted it as an explicit pg source so nothing failed at template time.
- **encryption key was treated as optional** — but it isn't. the proxy derives the sandbox-iframe asset-token HMAC key from `AGENT_SANDBOX_ENCRYPTION_KEY` (`agent_executor/proxy/src/config.ts` `getAssetTokenHmacSecret`) and **throws the first time it serves a sandbox** if it's missing. the pod comes up green and then fails at first use.

separately, the snapshot blob-storage env never reached the **workflow worker**, even though the agent/snapshot temporal activities run there.

## changes

- **`externalSecret.name` now covers only the JWT/encryption keys — it never sources postgres.** to read a DSN from that same secret, point `postgres.urlSecretName` at it (Option 3; `urlSecretKey` defaults to `postgres-url`). otherwise postgres inherits `config.postgresql` — an existing deployment needs no DB config.
- **require** the agent sandbox encryption key in `validateSecrets` (mirrors the JWT-key checks) — fail loudly at render instead of shipping a pod that breaks at first sandbox use; both fail hints point at `postgres.urlSecretName`
- **render `gitServer.commonEnv` (`RR_DEFAULT_*`) onto the workflow worker** when `rr.gitServer.enabled`. the `agentExecutor`/`snapshotRetention` temporal activities run on `WORKFLOW_TEMPORAL_WORKER` and read snapshot blob storage (`getBlobStoreForSnapshots`, `RR_SNAPSHOTS_*` → `RR_DEFAULT_*` fallback), but `commonEnv` was only injected onto the backend + standalone git-server pod — so the worker had no creds and snapshot access failed there.
- `values.yaml` (both copies): drop `postgres-url` from the `externalSecret.name` key list, mark `encryptionKey` required (64 hex, `openssl rand -hex 32`)
- bump chart 6.11.1 → 6.11.2; update `ci/` fixtures to supply the now-required encryption key

## incorporates #332

pulled in @ryanartecona's `passwordSecretName` support so the two don't collide. in the final shape it lives in the `postgres.urlSecretName` branch: the blueprints case (DSN from the agent-sandbox secret, password from the auto-rotated main secret) is `postgres.urlSecretName: agent-sandbox-env` + `postgres.passwordSecretName: retool-config`.

> note: an earlier revision used a `postgres.fromExternalSecret` boolean — redundant with `postgres.urlSecretName`, since removed in favor of it.

## testing

`helm template` verified: `urlSecretName` routes to the secret's `postgres-url` (+ `PGPASSWORD` when `passwordSecretName` set); JWT-only `externalSecret` inherits the backend DSN; render **fails** with a clear error when no encryption-key source is set; the workflow worker now renders `RR_DEFAULT_*` when `gitServer.enabled` + `blobStorage` is set. all `ci/` fixtures render; `helm lint` clean.

note: same-origin-on-HTTPS (a separate reported issue) is a backend gap, not chart-fixable, and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)