### PR TITLE
[codex] Add MCP agent sandbox JWT config

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.11.1
+version: 6.11.2
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/ci/test-mcp-agent-sandbox-secret-option.yaml
+++ b/charts/retool/ci/test-mcp-agent-sandbox-secret-option.yaml
@@ -1,0 +1,6 @@
+mcp:
+  enabled: true
+  config:
+    oauthIntrospectionAuthToken: test-oauth-introspection-token
+    agentSandboxJwtPrivateKeySecretName: agent-sandbox-jwt
+    agentSandboxJwtPrivateKeySecretKey: private-key

--- a/charts/retool/ci/test-mcp-enabled-option.yaml
+++ b/charts/retool/ci/test-mcp-enabled-option.yaml
@@ -4,6 +4,7 @@ mcp:
   config:
     oauthMainDomain: https://oauth.example.com
     oauthIntrospectionAuthToken: test-oauth-introspection-token
+    agentSandboxJwtPrivateKey: test-agent-sandbox-jwt-private-key
     enabledToolsets:
       - apps
       - resources

--- a/charts/retool/templates/deployment_mcp.yaml
+++ b/charts/retool/templates/deployment_mcp.yaml
@@ -146,6 +146,16 @@ spec:
           - name: OAUTH_INTROSPECTION_AUTH_TOKEN
             value: {{ $mcpConfig.oauthIntrospectionAuthToken | quote }}
           {{- end }}
+          {{- if $mcpConfig.agentSandboxJwtPrivateKeySecretName }}
+          - name: AGENT_SANDBOX_JWT_PRIVATE_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ $mcpConfig.agentSandboxJwtPrivateKeySecretName }}
+                key: {{ $mcpConfig.agentSandboxJwtPrivateKeySecretKey | default "jwt-private-key" }}
+          {{- else if $mcpConfig.agentSandboxJwtPrivateKey }}
+          - name: AGENT_SANDBOX_JWT_PRIVATE_KEY
+            value: {{ $mcpConfig.agentSandboxJwtPrivateKey | quote }}
+          {{- end }}
           {{- if $mcpConfig.nodeOptions }}
           - name: NODE_OPTIONS
             value: {{ $mcpConfig.nodeOptions | quote }}

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -624,6 +624,15 @@ mcp:
   #   # is provided directly in mcp.environmentVariables.
   #   oauthIntrospectionAuthToken:
   #
+  #   # Secret-backed private key used by MCP to sign agent sandbox requests.
+  #   # Usually points at the same key as rr.agentSandbox.externalSecret.name.
+  #   agentSandboxJwtPrivateKeySecretName:
+  #   agentSandboxJwtPrivateKeySecretKey: jwt-private-key
+  #
+  #   # Literal private key override for development/testing only. Prefer the
+  #   # secret-backed setting above for real deployments.
+  #   agentSandboxJwtPrivateKey:
+  #
   #   # Optional Node.js options for the MCP server process. Unset by default.
   #   nodeOptions: --max_old_space_size=1024
   #

--- a/values.yaml
+++ b/values.yaml
@@ -624,6 +624,15 @@ mcp:
   #   # is provided directly in mcp.environmentVariables.
   #   oauthIntrospectionAuthToken:
   #
+  #   # Secret-backed private key used by MCP to sign agent sandbox requests.
+  #   # Usually points at the same key as rr.agentSandbox.externalSecret.name.
+  #   agentSandboxJwtPrivateKeySecretName:
+  #   agentSandboxJwtPrivateKeySecretKey: jwt-private-key
+  #
+  #   # Literal private key override for development/testing only. Prefer the
+  #   # secret-backed setting above for real deployments.
+  #   agentSandboxJwtPrivateKey:
+  #
   #   # Optional Node.js options for the MCP server process. Unset by default.
   #   nodeOptions: --max_old_space_size=1024
   #


### PR DESCRIPTION
Adds typed MCP configuration for AGENT_SANDBOX_JWT_PRIVATE_KEY, supporting both inline values and Kubernetes Secret references. Documents the new mcp.config keys in both synced values files and adds CI overlays for inline and secret-backed rendering. Bumps the chart patch version to 6.11.2. Validated with Helm render checks, targeted helm lint, a full CI option render sweep, and the values sync diff.