### PR TITLE
fix(rr): inherit backend SSL for agent sandbox postgres (sslmode=no-verify)

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.11.3
+version: 6.11.4
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/ci/test-agent-sandbox-inherit-ssl-option.yaml
+++ b/charts/retool/ci/test-agent-sandbox-inherit-ssl-option.yaml
@@ -1,0 +1,38 @@
+rr:
+
+  # Agent Sandbox — inherit an EXTERNAL, SSL-required Postgres. Complements
+  # test-agent-sandbox-inherit-postgres-option.yaml (which inherits the in-cluster
+  # subchart with SSL off). Here postgresql.enabled is false and the backend points
+  # at an external DB with config.postgresql.ssl_enabled: true, so the inherited
+  # AGENT_SANDBOX_POSTGRES_URL must carry ?sslmode=no-verify (regression guard for
+  # the SSL-inheritance fix; without it an SSL-required RDS rejects the connection
+  # with "no pg_hba.conf entry ... no encryption").
+  #
+  # agentSandbox.postgres is left unset (only schema) so it inherits the backend.
+  agentSandbox:
+    enabled: true
+
+    image:
+      repository: tryretool/agent-sandbox-service
+      tag: 3.123.4
+      pullPolicy: IfNotPresent
+
+    jwtPublicKey: '-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEljtqa2nhBwe/PqNhWgPHhj0jv8AI\nY+QUCicYtfv9wLGcEGPQuXoBQtuoIuOwXOdbEWgrQyLdIEb0YjegAW3miA==\n-----END PUBLIC KEY-----'
+    jwtPrivateKey: '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMFXLiN/YsJv89D2YkEZ6/Dj5fujghENmYTOilwdChU3oAoGCCqGSM49\nAwEHoUQDQgAEljtqa2nhBwe/PqNhWgPHhj0jv8AIY+QUCicYtfv9wLGcEGPQuXoBQtuoIuOwXOdbEWgrQyLdIEb0YjegAW3miA==\n-----END EC PRIVATE KEY-----'
+    # encryption key is required (proxy derives the asset-token HMAC key from it)
+    encryptionKey: a12b01429fe0fe69a80da94e9e837ab2f1e9bda378ed8a25905a238f6fea6b7a
+    postgres:
+      schema: agent_executor
+
+# Disable the in-cluster subchart and inherit an external SSL-required DB.
+postgresql:
+  enabled: false
+config:
+  postgresql:
+    host: agentdb-prod.postgres.database.example.com
+    port: 5432
+    db: hammerhead_production
+    user: retool_internal_user
+    ssl_enabled: true
+    passwordSecretName: main-postgres-password
+    passwordSecretKey: postgresql-password

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -725,7 +725,8 @@ Render the AGENT_SANDBOX_POSTGRES_URL env entry for the controller/proxy (plus a
 PGPASSWORD entry when assembling from fields). validateSecrets guarantees one of
 these applies, in order: postgres.url -> postgres.host -> postgres.urlSecretName
 -> inherit the backend's config.postgresql connection (the default when nothing
-agent-specific is set). externalSecret.name covers only the JWT/encryption keys
+agent-specific is set; the inherited DSN also carries sslmode=no-verify when the
+backend uses SSL). externalSecret.name covers only the JWT/encryption keys
 -- it never sources Postgres. To read a DSN from that same secret, point
 postgres.urlSecretName at it (its postgres-url key is the urlSecretKey default).
 
@@ -803,8 +804,10 @@ Usage: {{- include "retool.agentSandbox.postgresUrlEnv" . | nindent 12 }}
       name: {{ template "retool.fullname" . }}
       key: postgresql-password
       {{- end }}
+{{- /* inherit the backend's SSL too (mirror POSTGRES_SSL_ENABLED) */}}
+{{- $sslSuffix := ternary "?sslmode=no-verify" "" (eq (include "retool.postgresql.ssl_enabled" . | trimAll "\"") "true") }}
 - name: AGENT_SANDBOX_POSTGRES_URL
-  value: {{ printf "postgres://%s@%s:%s/%s" (include "retool.postgresql.user" . | trimAll "\"") (include "retool.postgresql.host" . | trimAll "\"") (include "retool.postgresql.port" . | trimAll "\"" | default "5432") (include "retool.postgresql.database" . | trimAll "\"") | quote }}
+  value: {{ printf "postgres://%s@%s:%s/%s%s" (include "retool.postgresql.user" . | trimAll "\"") (include "retool.postgresql.host" . | trimAll "\"") (include "retool.postgresql.port" . | trimAll "\"" | default "5432") (include "retool.postgresql.database" . | trimAll "\"") $sslSuffix | quote }}
 {{- end }}
 {{- end -}}
 


### PR DESCRIPTION
## what

When `rr.agentSandbox.postgres` is left to **inherit** the backend connection (`config.postgresql`), the chart assembled `AGENT_SANDBOX_POSTGRES_URL` with **no `sslmode`**. The agent-sandbox controller/proxy connect via Knex/`pg`, which only does TLS if the connection string says so — so an SSL-required RDS rejects them:

```
no pg_hba.conf entry for host "...", user "retool_internal_user", database "hammerhead_admin_prod", no encryption
```

The backend connects to the same DB fine because it applies SSL (`common/resources/connectionStringUtil.ts` → `sslmode=no-verify`); the inherited sandbox DSN didn't carry it.

## fix

Append `?sslmode=no-verify` to the inherited DSN when the backend uses SSL (`retool.postgresql.ssl_enabled` is true), mirroring the backend. No effect when SSL is off (e.g. the in-cluster postgresql subchart). The explicit `postgres.url` / `urlSecretName` paths are unchanged — operators put `sslmode` in those themselves.

## testing

- `helm template`: external pg + `ssl_enabled: true` → `…/hammerhead_admin_prod?sslmode=no-verify`; in-cluster subchart → no `sslmode`. All `ci/` fixtures render; `helm lint` clean.
- **New CI fixture** `ci/test-agent-sandbox-inherit-ssl-option.yaml` exercises the external-SSL inherit path (`postgresql.enabled: false` + `config.postgresql.ssl_enabled: true`), which no existing fixture covered — locks in the `sslmode` suffix against future regressions.
- Chart bumped 6.11.3 → 6.11.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)