### PR TITLE
[fix][MCP] MCP Configuration improvements

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.11.5
+version: 6.11.6
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/ci/test-install-values.yaml
+++ b/charts/retool/ci/test-install-values.yaml
@@ -55,6 +55,9 @@ commandline:
 env:
   # required env var for backend to start up, but not actually registered
   BASE_DOMAIN: "https://helm-ci.retool.dev"
+  # CI runs all pods at once in kind. Avoid failing chart install on transient
+  # DNS/startup ordering while the code executor service is coming up.
+  IGNORE_CODE_EXECUTOR_STARTUP_CHECK: "true"
 
 # Optionally specify additional environment variables to be populated from Kubernetes secrets.
 # Useful for passing in SCIM_AUTH_TOKEN or other secret environment variables from Kubernetes secrets.

--- a/charts/retool/ci/test-mcp-agent-sandbox-secret-option.yaml
+++ b/charts/retool/ci/test-mcp-agent-sandbox-secret-option.yaml
@@ -1,6 +1,11 @@
+rr:
+  agentSandbox:
+    enabled: true
+    externalSecret:
+      name: agent-sandbox-jwt
+
 mcp:
   enabled: true
   config:
+    oauthMainDomain: example.retool.com
     oauthIntrospectionAuthToken: test-oauth-introspection-token
-    agentSandboxJwtPrivateKeySecretName: agent-sandbox-jwt
-    agentSandboxJwtPrivateKeySecretKey: private-key

--- a/charts/retool/ci/test-mcp-enabled-option.yaml
+++ b/charts/retool/ci/test-mcp-enabled-option.yaml
@@ -2,8 +2,8 @@ mcp:
   enabled: true
   replicaCount: 2
   config:
-    oauthMainDomain: https://oauth.example.com
-    oauthIntrospectionAuthToken: test-oauth-introspection-token
+    mcpServiceExternalUrl: https://retool.example.com
+    oauthMainDomain: example.retool.com
     agentSandboxJwtPrivateKey: test-agent-sandbox-jwt-private-key
     enabledToolsets:
       - apps

--- a/charts/retool/ci/test-rr-enabled-option.yaml
+++ b/charts/retool/ci/test-rr-enabled-option.yaml
@@ -13,6 +13,11 @@
 rr:
   enabled: true
 
+  blobStorage:
+    s3:
+      bucket: rr-test-bucket
+      region: us-east-1
+
   agentSandbox:
     # jwtPublicKey is injected raw into the sandbox job-template JSON, so it MUST
     # be single-line (\n-escaped) or templating breaks.

--- a/charts/retool/ci/test-rr-git-server-separate-option.yaml
+++ b/charts/retool/ci/test-rr-git-server-separate-option.yaml
@@ -37,5 +37,5 @@ rr:
 mcp:
   enabled: true
   config:
-    oauthMainDomain: https://oauth.example.com
+    oauthMainDomain: example.retool.com
     oauthIntrospectionAuthToken: test-oauth-introspection-token

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -24,34 +24,18 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
-Whether MCP routing needs the main Retool Service to expose the backend API
-listener in addition to the primary frontend-facing port.
+Append a suffix to retool.fullname while preserving the 63-character DNS label
+limit used by Service names and label values.
 */}}
-{{- define "retool.mcp.needsBackendApi" -}}
-{{- $mcp := .Values.mcp | default dict -}}
-{{- $mcpIngress := $mcp.ingress | default dict -}}
-{{- $mcpHttpRoute := $mcp.httpRoute | default dict -}}
-{{- $needsBackendApi := false -}}
-{{- if and .Values.ingress.enabled $mcp.enabled $mcpIngress.enabled -}}
-{{- range ($mcpIngress.paths | default list) -}}
-{{- if eq (.target | default "mcp") "backendApi" -}}
-{{- $needsBackendApi = true -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-{{- if and .Values.httpRoute.enabled $mcp.enabled $mcpHttpRoute.enabled -}}
-{{- range ($mcpHttpRoute.rules | default list) -}}
-{{- if eq (.target | default "mcp") "backendApi" -}}
-{{- $needsBackendApi = true -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-{{- if $needsBackendApi -}}true{{- else -}}false{{- end -}}
+{{- define "retool.fullnameWithSuffix" -}}
+{{- $root := index . 0 -}}
+{{- $suffix := index . 1 -}}
+{{- printf "%s-%s" (include "retool.fullname" $root | trunc (sub 62 (len $suffix) | int) | trimSuffix "-") $suffix | trunc 63 | trimSuffix "-" -}}
 {{- end }}
 
 {{/*
 Render an MCP-related Ingress path. By default paths route to the MCP service;
-target: backendApi routes to the main backend API listener instead.
+target: backendApi routes to the main backend API Service instead.
 */}}
 {{- define "retool.ingress.mcpPath" -}}
 {{- $root := .root -}}
@@ -65,7 +49,7 @@ target: backendApi routes to the main backend API listener instead.
 {{- $servicePort := $path.port | default ($mcpService.externalPort | default 4010) -}}
 {{- $pathType := $path.pathType | default "ImplementationSpecific" -}}
 {{- if eq $target "backendApi" -}}
-{{- $serviceName = include "retool.fullname" $root -}}
+{{- $serviceName = include "retool.backendApi.name" $root -}}
 {{- $servicePort = $path.port | default (.backendApiPort | default 3001) -}}
 {{- $pathType = $path.pathType | default "Exact" -}}
 {{- end -}}
@@ -87,7 +71,7 @@ target: backendApi routes to the main backend API listener instead.
 
 {{/*
 Render an MCP-related HTTPRoute rule. By default rules route to the MCP service;
-target: backendApi routes to the main backend API listener instead.
+target: backendApi routes to the main backend API Service instead.
 */}}
 {{- define "retool.httpRoute.mcpRule" -}}
 {{- $root := .root -}}
@@ -101,7 +85,7 @@ target: backendApi routes to the main backend API listener instead.
 {{- $servicePort := $rule.port | default ($mcpService.externalPort | default 4010) -}}
 {{- $pathType := $rule.pathType | default "PathPrefix" -}}
 {{- if eq $target "backendApi" -}}
-{{- $serviceName = include "retool.fullname" $root -}}
+{{- $serviceName = include "retool.backendApi.name" $root -}}
 {{- $servicePort = $rule.port | default (.backendApiPort | default 3001) -}}
 {{- $pathType = $rule.pathType | default "Exact" -}}
 {{- end -}}
@@ -507,63 +491,63 @@ Set Temporal namespace
 Set dbconnector service name
 */}}
 {{- define "retool.dbconnector.name" -}}
-{{ template "retool.fullname" . }}-dbconnector
+{{ include "retool.fullnameWithSuffix" (list . "dbconnector") }}
 {{- end -}}
 
 {{/*
 Set workflow backend service name
 */}}
 {{- define "retool.workflowBackend.name" -}}
-{{ template "retool.fullname" . }}-workflow-backend
+{{ include "retool.fullnameWithSuffix" (list . "workflow-backend") }}
 {{- end -}}
 
 {{/*
 Set workflow worker service name
 */}}
 {{- define "retool.workflowWorker.name" -}}
-{{ template "retool.fullname" . }}-workflow-worker
+{{ include "retool.fullnameWithSuffix" (list . "workflow-worker") }}
 {{- end -}}
 
 {{/*
 Set code executor service name
 */}}
 {{- define "retool.codeExecutor.name" -}}
-{{ template "retool.fullname" . }}-code-executor
+{{ include "retool.fullnameWithSuffix" (list . "code-executor") }}
 {{- end -}}
 
 {{/*
 Set JS executor service name
 */}}
 {{- define "retool.jsExecutor.name" -}}
-{{ template "retool.fullname" . }}-js-executor
+{{ include "retool.fullnameWithSuffix" (list . "js-executor") }}
 {{- end -}}
 
 {{/*
 Set multiplayer service name
 */}}
 {{- define "retool.multiplayer.name" -}}
-{{ template "retool.fullname" . }}-multiplayer-ws
+{{ include "retool.fullnameWithSuffix" (list . "multiplayer-ws") }}
 {{- end -}}
 
 {{/*
 Set agent worker service name
 */}}
 {{- define "retool.agentWorker.name" -}}
-{{ template "retool.fullname" . }}-agent-worker
+{{ include "retool.fullnameWithSuffix" (list . "agent-worker") }}
 {{- end -}}
 
 {{/*
 Set agent eval worker service name
 */}}
 {{- define "retool.agentEvalWorker.name" -}}
-{{ template "retool.fullname" . }}-agent-eval-worker
+{{ include "retool.fullnameWithSuffix" (list . "agent-eval-worker") }}
 {{- end -}}
 
 {{/*
 Set RR agent worker service name
 */}}
 {{- define "retool.rrAgentWorker.name" -}}
-{{ template "retool.fullname" . }}-r2-agent-worker
+{{ include "retool.fullnameWithSuffix" (list . "r2-agent-worker") }}
 {{- end -}}
 
 {{/*
@@ -587,21 +571,21 @@ telemetry.retool.com/service-name: r2-agent-worker
 Set agent sandbox base name
 */}}
 {{- define "retool.agentSandbox.name" -}}
-{{ template "retool.fullname" . }}-agent-sandbox
+{{ include "retool.fullnameWithSuffix" (list . "agent-sandbox") }}
 {{- end -}}
 
 {{/*
 Set agent sandbox controller name
 */}}
 {{- define "retool.agentSandbox.controller.name" -}}
-{{ template "retool.fullname" . }}-agent-sandbox-controller
+{{ include "retool.fullnameWithSuffix" (list . "agent-sandbox-controller") }}
 {{- end -}}
 
 {{/*
 Set agent sandbox proxy name
 */}}
 {{- define "retool.agentSandbox.proxy.name" -}}
-{{ template "retool.fullname" . }}-agent-sandbox-proxy
+{{ include "retool.fullnameWithSuffix" (list . "agent-sandbox-proxy") }}
 {{- end -}}
 
 {{/*
@@ -874,14 +858,21 @@ Usage: {{- include "retool.agentSandbox.backendEnvVars" . | nindent 10 }}
 Set MCP server service name
 */}}
 {{- define "retool.mcp.name" -}}
-{{ template "retool.fullname" . }}-mcp
+{{ include "retool.fullnameWithSuffix" (list . "mcp") }}
+{{- end -}}
+
+{{/*
+Set backend API service name
+*/}}
+{{- define "retool.backendApi.name" -}}
+{{ include "retool.fullnameWithSuffix" (list . "backend-api") }}
 {{- end -}}
 
 {{/*
 Set git server deployment/service name (only used when rr.gitServer.separate is enabled)
 */}}
 {{- define "retool.gitServer.name" -}}
-{{ template "retool.fullname" . }}-git-server
+{{ include "retool.fullnameWithSuffix" (list . "git-server") }}
 {{- end -}}
 
 {{/*
@@ -902,7 +893,8 @@ Port the standalone git server listens on (RR_GIT_SERVER_PORT) and exposes via i
 {{- end -}}
 
 {{/*
-In-cluster URL of the standalone git server service, e.g. http://<release>-git-server:3010.
+In-cluster URL of the standalone git server service, e.g. http://<fullname>-git-server:3010
+(truncated to fit Kubernetes' 63-character DNS label limit when needed).
 Used to point the MCP server (and any other consumer) at the split-out git server.
 */}}
 {{- define "retool.gitServer.url" -}}

--- a/charts/retool/templates/_workers.tpl
+++ b/charts/retool/templates/_workers.tpl
@@ -154,12 +154,12 @@ spec:
             value: {{ $workerPoolMaxSize | quote }}
           {{- if $.Values.dbconnector.enabled }}
           - name: DB_CONNECTOR_HOST
-            value: http://{{ template "retool.fullname" $ }}-dbconnector
+            value: http://{{ include "retool.dbconnector.name" $ }}
           - name: DB_CONNECTOR_PORT
             value: {{ $.Values.dbconnector.port | quote }}
           {{- if $.Values.dbconnector.java.enabled }}
           - name: JAVA_DB_CONNECTOR_HOST
-            value: http://{{ template "retool.fullname" $ }}-dbconnector
+            value: http://{{ include "retool.dbconnector.name" $ }}
           - name: JAVA_DB_CONNECTOR_PORT
             value: {{ $.Values.dbconnector.java.port | quote }}
           {{- end }}

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -133,16 +133,16 @@ spec:
             value: {{ template "retool.postgresql.ssl_enabled" . }}
           {{- if .Values.dbconnector.enabled }}
           - name: DB_CONNECTOR_HOST
-            value: http://{{ template "retool.fullname" . }}-dbconnector
+            value: http://{{ include "retool.dbconnector.name" . }}
           - name: DB_CONNECTOR_PORT
             value: {{ $.Values.dbconnector.port | quote }}
           - name: DB_SSH_CONNECTOR_HOST
-            value: http://{{ template "retool.fullname" . }}-dbconnector
+            value: http://{{ include "retool.dbconnector.name" . }}
           - name: DB_SSH_CONNECTOR_PORT
             value: {{ .Values.dbconnector.port | quote }}
           {{- if $.Values.dbconnector.java.enabled }}
           - name: JAVA_DB_CONNECTOR_HOST
-            value: http://{{ template "retool.fullname" . }}-dbconnector
+            value: http://{{ include "retool.dbconnector.name" . }}
           - name: JAVA_DB_CONNECTOR_PORT
             value: {{ $.Values.dbconnector.java.port | quote }}
           {{- end }}
@@ -166,7 +166,7 @@ spec:
           {{- end }}
           {{- if include "retool.workflows.enabled" . }}
           - name: WORKFLOW_BACKEND_HOST
-            value: http://{{ template "retool.fullname" . }}-workflow-backend
+            value: http://{{ include "retool.workflowBackend.name" . }}
           - name: CODE_EXECUTOR_INGRESS_DOMAIN
             value: http://{{ template "retool.codeExecutor.name" . }}
           {{- end }}

--- a/charts/retool/templates/deployment_dbconnector.yaml
+++ b/charts/retool/templates/deployment_dbconnector.yaml
@@ -102,7 +102,7 @@ spec:
           - name: DISABLE_DATABASE_MIGRATIONS
             value: "true"
           - name: WORKFLOW_BACKEND_HOST
-            value: http://{{ template "retool.fullname" . }}-workflow-backend
+            value: http://{{ include "retool.workflowBackend.name" . }}
           {{- if .Values.config.auth.google.enabled }}
           - name: CLIENT_ID
             value: {{ default "" .Values.config.auth.google.clientId }}

--- a/charts/retool/templates/deployment_mcp.yaml
+++ b/charts/retool/templates/deployment_mcp.yaml
@@ -1,15 +1,49 @@
 {{- if .Values.mcp.enabled }}
-{{- $mcpConfig := .Values.mcp.config | default dict }}
-{{- $hasOAuthIntrospectionAuthTokenEnv := false }}
-{{- range .Values.mcp.environmentVariables }}
-{{- if eq .name "OAUTH_INTROSPECTION_AUTH_TOKEN" }}
-{{- $hasOAuthIntrospectionAuthTokenEnv = true }}
-{{- end }}
-{{- end }}
-{{- if not (or $mcpConfig.oauthIntrospectionAuthTokenSecretName $mcpConfig.oauthIntrospectionAuthToken $hasOAuthIntrospectionAuthTokenEnv) }}
-{{- fail "Please set .Values.mcp.config.oauthIntrospectionAuthTokenSecretName, .Values.mcp.config.oauthIntrospectionAuthToken, or an OAUTH_INTROSPECTION_AUTH_TOKEN entry in .Values.mcp.environmentVariables when the MCP server is enabled (.Values.mcp.enabled)" }}
-{{- end }}
-{{- $mcpInternalPort := .Values.mcp.service.internalPort | default 4010 }}
+  {{- $mcpConfig := .Values.mcp.config | default dict }}
+  {{- $chartOwnedConfigSecret := eq (include "shouldIncludeConfigSecretsEnvVars" . | trim) "1" }}
+  {{- $mcpServiceExternalUrl := ($mcpConfig.mcpServiceExternalUrl | default $mcpConfig.retoolUrl | default "") }}
+  {{- $mcpServiceExternalUrl = trimSuffix "/" (toString $mcpServiceExternalUrl) }}
+  {{- if and $mcpServiceExternalUrl (not (or (hasPrefix "http://" $mcpServiceExternalUrl) (hasPrefix "https://" $mcpServiceExternalUrl))) }}
+    {{- $mcpServiceExternalUrl = printf "https://%s" $mcpServiceExternalUrl }}
+  {{- end }}
+  {{- $mcpOAuthMainDomain := ($mcpConfig.oauthMainDomain | default "") }}
+  {{- $mcpOAuthMainDomain = trimSuffix "/" (trimPrefix "http://" (trimPrefix "https://" (toString $mcpOAuthMainDomain))) }}
+  {{- $hasOAuthMainDomainEnv := false }}
+  {{- range .Values.mcp.environmentVariables }}
+    {{- if eq .name "OAUTH_MAIN_DOMAIN" }}
+      {{- $hasOAuthMainDomainEnv = true }}
+    {{- end }}
+  {{- end }}
+  {{- $hasOAuthIntrospectionAuthTokenEnv := false }}
+  {{- range .Values.mcp.environmentVariables }}
+    {{- if eq .name "OAUTH_INTROSPECTION_AUTH_TOKEN" }}
+      {{- $hasOAuthIntrospectionAuthTokenEnv = true }}
+    {{- end }}
+  {{- end }}
+  {{- $hasAgentSandboxJwtPrivateKeyEnv := false }}
+  {{- range .Values.mcp.environmentVariables }}
+    {{- if eq .name "AGENT_SANDBOX_JWT_PRIVATE_KEY" }}
+      {{- $hasAgentSandboxJwtPrivateKeyEnv = true }}
+    {{- end }}
+  {{- end }}
+  {{- $agentSandboxEnabled := eq (include "retool.rr.componentEnabled" (dict "root" . "component" "agentSandbox")) "1" }}
+  {{- $mcpAgentSandboxJwtPrivateKeySecretName := ($mcpConfig.agentSandboxJwtPrivateKeySecretName | default "") }}
+  {{- $mcpAgentSandboxJwtPrivateKeySecretKey := ($mcpConfig.agentSandboxJwtPrivateKeySecretKey | default "jwt-private-key") }}
+  {{- $mcpAgentSandboxJwtPrivateKey := ($mcpConfig.agentSandboxJwtPrivateKey | default "") }}
+  {{- if and (not $mcpAgentSandboxJwtPrivateKeySecretName) (not $mcpAgentSandboxJwtPrivateKey) $agentSandboxEnabled }}
+    {{- if .Values.rr.agentSandbox.jwtPrivateKey }}
+      {{- $mcpAgentSandboxJwtPrivateKey = .Values.rr.agentSandbox.jwtPrivateKey }}
+    {{- else if .Values.rr.agentSandbox.externalSecret.name }}
+      {{- $mcpAgentSandboxJwtPrivateKeySecretName = .Values.rr.agentSandbox.externalSecret.name }}
+    {{- end }}
+  {{- end }}
+  {{- if not (or $mcpOAuthMainDomain $hasOAuthMainDomainEnv) }}
+    {{- fail "Please set .Values.mcp.config.oauthMainDomain or an OAUTH_MAIN_DOMAIN entry in .Values.mcp.environmentVariables when the MCP server is enabled (.Values.mcp.enabled)" }}
+  {{- end }}
+  {{- if not (or $mcpConfig.oauthIntrospectionAuthTokenSecretName $mcpConfig.oauthIntrospectionAuthToken $hasOAuthIntrospectionAuthTokenEnv $chartOwnedConfigSecret) }}
+    {{- fail "Please set .Values.mcp.config.oauthIntrospectionAuthTokenSecretName, .Values.mcp.config.oauthIntrospectionAuthToken, or an OAUTH_INTROSPECTION_AUTH_TOKEN entry in .Values.mcp.environmentVariables when the MCP server is enabled and chart-owned config secrets are disabled" }}
+  {{- end }}
+  {{- $mcpInternalPort := .Values.mcp.service.internalPort | default 4010 }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -128,33 +162,39 @@ spec:
           - name: RETOOL_GIT_SERVER_URL
             value: {{ $retoolGitServerUrl | quote }}
           {{- end }}
-          {{- if $mcpConfig.retoolUrl }}
-          - name: RETOOL_URL
-            value: {{ $mcpConfig.retoolUrl | quote }}
+          {{- if $mcpServiceExternalUrl }}
+          - name: MCP_SERVICE_EXTERNAL_URL
+            value: {{ $mcpServiceExternalUrl | quote }}
           {{- end }}
-          {{- if $mcpConfig.oauthMainDomain }}
+          {{- if and $mcpOAuthMainDomain (not $hasOAuthMainDomainEnv) }}
           - name: OAUTH_MAIN_DOMAIN
-            value: {{ $mcpConfig.oauthMainDomain | quote }}
+            value: {{ $mcpOAuthMainDomain | quote }}
           {{- end }}
-          {{- if $mcpConfig.oauthIntrospectionAuthTokenSecretName }}
+          {{- if and $mcpConfig.oauthIntrospectionAuthTokenSecretName (not $hasOAuthIntrospectionAuthTokenEnv) }}
           - name: OAUTH_INTROSPECTION_AUTH_TOKEN
             valueFrom:
               secretKeyRef:
                 name: {{ $mcpConfig.oauthIntrospectionAuthTokenSecretName }}
                 key: {{ $mcpConfig.oauthIntrospectionAuthTokenSecretKey | default "oauthIntrospectionAuthToken" }}
-          {{- else if $mcpConfig.oauthIntrospectionAuthToken }}
+          {{- else if and $mcpConfig.oauthIntrospectionAuthToken (not $hasOAuthIntrospectionAuthTokenEnv) }}
           - name: OAUTH_INTROSPECTION_AUTH_TOKEN
             value: {{ $mcpConfig.oauthIntrospectionAuthToken | quote }}
+          {{- else if and $chartOwnedConfigSecret (not $hasOAuthIntrospectionAuthTokenEnv) }}
+          - name: OAUTH_INTROSPECTION_AUTH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "retool.fullname" . }}
+                key: oauthIntrospectionAuthToken
           {{- end }}
-          {{- if $mcpConfig.agentSandboxJwtPrivateKeySecretName }}
+          {{- if and $mcpAgentSandboxJwtPrivateKeySecretName (not $hasAgentSandboxJwtPrivateKeyEnv) }}
           - name: AGENT_SANDBOX_JWT_PRIVATE_KEY
             valueFrom:
               secretKeyRef:
-                name: {{ $mcpConfig.agentSandboxJwtPrivateKeySecretName }}
-                key: {{ $mcpConfig.agentSandboxJwtPrivateKeySecretKey | default "jwt-private-key" }}
-          {{- else if $mcpConfig.agentSandboxJwtPrivateKey }}
+                name: {{ $mcpAgentSandboxJwtPrivateKeySecretName }}
+                key: {{ $mcpAgentSandboxJwtPrivateKeySecretKey }}
+          {{- else if and $mcpAgentSandboxJwtPrivateKey (not $hasAgentSandboxJwtPrivateKeyEnv) }}
           - name: AGENT_SANDBOX_JWT_PRIVATE_KEY
-            value: {{ $mcpConfig.agentSandboxJwtPrivateKey | quote }}
+            value: {{ $mcpAgentSandboxJwtPrivateKey | quote }}
           {{- end }}
           {{- if $mcpConfig.nodeOptions }}
           - name: NODE_OPTIONS

--- a/charts/retool/templates/deployment_workflows.yaml
+++ b/charts/retool/templates/deployment_workflows.yaml
@@ -96,16 +96,16 @@ spec:
             value: {{ join "," $serviceType }}
           {{- if $.Values.dbconnector.enabled }}
           - name: DB_CONNECTOR_HOST
-            value: http://{{ template "retool.fullname" . }}-dbconnector
+            value: http://{{ include "retool.dbconnector.name" . }}
           - name: DB_CONNECTOR_PORT
             value: {{ $.Values.dbconnector.port | quote }}
           - name: DB_SSH_CONNECTOR_HOST
-            value: http://{{ template "retool.fullname" . }}-dbconnector
+            value: http://{{ include "retool.dbconnector.name" . }}
           - name: DB_SSH_CONNECTOR_PORT
             value: {{ .Values.dbconnector.port | quote }}
           {{- if $.Values.dbconnector.java.enabled }}
           - name: JAVA_DB_CONNECTOR_HOST
-            value: http://{{ template "retool.fullname" . }}-dbconnector
+            value: http://{{ include "retool.dbconnector.name" . }}
           - name: JAVA_DB_CONNECTOR_PORT
             value: {{ $.Values.dbconnector.java.port | quote }}
           {{- end }}

--- a/charts/retool/templates/secret.yaml
+++ b/charts/retool/templates/secret.yaml
@@ -13,6 +13,13 @@ type: Opaque
 {{- $secretName := (include "retool.fullname" .) }}
 {{- $secret := lookup "v1" "Secret" .Release.Namespace $secretName | default dict }}
 {{- $secretData := (get $secret "data") | default dict }}
+{{- $mcpConfig := (.Values.mcp.config | default dict) }}
+{{- $hasOAuthIntrospectionAuthTokenEnv := false }}
+{{- range .Values.mcp.environmentVariables }}
+{{- if eq .name "OAUTH_INTROSPECTION_AUTH_TOKEN" }}
+{{- $hasOAuthIntrospectionAuthTokenEnv = true }}
+{{- end }}
+{{- end }}
 data:
   license-key: {{ .Values.config.licenseKey | default "" | b64enc | quote }}
 
@@ -50,4 +57,14 @@ data:
   {{ if ($temporalConfig).sslKey }}
   temporal-tls-key: {{ $temporalConfig.sslKey | default "" | b64enc | quote }}
   {{ end }}
+
+  {{- if and .Values.mcp.enabled (not $hasOAuthIntrospectionAuthTokenEnv) (not $mcpConfig.oauthIntrospectionAuthTokenSecretName) }}
+  {{- if $mcpConfig.oauthIntrospectionAuthToken }}
+  oauthIntrospectionAuthToken: {{ $mcpConfig.oauthIntrospectionAuthToken | b64enc | quote }}
+  {{- else if (get $secretData "oauthIntrospectionAuthToken") }}
+  oauthIntrospectionAuthToken: {{ get $secretData "oauthIntrospectionAuthToken" }}
+  {{- else }}
+  oauthIntrospectionAuthToken: {{ randAlphaNum 64 | b64enc | quote }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/retool/templates/service.yaml
+++ b/charts/retool/templates/service.yaml
@@ -1,9 +1,8 @@
-{{- $mcpNeedsBackendApi := eq (include "retool.mcp.needsBackendApi" .) "true" -}}
+{{- $mcpEnabled := ((.Values.mcp).enabled) | default false -}}
 {{- $backendApiService := (((.Values.mcp).backendMetadata).service) | default dict -}}
-{{- $servicePortName := .Values.service.portName | default "http" -}}
-{{- $backendApiPortName := $backendApiService.portName | default "http-api" -}}
-{{- if and $mcpNeedsBackendApi (eq $servicePortName $backendApiPortName) -}}
-{{- fail "When MCP backend API routing is enabled, .Values.service.portName and .Values.mcp.backendMetadata.service.portName must be different" -}}
+{{- $backendApiServiceEnabled := $mcpEnabled -}}
+{{- if hasKey $backendApiService "enabled" -}}
+{{- $backendApiServiceEnabled = and $mcpEnabled $backendApiService.enabled -}}
 {{- end -}}
 apiVersion: v1
 kind: Service
@@ -38,14 +37,8 @@ spec:
 {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
       nodePort: {{ .Values.service.nodePort }}
 {{- end }}
-{{- if or .Values.service.portName $mcpNeedsBackendApi }}
-      name: {{ $servicePortName }}
-{{- end }}
-{{- if $mcpNeedsBackendApi }}
-    - name: {{ $backendApiPortName }}
-      port: {{ $backendApiService.externalPort | default 3001 }}
-      targetPort: {{ $backendApiService.internalPort | default 3001 }}
-      protocol: TCP
+{{- if .Values.service.portName }}
+      name: {{ .Values.service.portName }}
 {{- end }}
 {{- if .Values.service.externalIPs }}
   externalIPs:
@@ -58,4 +51,34 @@ spec:
 {{- end }}
 {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+{{- end }}
+{{- if $backendApiServiceEnabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    {{- include "retool.labels" . | nindent 4 }}
+  {{- range $key, $value := $backendApiService.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  name: {{ template "retool.backendApi.name" . }}
+  {{- with $backendApiService.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: {{ $backendApiService.portName | default "http-api" }}
+      port: {{ $backendApiService.externalPort | default 3001 }}
+      targetPort: {{ $backendApiService.internalPort | default 3001 }}
+      protocol: TCP
+  selector:
+{{- include "retool.selectorLabels" . | nindent 4 }}
+{{- range $key, $value := .Values.service.selector }}
+    {{ $key }}: {{ $value | quote }}
+{{- end }}
 {{- end }}

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -601,9 +601,9 @@ mcp:
   # them. When unset, the MCP service uses its runtime defaults:
   #   enabledToolsets: all available toolsets
   #     apps, resources, workflows, folders, environments, users,
-  #     organization, user_invites, feedback
+  #     groups, organization, user_invites, feedback, r2_themes
   #   maxTransportSessions: 1000
-  #   sessionIdleTimeoutMs: 1800000 (30 minutes)
+  #   sessionIdleTimeoutMs: 3600000 (1 hour)
   #   sessionSweepIntervalMs: 60000 (1 minute)
   #   sessionGaugeEmitIntervalMs: 30000 (30 seconds)
   config: {}
@@ -617,43 +617,54 @@ mcp:
   #   # Unset by default.
   #   retoolGitServerUrl:
   #
-  #   # Public Retool URL used for links. Set explicitly when the request
-  #   # origin is not the right public URL.
+  #   # Optional public Retool origin used for client-facing MCP upload URLs
+  #   # when the request Host header is not enough. Do not include /mcp.
+  #   mcpServiceExternalUrl:
+  #
+  #   # Deprecated alias for mcpServiceExternalUrl.
   #   retoolUrl:
   #
-  #   # Public OAuth domain used by MCP OAuth metadata routes. Set explicitly
-  #   # when the request origin is not the right OAuth base URL.
+  #   # Required when mcp.enabled is true unless OAUTH_MAIN_DOMAIN is provided
+  #   # directly in mcp.environmentVariables. Public Retool host that serves MCP
+  #   # OAuth metadata routes and /api/oauth2/* endpoints. This is usually the
+  #   # same host users use to access Retool, not an oauth.* subdomain. The MCP
+  #   # service expects a host here, but the chart also accepts URL-shaped values
+  #   # and strips http(s)://.
   #   oauthMainDomain:
   #
-  #   # Secret-backed token used by MCP to call /api/oauth2/introspect.
-  #   # Required when mcp.enabled is true unless OAUTH_INTROSPECTION_AUTH_TOKEN
-  #   # is provided directly in mcp.environmentVariables.
+  #   # Secret-backed token used by MCP to call /api/oauth2/introspect. When
+  #   # unset, the chart auto-generates one in the release Secret on first deploy
+  #   # if chart-owned config secrets are enabled. Set this when using an
+  #   # externally managed Secret instead.
   #   oauthIntrospectionAuthTokenSecretName:
   #   oauthIntrospectionAuthTokenSecretKey: oauthIntrospectionAuthToken
   #
   #   # Literal token override for development/testing only. Prefer the
   #   # secret-backed setting above for real deployments.
-  #   # Required when mcp.enabled is true unless OAUTH_INTROSPECTION_AUTH_TOKEN
-  #   # is provided directly in mcp.environmentVariables.
   #   oauthIntrospectionAuthToken:
   #
-  #   # Secret-backed private key used by MCP to sign agent sandbox requests.
-  #   # Usually points at the same key as rr.agentSandbox.externalSecret.name.
+  #   # Optional override for the secret-backed private key used by MCP to sign
+  #   # agent sandbox requests. When unset and rr.agentSandbox is enabled, MCP
+  #   # reuses rr.agentSandbox.externalSecret.name with key jwt-private-key.
   #   agentSandboxJwtPrivateKeySecretName:
   #   agentSandboxJwtPrivateKeySecretKey: jwt-private-key
   #
-  #   # Literal private key override for development/testing only. Prefer the
-  #   # secret-backed setting above for real deployments.
+  #   # Literal private key override for development/testing only. When unset and
+  #   # rr.agentSandbox is enabled, MCP can reuse rr.agentSandbox.jwtPrivateKey.
+  #   # Prefer the secret-backed setting above for real deployments.
   #   agentSandboxJwtPrivateKey:
   #
   #   # Optional Node.js options for the MCP server process. Unset by default.
   #   nodeOptions: --max_old_space_size=1024
   #
-  #   # Optional MCP service configuration. If unset, all available toolsets
-  #   # are enabled by default.
+  #   # Optional MCP service configuration. If enabledToolsets is unset, all
+  #   # available toolsets are enabled by default.
   #   enabledToolsets:
   #     - apps
   #     - resources
+  #   # Optional max concurrent MCP transport sessions. Renders as
+  #   # MCP_MAX_TRANSPORT_SESSIONS. If unset, the MCP service uses its runtime
+  #   # default.
   #   maxTransportSessions: 1000
   #   sessionIdleTimeoutMs: 1800000
   #   sessionSweepIntervalMs: 60000
@@ -669,15 +680,19 @@ mcp:
       memory: "4096Mi"
 
   # MCP OAuth metadata routes are served by the main Retool backend, not the MCP
-  # pod. This config exposes the backend API listener as an additional port on
-  # the main Retool service when a route uses target: backendApi.
+  # pod. When MCP is enabled, this config creates a dedicated backend API
+  # Service named <fullname>-backend-api for metadata routes, truncated to fit
+  # Kubernetes' 63-character DNS label limit when needed.
   backendMetadata:
     service:
+      enabled: true
       # Service port that exposes the backend API listener for metadata paths
       # that should not fall through to the static frontend server.
       portName: http-api
       externalPort: 3001
       internalPort: 3001
+      annotations: {}
+      labels: {}
 
   # Public MCP-related ingress paths. Paths are emitted in order before the main
   # Retool route. Use target: backendApi for OAuth metadata routes that must hit
@@ -1178,7 +1193,8 @@ rr:
     # deployment + service (mirrors how the workload is split in Retool Cloud).
     # Requires the git server to be enabled (rr.gitServer.enabled: true, or
     # inherited from rr.enabled). When enabled:
-    #   - a dedicated <release>-git-server Deployment runs SERVICE_TYPE=RR_GIT_SERVER
+    #   - a dedicated <fullname>-git-server Deployment runs SERVICE_TYPE=RR_GIT_SERVER
+    #     (truncated to fit Kubernetes' 63-character DNS label limit when needed)
     #   - the main backend drops RR_GIT_SERVER from its SERVICE_TYPE and proxies git
     #     traffic to the service via RR_GIT_SERVER_HOST / RR_GIT_SERVER_PORT
     #   - the MCP server (if enabled) is auto-pointed at the same service unless

--- a/values.yaml
+++ b/values.yaml
@@ -601,9 +601,9 @@ mcp:
   # them. When unset, the MCP service uses its runtime defaults:
   #   enabledToolsets: all available toolsets
   #     apps, resources, workflows, folders, environments, users,
-  #     organization, user_invites, feedback
+  #     groups, organization, user_invites, feedback, r2_themes
   #   maxTransportSessions: 1000
-  #   sessionIdleTimeoutMs: 1800000 (30 minutes)
+  #   sessionIdleTimeoutMs: 3600000 (1 hour)
   #   sessionSweepIntervalMs: 60000 (1 minute)
   #   sessionGaugeEmitIntervalMs: 30000 (30 seconds)
   config: {}
@@ -617,43 +617,54 @@ mcp:
   #   # Unset by default.
   #   retoolGitServerUrl:
   #
-  #   # Public Retool URL used for links. Set explicitly when the request
-  #   # origin is not the right public URL.
+  #   # Optional public Retool origin used for client-facing MCP upload URLs
+  #   # when the request Host header is not enough. Do not include /mcp.
+  #   mcpServiceExternalUrl:
+  #
+  #   # Deprecated alias for mcpServiceExternalUrl.
   #   retoolUrl:
   #
-  #   # Public OAuth domain used by MCP OAuth metadata routes. Set explicitly
-  #   # when the request origin is not the right OAuth base URL.
+  #   # Required when mcp.enabled is true unless OAUTH_MAIN_DOMAIN is provided
+  #   # directly in mcp.environmentVariables. Public Retool host that serves MCP
+  #   # OAuth metadata routes and /api/oauth2/* endpoints. This is usually the
+  #   # same host users use to access Retool, not an oauth.* subdomain. The MCP
+  #   # service expects a host here, but the chart also accepts URL-shaped values
+  #   # and strips http(s)://.
   #   oauthMainDomain:
   #
-  #   # Secret-backed token used by MCP to call /api/oauth2/introspect.
-  #   # Required when mcp.enabled is true unless OAUTH_INTROSPECTION_AUTH_TOKEN
-  #   # is provided directly in mcp.environmentVariables.
+  #   # Secret-backed token used by MCP to call /api/oauth2/introspect. When
+  #   # unset, the chart auto-generates one in the release Secret on first deploy
+  #   # if chart-owned config secrets are enabled. Set this when using an
+  #   # externally managed Secret instead.
   #   oauthIntrospectionAuthTokenSecretName:
   #   oauthIntrospectionAuthTokenSecretKey: oauthIntrospectionAuthToken
   #
   #   # Literal token override for development/testing only. Prefer the
   #   # secret-backed setting above for real deployments.
-  #   # Required when mcp.enabled is true unless OAUTH_INTROSPECTION_AUTH_TOKEN
-  #   # is provided directly in mcp.environmentVariables.
   #   oauthIntrospectionAuthToken:
   #
-  #   # Secret-backed private key used by MCP to sign agent sandbox requests.
-  #   # Usually points at the same key as rr.agentSandbox.externalSecret.name.
+  #   # Optional override for the secret-backed private key used by MCP to sign
+  #   # agent sandbox requests. When unset and rr.agentSandbox is enabled, MCP
+  #   # reuses rr.agentSandbox.externalSecret.name with key jwt-private-key.
   #   agentSandboxJwtPrivateKeySecretName:
   #   agentSandboxJwtPrivateKeySecretKey: jwt-private-key
   #
-  #   # Literal private key override for development/testing only. Prefer the
-  #   # secret-backed setting above for real deployments.
+  #   # Literal private key override for development/testing only. When unset and
+  #   # rr.agentSandbox is enabled, MCP can reuse rr.agentSandbox.jwtPrivateKey.
+  #   # Prefer the secret-backed setting above for real deployments.
   #   agentSandboxJwtPrivateKey:
   #
   #   # Optional Node.js options for the MCP server process. Unset by default.
   #   nodeOptions: --max_old_space_size=1024
   #
-  #   # Optional MCP service configuration. If unset, all available toolsets
-  #   # are enabled by default.
+  #   # Optional MCP service configuration. If enabledToolsets is unset, all
+  #   # available toolsets are enabled by default.
   #   enabledToolsets:
   #     - apps
   #     - resources
+  #   # Optional max concurrent MCP transport sessions. Renders as
+  #   # MCP_MAX_TRANSPORT_SESSIONS. If unset, the MCP service uses its runtime
+  #   # default.
   #   maxTransportSessions: 1000
   #   sessionIdleTimeoutMs: 1800000
   #   sessionSweepIntervalMs: 60000
@@ -669,15 +680,19 @@ mcp:
       memory: "4096Mi"
 
   # MCP OAuth metadata routes are served by the main Retool backend, not the MCP
-  # pod. This config exposes the backend API listener as an additional port on
-  # the main Retool service when a route uses target: backendApi.
+  # pod. When MCP is enabled, this config creates a dedicated backend API
+  # Service named <fullname>-backend-api for metadata routes, truncated to fit
+  # Kubernetes' 63-character DNS label limit when needed.
   backendMetadata:
     service:
+      enabled: true
       # Service port that exposes the backend API listener for metadata paths
       # that should not fall through to the static frontend server.
       portName: http-api
       externalPort: 3001
       internalPort: 3001
+      annotations: {}
+      labels: {}
 
   # Public MCP-related ingress paths. Paths are emitted in order before the main
   # Retool route. Use target: backendApi for OAuth metadata routes that must hit
@@ -1178,7 +1193,8 @@ rr:
     # deployment + service (mirrors how the workload is split in Retool Cloud).
     # Requires the git server to be enabled (rr.gitServer.enabled: true, or
     # inherited from rr.enabled). When enabled:
-    #   - a dedicated <release>-git-server Deployment runs SERVICE_TYPE=RR_GIT_SERVER
+    #   - a dedicated <fullname>-git-server Deployment runs SERVICE_TYPE=RR_GIT_SERVER
+    #     (truncated to fit Kubernetes' 63-character DNS label limit when needed)
     #   - the main backend drops RR_GIT_SERVER from its SERVICE_TYPE and proxies git
     #     traffic to the service via RR_GIT_SERVER_HOST / RR_GIT_SERVER_PORT
     #   - the MCP server (if enabled) is auto-pointed at the same service unless


### PR DESCRIPTION
## Summary

This PR improves the Helm chart setup path for self-hosted MCP deployments.

**Example shape**

```
mcp:
    enabled: true
    config:
      # Public Retool host that serves OAuth metadata and /api/oauth2/*.
      # Host-only is preferred; the chart also accepts https://example.retool.com.
      oauthMainDomain: example.retool.com

      # Secret-backed token used by MCP to call /api/oauth2/introspect.
      # oauthIntrospectionAuthTokenSecretKey defaults to oauthIntrospectionAuthToken.
      oauthIntrospectionAuthTokenSecretName: oauth-introspection-auth-token

      # Optional public Retool origin for client-facing MCP upload URLs.
      # Do not include /mcp.
      mcpServiceExternalUrl: https://example.retool.com

      # Optional MCP concurrency tuning. Renders MCP_MAX_TRANSPORT_SESSIONS.
      maxTransportSessions: 1000
```

**Some** **more** **details**

- Adds a dedicated backend API Service for MCP OAuth metadata routes, exposing the main backend API listener on port 3001.
- Adds a dedicated backend API Service and routes existing MCP backendApi Ingress/HTTPRoute entries to it
- Replaces old MCP RETOOL_URL env wiring with MCP_SERVICE_EXTERNAL_URL.
- Keeps retoolUrl as a deprecated alias for mcpServiceExternalUrl.
- Normalizes mcpServiceExternalUrl and oauthMainDomain.
- Requires oauthMainDomain and an OAuth introspection token source when mcp.enabled=true.
- Supports Secret-backed introspection token config without requiring plaintext values.
- Avoids duplicate env vars when OAUTH_MAIN_DOMAIN or OAUTH_INTROSPECTION_AUTH_TOKEN is supplied through mcp.environmentVariables.
- Documents optional MCP config, including maxTransportSessions.

## Validation

- helm lint charts/retool -f charts/retool/ci/test-install-values.yaml -f charts/retool/ci/test-mcp-enabled-option.yaml
- helm template for MCP deployment with CI values
- helm template for Secret-backed production-style MCP config
- helm template failure checks for missing oauthMainDomain and missing introspection token
- git diff --check
- Redeployed arniew-mcp balloon instance with the local chart
- Verified MCP connection through the connected arniew-mcp MCP server:
    - listed environments
    - listed apps
    - listed resources
    - listed folders