### PR TITLE
Respect postgres.passwordSecretName in presence of rr.agentSandbox.externalSecret

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.11.0
+version: 6.11.1
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -747,6 +747,13 @@ Usage: {{- include "retool.agentSandbox.postgresUrlEnv" . | nindent 12 }}
     secretKeyRef:
       name: {{ $ext }}
       key: postgres-url
+{{- if $pg.passwordSecretName }}
+- name: PGPASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ $pg.passwordSecretName }}
+      key: {{ $pg.passwordSecretKey | default "password" }}
+{{- end }}
 {{- else }}
 {{- /*
   Default: inherit the backend's Postgres connection (config.postgresql or the

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -878,8 +878,10 @@ rr:
     # === Secrets ============================================================
     # Provide each secret as a plaintext value below, OR set externalSecret.name
     # to a pre-existing Secret with keys jwt-public-key, jwt-private-key,
-    # encryption-key, api-secret, postgres-url. A plaintext value always wins over
-    # the external secret for that key.
+    # encryption-key, api-secret, postgres-url. A plaintext value always wins
+    # over the external secret for that key. The postgres-url key can either
+    # include or omit an embedded password; if the password is omitted, it can
+    # be provided separately via rr.agentSandbox.postgres.passwordSecretName.
     externalSecret:
       name: ''                 # optional: existing Secret holding all keys below
 

--- a/values.yaml
+++ b/values.yaml
@@ -878,8 +878,10 @@ rr:
     # === Secrets ============================================================
     # Provide each secret as a plaintext value below, OR set externalSecret.name
     # to a pre-existing Secret with keys jwt-public-key, jwt-private-key,
-    # encryption-key, api-secret, postgres-url. A plaintext value always wins over
-    # the external secret for that key.
+    # encryption-key, api-secret, postgres-url. A plaintext value always wins
+    # over the external secret for that key. The postgres-url key can either
+    # include or omit an embedded password; if the password is omitted, it can
+    # be provided separately via rr.agentSandbox.postgres.passwordSecretName.
     externalSecret:
       name: ''                 # optional: existing Secret holding all keys below
 


### PR DESCRIPTION
In blueprints, we want the agentSandbox secrets to come from different places: jwt-public-key, jwt-private-key, and postgres-url from an agent-sandbox secret, but specifically the postgres password from the main retool secret, as that is the only one that gets auto rotated by e.g. RDS.

This allows agentSandbox.externalSecret to also be used with agentSandbox.postgres.passwordSecretName when both are present.