### PR TITLE
support keyless auth for rr blob storage

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.11.7
+version: 6.11.8
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -988,12 +988,51 @@ directly via environmentVariables / environmentSecrets).
 {{- else if $bs.azure.connectionString }}
 - name: RR_DEFAULT_AZURE_CONNECTION_STRING
   value: {{ $bs.azure.connectionString | quote }}
+{{- else if $bs.azure.accountUrl }}
+- name: RR_DEFAULT_AZURE_ACCOUNT_URL
+  value: {{ $bs.azure.accountUrl | quote }}
 {{- end }}
 {{- end }}
 {{- if .Values.rr.gitServer.repackThreshold }}
 - name: RR_GIT_REPACK_THRESHOLD
   value: {{ .Values.rr.gitServer.repackThreshold | quote }}
 {{- end }}
+{{- end -}}
+
+{{/*
+Returns "1" when blob storage is configured to authenticate keyless -- i.e. a
+provider block is set but its static credential is omitted, so the backend
+resolves credentials from the pod's own identity (S3 IRSA / instance profile,
+GCS Workload Identity, Azure managed identity) rather than a baked-in key.
+Empty otherwise (no provider, or a static credential is present).
+*/}}
+{{- define "retool.blobStorage.keyless" -}}
+{{- $bs := .Values.rr.blobStorage | default dict -}}
+{{- if $bs.s3 -}}
+{{- if not (or $bs.s3.accessKeyId $bs.s3.secretAccessKey $bs.s3.secretAccessKeySecretName) -}}1{{- end -}}
+{{- else if $bs.gcs -}}
+{{- if not (or $bs.gcs.credentials $bs.gcs.credentialsSecretName) -}}1{{- end -}}
+{{- else if $bs.azure -}}
+{{- if and $bs.azure.accountUrl (not (or $bs.azure.connectionString $bs.azure.connectionStringSecretName)) -}}1{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns "1" when the backend metadata-egress NetworkPolicy should be rendered.
+networkPolicy.blockCloudMetadataEgress is tri-state: an explicit bool forces
+on/off; null (default) auto-enables only when blob storage is keyless -- in that
+mode credentials come from a projected token file + the provider STS/IAM
+endpoint, never the metadata service, so blocking metadata is safe. Left off for
+non-keyless setups, which may legitimately read credentials from the metadata
+endpoint (e.g. an IAM-role data source using the instance profile).
+*/}}
+{{- define "retool.networkPolicy.blockMetadata.enabled" -}}
+{{- $v := (.Values.networkPolicy | default dict).blockCloudMetadataEgress -}}
+{{- if kindIs "bool" $v -}}
+{{- if $v -}}1{{- end -}}
+{{- else -}}
+{{- include "retool.blobStorage.keyless" . -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/retool/templates/metadata_egress_networkpolicy.yaml
+++ b/charts/retool/templates/metadata_egress_networkpolicy.yaml
@@ -1,0 +1,53 @@
+{{- if eq (include "retool.networkPolicy.blockMetadata.enabled" .) "1" }}
+{{- $np := .Values.networkPolicy | default dict }}
+{{- /*
+=======================================================================
+  Backend metadata-egress NetworkPolicy
+  -----------------------------------------------------------------------
+  Allows all egress EXCEPT the cloud instance-metadata endpoint
+  (169.254.169.254 -- AWS IMDS, GCP metadata.google.internal, Azure IMDS),
+  closing the SSRF -> metadata credential-theft vector from the backend
+  pods that execute user-defined resource requests. Safe alongside keyless
+  blob storage auth (IRSA / Workload Identity / managed identity), whose
+  credentials come from a projected token file + the provider STS/IAM
+  endpoint, not the metadata service.
+
+  Enforced only by CNIs that implement egress NetworkPolicy (Cilium,
+  Calico, AWS VPC CNI network-policy agent). Defense in depth -- pair with
+  IMDS hop-limit=1 at the node level and the application-layer SSRF filter.
+=======================================================================
+*/}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "retool.fullname" . }}-block-metadata
+  labels:
+    {{- include "retool.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "retool.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Egress
+  egress:
+    # Allow all IPv4 egress except the metadata endpoint (and any extra ranges).
+    # DNS and in-cluster traffic fall within 0.0.0.0/0 and stay permitted.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 169.254.169.254/32
+              {{- range $np.blockedRanges }}
+              - {{ . }}
+              {{- end }}
+    # Allow all IPv6 egress (metadata is IPv4-only); restrict only if configured.
+    - to:
+        - ipBlock:
+            cidr: ::/0
+            {{- with $np.blockedRanges6 }}
+            except:
+              {{- range . }}
+              - {{ . }}
+              {{- end }}
+            {{- end }}
+{{- end }}

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -260,6 +260,36 @@ serviceAccount:
   labels: {}
   automountToken: false
 
+# NetworkPolicy applied to the main Retool backend pods. Enforced only by CNIs
+# that implement egress NetworkPolicy (Cilium, Calico, AWS VPC CNI network-policy
+# agent); a no-op on CNIs that don't.
+networkPolicy:
+  # Block egress to the cloud instance-metadata endpoint (169.254.169.254 -- AWS
+  # IMDS, GCP metadata.google.internal, Azure IMDS) from the backend pods. They
+  # execute user-defined resource requests and are the primary SSRF surface, so
+  # this closes the SSRF -> metadata credential-theft vector. Allows all other
+  # egress (only that one IP is denied).
+  #
+  # Tri-state:
+  #   null (default) -> auto: ON when blob storage is keyless (no static
+  #                     credential set), OFF otherwise. Keyless auth (S3 IRSA /
+  #                     GCS Workload Identity / Azure managed identity) resolves
+  #                     credentials via a projected token file + the provider
+  #                     STS/IAM endpoint, NOT the metadata service, so blocking
+  #                     metadata is safe and is the recommended pairing.
+  #   true / false   -> force on/off.
+  #
+  # Do NOT enable if the backend relies on the metadata endpoint for credentials
+  # (e.g. an IAM-role data source connection using the instance profile).
+  # Defense in depth -- pair with IMDS hop-limit=1 at the node level and the
+  # application-layer SSRF filter.
+  blockCloudMetadataEgress: null
+  # Additional CIDRs to deny in backend egress (beyond the metadata IP). e.g.
+  # private ranges you don't want reachable from user-defined requests.
+  blockedRanges: []
+  # IPv6 CIDRs to deny. Empty leaves IPv6 egress fully allowed (metadata is IPv4).
+  blockedRanges6: []
+
 livenessProbe:
   enabled: true
   path: /api/checkHealth
@@ -1229,11 +1259,23 @@ rr:
   # This block can be omitted entirely if RR_BLOB_STORAGE_PROVIDER and the
   # RR_DEFAULT_*_* env vars are provided directly via environmentVariables /
   # environmentSecrets above — the chart detects that and skips this guard.
+  #
+  # Keyless auth: each provider can authenticate as the pod's own identity
+  # instead of a static credential. Leave the credential field unset and set
+  # serviceAccount.annotations so the pod carries the right identity:
+  #   - s3:    omit accessKeyId/secret -> AWS default chain (EKS IRSA via the
+  #            eks.amazonaws.com/role-arn annotation, instance profile, ECS role)
+  #   - gcs:   omit credentials -> Application Default Credentials (GKE Workload
+  #            Identity via the iam.gke.io/gcp-service-account annotation)
+  #   - azure: set accountUrl instead of a connection string -> managed identity
+  #            (azure.workload.identity/client-id annotation + the
+  #            azure.workload.identity/use: "true" pod label)
   blobStorage: {}
     # s3:
     #   bucket: my-rr-bucket
     #   region: us-east-1
     #   endpoint: ""                              # optional, for S3-compatible (MinIO, R2, etc.)
+    #   # Omit accessKeyId + secret to use the AWS default credential chain (IAM role / IRSA).
     #   accessKeyId: AKIA...
     #   # Provide secretAccessKey OR the secretName/secretKey pair below.
     #   secretAccessKey: ""
@@ -1242,17 +1284,19 @@ rr:
     #
     # gcs:
     #   bucket: my-rr-bucket
-    #   # Provide credentials (JSON string) OR the secretName/secretKey pair below.
+    #   # Omit credentials to use Application Default Credentials (Workload Identity).
     #   credentials: ""
     #   credentialsSecretName: ""
     #   credentialsSecretKey: credentials.json
     #
     # azure:
     #   container: my-rr-container
-    #   # Provide connectionString OR the secretName/secretKey pair below.
+    #   # Provide connectionString OR the secretName/secretKey pair below, OR set
+    #   # accountUrl on its own to authenticate via managed identity.
     #   connectionString: ""
     #   connectionStringSecretName: ""
     #   connectionStringSecretKey: connection-string
+    #   accountUrl: ""                            # e.g. https://<account>.blob.core.windows.net
 
 agents:
   # Enable AI Agents


### PR DESCRIPTION
### what

adds keyless auth support for rr blob storage so deployments can authenticate as the pod's own cloud identity instead of a static credential. pairs with tryretool/retool_development#80111, which makes the backend accept keyless auth.

- **azure**: new `rr.blobStorage.azure.accountUrl`. when set with no connection string, the chart renders `RR_DEFAULT_AZURE_ACCOUNT_URL` and the backend authenticates via `DefaultAzureCredential` (managed identity / azure workload identity). connection string still wins when both are set.
- **s3 / gcs**: already worked at the template level (credentials are only rendered when set). this just documents the keyless flow and the serviceAccount wiring.

to use keyless auth, omit the static credential and set `serviceAccount.annotations` so the pod carries the right identity:
- s3: `eks.amazonaws.com/role-arn` (irsa), or an instance/ecs role
- gcs: `iam.gke.io/gcp-service-account` (workload identity)
- azure: `azure.workload.identity/client-id` + the `azure.workload.identity/use: "true"` pod label

### metadata-egress networkpolicy

keyless auth means a leaked cloud token = the pod's identity, so the ssrf -> metadata credential-theft vector (capital-one style) matters more. retool runs user-defined http requests, so that vector is first-class. adds a backend `NetworkPolicy` that allows all egress **except** the cloud instance-metadata endpoint `169.254.169.254` (aws imds / gcp `metadata.google.internal` / azure imds).

- `networkPolicy.blockCloudMetadataEgress` is tri-state:
  - `null` (default) -> **auto-on when blob storage is keyless**, off otherwise. safe because keyless creds come from a projected token file + the provider sts/iam endpoint, never the metadata service. left off for non-keyless setups that may legitimately use the instance profile (e.g. an iam-role data source).
  - `true` / `false` -> force.
- `networkPolicy.blockedRanges` / `blockedRanges6` allow blocking extra cidrs.
- enforced only by cnis that implement egress networkpolicy (cilium, calico, aws vpc cni network-policy agent). **defense in depth** — pair with imds hop-limit=1 at the node level and the app-layer ssrf filter. (the app-layer filter is the must-have backstop since byoc cni support varies.)

### test

- `helm template` with `azure: { container, accountUrl }` renders `RR_DEFAULT_AZURE_ACCOUNT_URL` and no connection string env.
- with both `accountUrl` and `connectionString` set, only `RR_DEFAULT_AZURE_CONNECTION_STRING` is rendered (precedence matches backend).
- networkpolicy gating verified across all four cases: keyless->rendered, static-key->absent, force-true->rendered, force-false->absent; `blockedRanges`/`blockedRanges6` merge into the `except` lists.
- `helm lint` passes; `kubeconform -strict` (k8s 1.32.3) clean (16/16 resources valid).

chart version bumped to 6.11.8 (rebased on main).
