### PR TITLE
fix: use FQDN for CODE_EXECUTOR_INGRESS_DOMAIN / JS_EXECUTOR_INGRESS_DOMAIN

### DIFF
--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -532,10 +532,27 @@ Set code executor service name
 {{- end -}}
 
 {{/*
+Internal URL for server-side callers to reach the code executor Service.
+Fully-qualified because the backend resolves via c-ares, which does not
+apply /etc/resolv.conf search domains.
+*/}}
+{{- define "retool.codeExecutor.url" -}}
+{{- .Values.codeExecutor.url | default (printf "http://%s.%s.svc.cluster.local" (include "retool.codeExecutor.name" .) .Release.Namespace) -}}
+{{- end -}}
+
+{{/*
 Set JS executor service name
 */}}
 {{- define "retool.jsExecutor.name" -}}
 {{ template "retool.fullname" . }}-js-executor
+{{- end -}}
+
+{{/*
+Internal URL for server-side callers to reach the JS executor Service.
+Same FQDN rationale as retool.codeExecutor.url.
+*/}}
+{{- define "retool.jsExecutor.url" -}}
+{{- .Values.rr.jsExecutor.url | default (printf "http://%s.%s.svc.cluster.local" (include "retool.jsExecutor.name" .) .Release.Namespace) -}}
 {{- end -}}
 
 {{/*

--- a/charts/retool/templates/_workers.tpl
+++ b/charts/retool/templates/_workers.tpl
@@ -224,10 +224,10 @@ spec:
           - name: POSTGRES_SSL_ENABLED
             value: {{ template "retool.postgresql.ssl_enabled" $ }}
           - name: CODE_EXECUTOR_INGRESS_DOMAIN
-            value: http://{{ template "retool.codeExecutor.name" $ }}
+            value: {{ include "retool.codeExecutor.url" $ }}
           {{- if eq (include "retool.rr.componentEnabled" (dict "root" $ "component" "jsExecutor")) "1" }}
           - name: JS_EXECUTOR_INGRESS_DOMAIN
-            value: http://{{ template "retool.jsExecutor.name" $ }}
+            value: {{ include "retool.jsExecutor.url" $ }}
           {{- end }}
           {{- include "retool.agentSandbox.backendEnvVars" $ | nindent 10 }}
           {{- if eq (include "retool.gitServer.enabled" $) "1" }}

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -168,7 +168,7 @@ spec:
           - name: WORKFLOW_BACKEND_HOST
             value: http://{{ template "retool.fullname" . }}-workflow-backend
           - name: CODE_EXECUTOR_INGRESS_DOMAIN
-            value: http://{{ template "retool.codeExecutor.name" . }}
+            value: {{ include "retool.codeExecutor.url" . }}
           {{- end }}
           {{- include "retool.agentSandbox.backendEnvVars" . | nindent 10 }}
           {{- if ($temporalConfig).sslEnabled }}
@@ -191,7 +191,7 @@ spec:
           {{- end }}
           {{- if eq (include "retool.rr.componentEnabled" (dict "root" $ "component" "jsExecutor")) "1" }}
           - name: JS_EXECUTOR_INGRESS_DOMAIN
-            value: http://{{ template "retool.jsExecutor.name" . }}
+            value: {{ include "retool.jsExecutor.url" . }}
           {{- end }}
 
           {{- include "retool.telemetry.includeEnvVars" . | nindent 10 }}

--- a/charts/retool/templates/deployment_workflows.yaml
+++ b/charts/retool/templates/deployment_workflows.yaml
@@ -155,7 +155,7 @@ spec:
           {{- end }}
           {{- if eq (include "retool.rr.componentEnabled" (dict "root" $ "component" "jsExecutor")) "1" }}
           - name: JS_EXECUTOR_INGRESS_DOMAIN
-            value: http://{{ template "retool.jsExecutor.name" . }}
+            value: {{ include "retool.jsExecutor.url" . }}
           {{- end }}
 
           {{- include "retool.telemetry.includeEnvVars" . | nindent 10 }}
@@ -179,7 +179,7 @@ spec:
           - name: WORKFLOW_BACKEND_HOST
             value: http://{{ include "retool.workflowBackend.name" . }}
           - name: CODE_EXECUTOR_INGRESS_DOMAIN
-            value: http://{{ template "retool.codeExecutor.name" . }}
+            value: {{ include "retool.codeExecutor.url" . }}
           {{- include "retool.agentSandbox.backendEnvVars" . | nindent 10 }}
           {{- if include "shouldIncludeConfigSecretsEnvVars" . }}
           - name: LICENSE_KEY

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -728,6 +728,12 @@ codeExecutor:
   # as of Chart version 6.7.0, code-executor image version must align with the top-level `image` parameters
   # explicitly set other fields as needed
 
+  # Internal URL the backend uses to reach code-executor. Defaults to the
+  # fully-qualified Service DNS name in the release namespace. Override only
+  # for non-default cluster domains or custom routing.
+  # url: http://my-code-executor.my-namespace.svc.cluster.local
+  url: null
+
   image:
     repository: tryretool/code-executor-service
     pullPolicy: IfNotPresent
@@ -790,6 +796,12 @@ rr:
   jsExecutor:
     # Inherits .Values.rr.enabled when left unset (null); set true/false to override.
     enabled: null
+
+    # Internal URL the backend uses to reach js-executor. Defaults to the
+    # fully-qualified Service DNS name in the release namespace. Override only
+    # for non-default cluster domains or custom routing.
+    # url: http://my-js-executor.my-namespace.svc.cluster.local
+    url: null
 
     image:
       repository: tryretool/js-executor-service


### PR DESCRIPTION
## Summary

The backend's HTTP client to code-executor / js-executor resolves hostnames via Node's [`cacheable-lookup`](https://github.com/szmarczak/cacheable-lookup), which calls `dns.resolve4` / `dns.resolve6` (c-ares) directly instead of the default `dns.lookup` (glibc getaddrinfo). **c-ares does not apply the `/etc/resolv.conf` search list.** So the current bare service name (`http://<fullname>-code-executor`) is queried verbatim, kube-dns has no record for the unqualified label, and the query gets forwarded upstream.

On clusters whose upstream resolver returns `SERVFAIL` for unknown bare labels (notably AKS via Azure DNS at `168.63.129.16`), this fails the Retool 4.0 startup health-check with `queryA ESERVFAIL <name>-code-executor` and the backend crash-loops. The same path on EKS / GKE fails with `ENOTFOUND` — the bug is environment-agnostic, only the error code differs.

`curl` and `getent` from the same pod work because they go through glibc/getaddrinfo, which honours the search list and expands the bare label to `<name>-code-executor.<namespace>.svc.cluster.local`. The fix here is to give c-ares the same FQDN form so no search expansion is required.

## Changes

- New helpers in `charts/retool/templates/_helpers.tpl`:
  - `retool.codeExecutor.url` — defaults to `http://<codeExecutor.name>.<namespace>.svc.cluster.local`, with override path via `.Values.codeExecutor.url`.
  - `retool.jsExecutor.url` — defaults to `http://<jsExecutor.name>.<namespace>.svc.cluster.local`, with override path via `.Values.rr.jsExecutor.url`.
- Replace six hardcoded bare-name env var sources with the new helpers:
  - `deployment_backend.yaml` × 2 (`CODE_EXECUTOR_INGRESS_DOMAIN`, `JS_EXECUTOR_INGRESS_DOMAIN`)
  - `deployment_workflows.yaml` × 2
  - `_workers.tpl` × 2 (which renders for each worker type listed in `retool.workers`)
- Document the new override values in `charts/retool/values.yaml` under `codeExecutor:` and `rr.jsExecutor:`.

Mirrors the existing [`retool.agentSandbox.proxyUrl`](https://github.com/tryretool/retool-helm/blob/main/charts/retool/templates/_helpers.tpl#L662-L664) pattern, which already documents the same FQDN rationale ("keeps this default valid even when callers run outside the proxy Service's namespace").

## Evidence

Reproduced in a customer's AKS pod (Helm 6.11.4 + backend 4.0.2-stable) with four `dns.resolve*` calls — the same APIs `cacheable-lookup` uses internally:

| Query | Result |
|-------|--------|
| `dns.resolve4('dev-retool-app-code-executor')` | `ESERVFAIL` |
| `dns.resolve4('dev-retool-app-code-executor.retool.svc.cluster.local')` | `[ '10.0.67.39' ]` |
| `dns.resolve6('dev-retool-app-code-executor')` | `ESERVFAIL` |
| `dns.resolve6('dev-retool-app-code-executor.retool.svc.cluster.local')` | `ENODATA` |

The fourth result — a clean `ENODATA` rather than another `ESERVFAIL` — proves the failure is the upstream resolver's SERVFAIL on bare labels, not anything wrong with the resolver path itself. The FQDN resolves cleanly; the service simply has no native AAAA record.

`reddog.microsoft.com` was present in the customer's `/etc/resolv.conf` search list, confirming AKS.

## Verification

`helm template` diff (rr disabled):

```diff
-            value: http://myrel-retool-code-executor
+            value: http://myrel-retool-code-executor.retool.svc.cluster.local
```

`helm template` diff (rr enabled, jsExecutor enabled) shows 8 env-var lines change — all `CODE_EXECUTOR_INGRESS_DOMAIN` or `JS_EXECUTOR_INGRESS_DOMAIN` switching from bare label to FQDN. No unrelated changes.

Override values flow through correctly:

```yaml
codeExecutor:
  url: http://custom-ce.custom-ns.svc.cluster.local
rr:
  jsExecutor:
    url: http://custom-jse.custom-ns.svc.cluster.local
```

renders the overridden value at all eight rendering sites.

## Out of scope

This is a chart-side mitigation. The underlying behaviour — `cacheable-lookup` on the ingress HTTP agent calling `dns.resolve*` and bypassing search-expansion — is still in the backend. Any other in-cluster service that the backend reaches via the same agent would have the same vulnerability if configured with a bare service name. A follow-up question for Core Infra is whether `cacheable-lookup` belongs on the in-cluster ingress agent at all (the DNS cache value of sub-millisecond kube-dns hits is questionable; the foot-gun cost is high).

## Test plan

- [ ] Render with default values (no overrides) and confirm CODE_EXECUTOR_INGRESS_DOMAIN / JS_EXECUTOR_INGRESS_DOMAIN now have `.svc.cluster.local` form.
- [ ] Render with `codeExecutor.url` / `rr.jsExecutor.url` overrides and confirm they flow through.
- [ ] Render with a non-default release namespace and confirm the namespace is templated in correctly.
- [ ] Deploy to a 4.x customer environment (ideally AKS) and confirm the backend boots without `IGNORE_CODE_EXECUTOR_STARTUP_CHECK=true`.

Refs: Salesforce case 00117651 (Flaschenpost SE). Sibling Linear: INF-7104 (Omniva — same chart + backend version, different surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)