### PR TITLE
rr: git server inherits rr.enabled; fail on bad blob storage (warn if skip set)

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.11.4
+version: 6.11.5
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/NOTES.txt
+++ b/charts/retool/templates/NOTES.txt
@@ -30,4 +30,17 @@ Alternatively, you can fetch the randomly generated password and set the value i
   echo $(kubectl --namespace {{ .Release.Namespace }} get secret/{{ include "retool.fullname" . }}-postgresql -o jsonpath='{.data.postgres-password}' | base64 -d)
 We highly recommend you do NOT use this subchart as is to run Postgres in a container for your production instance of Retool. It is only suitable for proof-of-concepts. Please use a managed Postgres, or self-host more permanantly.
 ***************************************************************************
+{{- end }}
+{{- if and (eq (include "retool.gitServer.blobStorageMisconfigured" .) "1") .Values.rr.gitServer.skipBlobStorageValidation }}
+
+***************************************************************************
+WARNING: the React Retool git server is enabled and blob-storage validation is
+bypassed (rr.gitServer.skipBlobStorageValidation=true). The chart could not find
+exactly one provider in rr.blobStorage, nor RR_BLOB_STORAGE_PROVIDER / RR_DEFAULT_*
+in env/environmentVariables/environmentSecrets.
+
+Ensure exactly one blob-storage provider is supplied another way (e.g. envFrom) —
+otherwise git operations will FAIL at runtime. git_server stores all objects/packs
+in blob storage.
+***************************************************************************
 {{- end }} 

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -453,6 +453,15 @@ Usage: (include "retool.agent.enabled" .)
 {{- include "retool.rr.componentEnabled" (dict "root" . "component" "agent") -}}
 {{- end -}}
 
+{{/*
+Set RR git server enabled. Honors the shared RR master switch (rr.enabled)
+unless rr.gitServer.enabled is set explicitly true|false.
+Usage: (include "retool.gitServer.enabled" .)
+*/}}
+{{- define "retool.gitServer.enabled" -}}
+{{- include "retool.rr.componentEnabled" (dict "root" . "component" "gitServer") -}}
+{{- end -}}
+
 {{/* Global Temporal configuration */}}
 {{- define "retool.temporalConfig" -}}
 {{- .Values.workflows.temporal | default .Values.temporal | toYaml -}}
@@ -880,7 +889,7 @@ Returns "1" when the git server should run as its own deployment/service
 (rr.gitServer.enabled AND rr.gitServer.separate.enabled), empty otherwise.
 */}}
 {{- define "retool.gitServer.separateEnabled" -}}
-{{- if and .Values.rr.gitServer.enabled (.Values.rr.gitServer.separate | default dict).enabled -}}
+{{- if and (eq (include "retool.gitServer.enabled" .) "1") (.Values.rr.gitServer.separate | default dict).enabled -}}
 1
 {{- end -}}
 {{- end -}}
@@ -975,17 +984,16 @@ directly via environmentVariables / environmentSecrets).
 {{- end -}}
 
 {{/*
-Validate that exactly one blob-storage provider is configured when rr.gitServer
-is enabled. Skipped when the user has plumbed the RR_BLOB_STORAGE_PROVIDER /
-RR_DEFAULT_*_* env vars in directly via env/environmentVariables/environmentSecrets,
-which is treated as an opt-out from the first-class blobStorage config.
-Also skipped entirely when rr.gitServer.skipBlobStorageValidation is true, which
-is the escape hatch for sources we cannot inspect at template time (e.g. env
-vars injected via envFrom from a Secret/ConfigMap).
-No-op when rr.gitServer is disabled.
+Returns "1" when the git server is enabled but blob storage is misconfigured --
+i.e. NOT exactly one of rr.blobStorage.s3/gcs/azure is set (zero or 2+). Skipped
+when the user has plumbed RR_BLOB_STORAGE_PROVIDER / RR_DEFAULT_*_* in directly
+via env/environmentVariables/environmentSecrets (treated as an opt-out from the
+first-class blobStorage config). Empty when gitServer is disabled or blob storage
+is configured. Does NOT consider skipBlobStorageValidation -- that flag only
+decides whether this is fatal (validateBlobStorage) or a NOTES.txt warning.
 */}}
-{{- define "retool.gitServer.validateBlobStorage" -}}
-{{- if and .Values.rr.gitServer.enabled (not .Values.rr.gitServer.skipBlobStorageValidation) -}}
+{{- define "retool.gitServer.blobStorageMisconfigured" -}}
+{{- if eq (include "retool.gitServer.enabled" .) "1" -}}
 {{- $hasDirectEnv := false -}}
 {{- range $name, $value := .Values.env -}}
 {{- if or (hasPrefix "RR_DEFAULT_" $name) (eq $name "RR_BLOB_STORAGE_PROVIDER") -}}
@@ -1008,10 +1016,20 @@ No-op when rr.gitServer is disabled.
 {{- if $bs.s3 }}{{ $providers = append $providers "s3" }}{{ end -}}
 {{- if $bs.gcs }}{{ $providers = append $providers "gcs" }}{{ end -}}
 {{- if $bs.azure }}{{ $providers = append $providers "azure" }}{{ end -}}
-{{- if ne (len $providers) 1 -}}
-{{- fail "rr.gitServer.enabled requires exactly one of rr.blobStorage.s3, rr.blobStorage.gcs, rr.blobStorage.azure to be configured, or set RR_BLOB_STORAGE_PROVIDER / RR_DEFAULT_* directly via env / environmentVariables / environmentSecrets. If those vars are supplied another way (e.g. envFrom), set rr.gitServer.skipBlobStorageValidation=true to bypass this check." -}}
+{{- if ne (len $providers) 1 -}}1{{- end -}}
 {{- end -}}
 {{- end -}}
+{{- end -}}
+
+{{/*
+Hard-fail when the git server is enabled but blob storage is misconfigured.
+Downgraded to a non-fatal NOTES.txt warning when rr.gitServer.skipBlobStorageValidation
+is true -- the escape hatch for providers we cannot inspect at template time (e.g.
+RR_BLOB_STORAGE_PROVIDER / RR_DEFAULT_* injected via envFrom). No-op otherwise.
+*/}}
+{{- define "retool.gitServer.validateBlobStorage" -}}
+{{- if and (eq (include "retool.gitServer.blobStorageMisconfigured" .) "1") (not .Values.rr.gitServer.skipBlobStorageValidation) -}}
+{{- fail "rr git server is enabled but blob storage is misconfigured: set exactly one of rr.blobStorage.s3, rr.blobStorage.gcs, rr.blobStorage.azure, or supply RR_BLOB_STORAGE_PROVIDER / RR_DEFAULT_* via env / environmentVariables / environmentSecrets. If those vars are injected another way (e.g. envFrom), set rr.gitServer.skipBlobStorageValidation=true to downgrade this hard error to a warning." -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/retool/templates/_workers.tpl
+++ b/charts/retool/templates/_workers.tpl
@@ -230,7 +230,7 @@ spec:
             value: http://{{ template "retool.jsExecutor.name" $ }}
           {{- end }}
           {{- include "retool.agentSandbox.backendEnvVars" $ | nindent 10 }}
-          {{- if $.Values.rr.gitServer.enabled }}
+          {{- if eq (include "retool.gitServer.enabled" $) "1" }}
           {{- /*
             Snapshot blob storage: the agentExecutor / snapshotRetention temporal
             activities run on this worker and read RR_SNAPSHOTS_* with an

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -106,7 +106,7 @@ spec:
             Run the git server in-process on the main backend unless it has been
             split out into its own deployment (rr.gitServer.separate.enabled).
           */}}
-          {{- if and .Values.rr.gitServer.enabled (not (include "retool.gitServer.separateEnabled" .)) }}
+          {{- if and (eq (include "retool.gitServer.enabled" .) "1") (not (include "retool.gitServer.separateEnabled" .)) }}
             {{- $serviceType = append $serviceType "RR_GIT_SERVER" }}
           {{- end }}
           - name: SERVICE_TYPE
@@ -261,7 +261,7 @@ spec:
                 {{- end }}
           {{- end }}
           {{- end }}
-          {{- if .Values.rr.gitServer.enabled }}
+          {{- if eq (include "retool.gitServer.enabled" .) "1" }}
           {{- if include "retool.gitServer.separateEnabled" . }}
           {{- /*
             git server runs in its own deployment; point the main backend's

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -1143,8 +1143,12 @@ rr:
     #
     # When enabled, exactly one of blobStorage.s3, blobStorage.gcs, or
     # blobStorage.azure must be configured below — git_server stores all
-    # objects/packs in blob storage.
-    enabled: false
+    # objects/packs in blob storage. If it isn't, the render FAILS (set
+    # skipBlobStorageValidation below to downgrade that to a NOTES.txt warning).
+    #
+    # Tri-state, like jsExecutor/agent/agentSandbox: leave null to INHERIT the
+    # rr.enabled master switch; set true|false to override explicitly.
+    enabled: null
 
     # Optional: number of loose objects before git_server triggers a repack.
     # Backend default is 100; unset to inherit it.
@@ -1153,13 +1157,14 @@ rr:
     # Escape hatch for the blob-storage validation below. The chart can only
     # inspect blobStorage, env, environmentVariables, and environmentSecrets at
     # template time; it cannot see env vars injected via envFrom (Secret/ConfigMap
-    # splat). Set this to true to bypass the check when RR_BLOB_STORAGE_PROVIDER /
-    # RR_DEFAULT_* are provided that way.
+    # splat). Set this to true to DOWNGRADE the hard-fail to a non-fatal NOTES.txt
+    # warning when RR_BLOB_STORAGE_PROVIDER / RR_DEFAULT_* are provided that way.
     skipBlobStorageValidation: false
 
     # Optionally split the git server out of the main backend into its own
     # deployment + service (mirrors how the workload is split in Retool Cloud).
-    # Requires rr.gitServer.enabled: true. When enabled:
+    # Requires the git server to be enabled (rr.gitServer.enabled: true, or
+    # inherited from rr.enabled). When enabled:
     #   - a dedicated <release>-git-server Deployment runs SERVICE_TYPE=RR_GIT_SERVER
     #   - the main backend drops RR_GIT_SERVER from its SERVICE_TYPE and proxies git
     #     traffic to the service via RR_GIT_SERVER_HOST / RR_GIT_SERVER_PORT

--- a/values.yaml
+++ b/values.yaml
@@ -1143,8 +1143,12 @@ rr:
     #
     # When enabled, exactly one of blobStorage.s3, blobStorage.gcs, or
     # blobStorage.azure must be configured below — git_server stores all
-    # objects/packs in blob storage.
-    enabled: false
+    # objects/packs in blob storage. If it isn't, the render FAILS (set
+    # skipBlobStorageValidation below to downgrade that to a NOTES.txt warning).
+    #
+    # Tri-state, like jsExecutor/agent/agentSandbox: leave null to INHERIT the
+    # rr.enabled master switch; set true|false to override explicitly.
+    enabled: null
 
     # Optional: number of loose objects before git_server triggers a repack.
     # Backend default is 100; unset to inherit it.
@@ -1153,13 +1157,14 @@ rr:
     # Escape hatch for the blob-storage validation below. The chart can only
     # inspect blobStorage, env, environmentVariables, and environmentSecrets at
     # template time; it cannot see env vars injected via envFrom (Secret/ConfigMap
-    # splat). Set this to true to bypass the check when RR_BLOB_STORAGE_PROVIDER /
-    # RR_DEFAULT_* are provided that way.
+    # splat). Set this to true to DOWNGRADE the hard-fail to a non-fatal NOTES.txt
+    # warning when RR_BLOB_STORAGE_PROVIDER / RR_DEFAULT_* are provided that way.
     skipBlobStorageValidation: false
 
     # Optionally split the git server out of the main backend into its own
     # deployment + service (mirrors how the workload is split in Retool Cloud).
-    # Requires rr.gitServer.enabled: true. When enabled:
+    # Requires the git server to be enabled (rr.gitServer.enabled: true, or
+    # inherited from rr.enabled). When enabled:
     #   - a dedicated <release>-git-server Deployment runs SERVICE_TYPE=RR_GIT_SERVER
     #   - the main backend drops RR_GIT_SERVER from its SERVICE_TYPE and proxies git
     #     traffic to the service via RR_GIT_SERVER_HOST / RR_GIT_SERVER_PORT


### PR DESCRIPTION
## what

Two changes to `rr.gitServer` in `charts/retool`:

1. **gitServer inherits the `rr.enabled` master switch** — same tri-state as `jsExecutor`/`agent`/`agentSandbox`. New `retool.gitServer.enabled` helper backed by `retool.rr.componentEnabled`; every gitServer gate routes through it; `rr.gitServer.enabled` defaults to `null` (inherit). Explicit `true|false` still overrides.

2. **Hybrid blob-storage validation.** When the git server is enabled and blob storage is misconfigured (not exactly one of `rr.blobStorage.s3/gcs/azure`, and no `RR_BLOB_STORAGE_PROVIDER`/`RR_DEFAULT_*` supplied directly):
   - **default → hard fail** (render aborts; blocks the deploy)
   - **`rr.gitServer.skipBlobStorageValidation: true` → non-fatal NOTES.txt warning** — the escape hatch for providers injected via `envFrom` that can't be inspected at template time.

## why

`rr.gitServer.enabled` defaulted to `false` and did not follow the master switch, so enabling rr without explicitly enabling gitServer left React Retool git silently broken. This makes it inherit. Validation stays fail-fast by default but can be downgraded to a warning when the operator knows the provider is supplied another way.

## behavior change

Consumers with `rr.enabled: true` who did not explicitly set `gitServer` now get the git server, and the render fails if blob storage isn't configured (unless they set `skipBlobStorageValidation`). Consumers that set `rr.gitServer.enabled` explicitly are unaffected.

## caveat

The skip-path warning shows in `helm install`/`upgrade`/`--dry-run` output, not in `helm template`/CI renders.

## verification

- `helm lint` passes; existing `git-server-separate` CI fixture still renders.
- gitServer inherits `rr.enabled`; explicit `gitServer.enabled: false` overrides.
- misconfigured (zero or 2+ providers), skip=false → render FAILS; skip=true → renders + warning; configured provider → renders clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)