### PR TITLE
Allow configuring host/scheme on liveness, readiness, and startup probes (fixes code-executor on IPv6 clusters)

### DIFF
--- a/charts/retool/templates/_workers.tpl
+++ b/charts/retool/templates/_workers.tpl
@@ -358,6 +358,12 @@ spec:
           httpGet:
             path: {{ $.Values.livenessProbe.path }}
             port: {{ $healthcheckPort }}
+            {{- with $.Values.livenessProbe.host }}
+            host: {{ . | quote }}
+            {{- end }}
+            {{- with $.Values.livenessProbe.scheme }}
+            scheme: {{ . }}
+            {{- end }}
           initialDelaySeconds: {{ $.Values.livenessProbe.initialDelaySeconds }}
           timeoutSeconds: {{ $.Values.livenessProbe.timeoutSeconds }}
           failureThreshold:  {{ $.Values.livenessProbe.failureThreshold }}
@@ -367,6 +373,12 @@ spec:
           httpGet:
             path: {{ $.Values.readinessProbe.path }}
             port: {{ $healthcheckPort }}
+            {{- with $.Values.readinessProbe.host }}
+            host: {{ . | quote }}
+            {{- end }}
+            {{- with $.Values.readinessProbe.scheme }}
+            scheme: {{ . }}
+            {{- end }}
           initialDelaySeconds: {{ $.Values.readinessProbe.initialDelaySeconds }}
           timeoutSeconds: {{ $.Values.readinessProbe.timeoutSeconds }}
           successThreshold: {{ $.Values.readinessProbe.successThreshold }}

--- a/charts/retool/templates/deployment_agent_sandbox.yaml
+++ b/charts/retool/templates/deployment_agent_sandbox.yaml
@@ -366,6 +366,12 @@ spec:
             httpGet:
               path: /livez
               port: http
+              {{- with .Values.livenessProbe.host }}
+              host: {{ . | quote }}
+              {{- end }}
+              {{- with .Values.livenessProbe.scheme }}
+              scheme: {{ . }}
+              {{- end }}
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
@@ -374,6 +380,12 @@ spec:
             httpGet:
               path: /health
               port: http
+              {{- with .Values.readinessProbe.host }}
+              host: {{ . | quote }}
+              {{- end }}
+              {{- with .Values.readinessProbe.scheme }}
+              scheme: {{ . }}
+              {{- end }}
             initialDelaySeconds: 1
             periodSeconds: 2
             timeoutSeconds: 3
@@ -542,6 +554,12 @@ spec:
             httpGet:
               path: /livez
               port: http
+              {{- with .Values.livenessProbe.host }}
+              host: {{ . | quote }}
+              {{- end }}
+              {{- with .Values.livenessProbe.scheme }}
+              scheme: {{ . }}
+              {{- end }}
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
@@ -550,6 +568,12 @@ spec:
             httpGet:
               path: /health
               port: http
+              {{- with .Values.readinessProbe.host }}
+              host: {{ . | quote }}
+              {{- end }}
+              {{- with .Values.readinessProbe.scheme }}
+              scheme: {{ . }}
+              {{- end }}
             initialDelaySeconds: 1
             periodSeconds: 2
             timeoutSeconds: 3

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -313,6 +313,12 @@ spec:
           httpGet:
             path: {{ .Values.livenessProbe.path }}
             port: {{ .Values.service.internalPort }}
+            {{- with .Values.livenessProbe.host }}
+            host: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.livenessProbe.scheme }}
+            scheme: {{ . }}
+            {{- end }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
@@ -323,6 +329,12 @@ spec:
           httpGet:
             path: {{ .Values.readinessProbe.path }}
             port: {{ .Values.service.internalPort }}
+            {{- with .Values.readinessProbe.host }}
+            host: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.readinessProbe.scheme }}
+            scheme: {{ . }}
+            {{- end }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
           successThreshold: {{ .Values.readinessProbe.successThreshold }}
@@ -339,6 +351,12 @@ spec:
           httpGet:
             path: {{ .Values.startupProbe.path }}
             port: {{ .Values.service.internalPort }}
+            {{- with .Values.startupProbe.host }}
+            host: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.startupProbe.scheme }}
+            scheme: {{ . }}
+            {{- end }}
           initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
           timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
           successThreshold: {{ .Values.startupProbe.successThreshold }}

--- a/charts/retool/templates/deployment_code_executor.yaml
+++ b/charts/retool/templates/deployment_code_executor.yaml
@@ -141,6 +141,12 @@ spec:
           httpGet:
             path: {{ .Values.livenessProbe.path }}
             port: 3004
+            {{- with .Values.livenessProbe.host }}
+            host: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.livenessProbe.scheme }}
+            scheme: {{ . }}
+            {{- end }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           failureThreshold:  {{ .Values.livenessProbe.failureThreshold }}
@@ -150,6 +156,12 @@ spec:
           httpGet:
             path: {{ .Values.readinessProbe.path }}
             port: 3004
+            {{- with .Values.readinessProbe.host }}
+            host: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.readinessProbe.scheme }}
+            scheme: {{ . }}
+            {{- end }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
           successThreshold: {{ .Values.readinessProbe.successThreshold }}

--- a/charts/retool/templates/deployment_dbconnector.yaml
+++ b/charts/retool/templates/deployment_dbconnector.yaml
@@ -47,6 +47,12 @@ spec:
           httpGet:
             path: {{ .Values.readinessProbe.path }}
             port: {{ .Values.dbconnector.port }}
+            {{- with .Values.readinessProbe.host }}
+            host: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.readinessProbe.scheme }}
+            scheme: {{ . }}
+            {{- end }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
           successThreshold: {{ .Values.readinessProbe.successThreshold }}
@@ -55,6 +61,12 @@ spec:
           httpGet:
             path: {{ .Values.livenessProbe.path }}
             port: {{ .Values.dbconnector.port }}
+            {{- with .Values.livenessProbe.host }}
+            host: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.livenessProbe.scheme }}
+            scheme: {{ . }}
+            {{- end }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           failureThreshold:  {{ .Values.livenessProbe.failureThreshold }}

--- a/charts/retool/templates/deployment_jobs.yaml
+++ b/charts/retool/templates/deployment_jobs.yaml
@@ -226,6 +226,12 @@ spec:
           httpGet:
             path: /api/checkJobsRunnerHealth
             port: 3003
+            {{- with .Values.livenessProbe.host }}
+            host: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.livenessProbe.scheme }}
+            scheme: {{ . }}
+            {{- end }}
           initialDelaySeconds: 120
           periodSeconds: 30
           timeoutSeconds: 3
@@ -233,6 +239,12 @@ spec:
           httpGet:
             path: /api/checkJobsRunnerHealth
             port: 3003
+            {{- with .Values.readinessProbe.host }}
+            host: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.readinessProbe.scheme }}
+            scheme: {{ . }}
+            {{- end }}
           initialDelaySeconds: 120
           periodSeconds: 30
           timeoutSeconds: 3

--- a/charts/retool/templates/deployment_js_executor.yaml
+++ b/charts/retool/templates/deployment_js_executor.yaml
@@ -117,6 +117,12 @@ spec:
           httpGet:
             path: /api/health
             port: 3000
+            {{- with .Values.livenessProbe.host }}
+            host: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.livenessProbe.scheme }}
+            scheme: {{ . }}
+            {{- end }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           failureThreshold:  {{ .Values.livenessProbe.failureThreshold }}
@@ -124,6 +130,12 @@ spec:
           httpGet:
             path: /api/readiness
             port: 3000
+            {{- with .Values.readinessProbe.host }}
+            host: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.readinessProbe.scheme }}
+            scheme: {{ . }}
+            {{- end }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
           successThreshold: {{ .Values.readinessProbe.successThreshold }}

--- a/charts/retool/templates/deployment_mcp.yaml
+++ b/charts/retool/templates/deployment_mcp.yaml
@@ -191,11 +191,23 @@ spec:
           httpGet:
             path: /healthcheck
             port: {{ $mcpInternalPort }}
+            {{- with .Values.readinessProbe.host }}
+            host: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.readinessProbe.scheme }}
+            scheme: {{ . }}
+            {{- end }}
           periodSeconds: 10
         livenessProbe:
           httpGet:
             path: /healthcheck
             port: {{ $mcpInternalPort }}
+            {{- with .Values.livenessProbe.host }}
+            host: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.livenessProbe.scheme }}
+            scheme: {{ . }}
+            {{- end }}
           initialDelaySeconds: 30
           failureThreshold: 10
           timeoutSeconds: 10

--- a/charts/retool/templates/deployment_multiplayer_ws.yaml
+++ b/charts/retool/templates/deployment_multiplayer_ws.yaml
@@ -178,11 +178,23 @@ spec:
           httpGet:
             path: /api/checkHealth
             port: 3001
+            {{- with .Values.readinessProbe.host }}
+            host: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.readinessProbe.scheme }}
+            scheme: {{ . }}
+            {{- end }}
           periodSeconds: 10
         livenessProbe:
           httpGet:
             path: /api/checkHealth
             port: 3001
+            {{- with .Values.livenessProbe.host }}
+            host: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.livenessProbe.scheme }}
+            scheme: {{ . }}
+            {{- end }}
           initialDelaySeconds: 100
           failureThreshold: 10
           timeoutSeconds: 10

--- a/charts/retool/templates/deployment_workflows.yaml
+++ b/charts/retool/templates/deployment_workflows.yaml
@@ -277,6 +277,12 @@ spec:
           httpGet:
             path: {{ .Values.livenessProbe.path }}
             port: {{ .Values.service.internalPort }}
+            {{- with .Values.livenessProbe.host }}
+            host: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.livenessProbe.scheme }}
+            scheme: {{ . }}
+            {{- end }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           failureThreshold:  {{ .Values.livenessProbe.failureThreshold }}
@@ -286,6 +292,12 @@ spec:
           httpGet:
             path: {{ .Values.readinessProbe.path }}
             port: {{ .Values.service.internalPort }}
+            {{- with .Values.readinessProbe.host }}
+            host: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.readinessProbe.scheme }}
+            scheme: {{ . }}
+            {{- end }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
           successThreshold: {{ .Values.readinessProbe.successThreshold }}

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -263,6 +263,13 @@ serviceAccount:
 livenessProbe:
   enabled: true
   path: /api/checkHealth
+  # host and scheme are optional. On IPv6-primary or dual-stack clusters, set
+  # host to 127.0.0.1 so the kubelet probes the IPv4 loopback. Some services
+  # (e.g. code-executor) listen on IPv4 only, so probing the Pod's IPv6 address
+  # fails with "connection refused" and the pod CrashLoops. Leave unset for the
+  # default behavior (the kubelet probes the Pod IP).
+  # host: 127.0.0.1
+  # scheme: HTTP
   initialDelaySeconds: 30
   timeoutSeconds: 10
   periodSeconds: 10
@@ -271,6 +278,9 @@ livenessProbe:
 readinessProbe:
   enabled: true
   path: /api/checkHealth
+  # Optional; see livenessProbe above. Set host: 127.0.0.1 on IPv6/dual-stack clusters.
+  # host: 127.0.0.1
+  # scheme: HTTP
   initialDelaySeconds: 30
   timeoutSeconds: 10
   periodSeconds: 10
@@ -283,6 +293,9 @@ preStopHook:
 startupProbe:
   enabled: false
   path: /api/checkHealth
+  # Optional; see livenessProbe above. Set host: 127.0.0.1 on IPv6/dual-stack clusters.
+  # host: 127.0.0.1
+  # scheme: HTTP
   initialDelaySeconds: 60
   timeoutSeconds: 10
   periodSeconds: 10

--- a/values.yaml
+++ b/values.yaml
@@ -263,6 +263,13 @@ serviceAccount:
 livenessProbe:
   enabled: true
   path: /api/checkHealth
+  # host and scheme are optional. On IPv6-primary or dual-stack clusters, set
+  # host to 127.0.0.1 so the kubelet probes the IPv4 loopback. Some services
+  # (e.g. code-executor) listen on IPv4 only, so probing the Pod's IPv6 address
+  # fails with "connection refused" and the pod CrashLoops. Leave unset for the
+  # default behavior (the kubelet probes the Pod IP).
+  # host: 127.0.0.1
+  # scheme: HTTP
   initialDelaySeconds: 30
   timeoutSeconds: 10
   periodSeconds: 10
@@ -271,6 +278,9 @@ livenessProbe:
 readinessProbe:
   enabled: true
   path: /api/checkHealth
+  # Optional; see livenessProbe above. Set host: 127.0.0.1 on IPv6/dual-stack clusters.
+  # host: 127.0.0.1
+  # scheme: HTTP
   initialDelaySeconds: 30
   timeoutSeconds: 10
   periodSeconds: 10
@@ -283,6 +293,9 @@ preStopHook:
 startupProbe:
   enabled: false
   path: /api/checkHealth
+  # Optional; see livenessProbe above. Set host: 127.0.0.1 on IPv6/dual-stack clusters.
+  # host: 127.0.0.1
+  # scheme: HTTP
   initialDelaySeconds: 60
   timeoutSeconds: 10
   periodSeconds: 10


### PR DESCRIPTION
### What

Adds optional `host` and `scheme` fields to the `livenessProbe`, `readinessProbe`, and
`startupProbe` httpGet probes, wired into every deployment that renders from those shared
values (`backend`, `code-executor`, `dbconnector`, `workflows`, `js-executor`, and the
workers in `_workers.tpl`).

### Why

On IPv6-primary / dual-stack clusters, the `code-executor` pod CrashLoops because the
kubelet probes the Pod's primary IP (IPv6) but the service listens on IPv4 only, so the
probe fails with `connection refused`. There is currently no supported way to point the
probe at the IPv4 loopback — the probe values only expose `enabled`, `path`, and timing
fields. See #335 for the full reproduction and evidence.

With this change, operators on such clusters can set:

```yaml
livenessProbe:
  host: 127.0.0.1
readinessProbe:
  host: 127.0.0.1
```

which makes the kubelet probe the IPv4 loopback the server is already bound to. This is the
standard Kubernetes mechanism (`httpGet.host`) for exactly this situation.

### Backwards compatibility

Fully backwards-compatible. Both fields are rendered only `{{- with ... }}`, so when unset
(the default) the manifests are byte-for-byte identical to before.

Verified with `helm template`:

- Defaults → no `host`/`scheme` emitted anywhere.
- `--set livenessProbe.host=127.0.0.1 --set readinessProbe.host=127.0.0.1` → `host` rendered
  inside `httpGet` across all affected components.

### Notes

The deeper root cause (the `code-executor-service` image binding IPv4-only instead of `::`)
is out of scope for this chart; this PR gives operators a supported workaround at the chart
level. Happy to add a chart version bump if the release process expects it in-PR.

Fixes #335
