### PR TITLE
[chore][AI] simplify MCP metadata ingress routing requirements

### DIFF
--- a/charts/retool/ci/test-mcp-enabled-option.yaml
+++ b/charts/retool/ci/test-mcp-enabled-option.yaml
@@ -2,7 +2,7 @@ mcp:
   enabled: true
   replicaCount: 2
   config:
-    mcpServiceExternalUrl: https://retool.example.com
+    mcpServiceExternalUrl: https://example.retool.com
     oauthMainDomain: example.retool.com
     agentSandboxJwtPrivateKey: test-agent-sandbox-jwt-private-key
     enabledToolsets:

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -34,23 +34,44 @@ limit used by Service names and label values.
 {{- end }}
 
 {{/*
+Resolve the public host that serves MCP OAuth metadata routes. An explicit
+mcp.config.oauthMainDomain wins; when unset, fall back to the common backend
+BASE_DOMAIN value from .Values.env. Secret-backed or valueFrom-style BASE_DOMAIN
+settings are intentionally not inferred because their values are not available
+at template time.
+*/}}
+{{- define "retool.mcp.oauthMainDomain" -}}
+{{- $mcpConfig := (.Values.mcp.config | default dict) -}}
+{{- $domain := ($mcpConfig.oauthMainDomain | default "") -}}
+{{- if not $domain -}}
+{{- $baseDomain := get (.Values.env | default dict) "BASE_DOMAIN" | default "" -}}
+{{- if kindIs "map" $baseDomain -}}
+{{- $domain = get $baseDomain "value" | default "" -}}
+{{- else -}}
+{{- $domain = $baseDomain -}}
+{{- end -}}
+{{- end -}}
+{{- trimSuffix "/" (trimPrefix "http://" (trimPrefix "https://" (toString $domain))) -}}
+{{- end }}
+
+{{/*
 Render an MCP-related Ingress path. By default paths route to the MCP service;
-target: backendApi routes to the main backend API Service instead.
+target: backendInternal routes to the main backend API Service instead.
 */}}
 {{- define "retool.ingress.mcpPath" -}}
 {{- $root := .root -}}
 {{- $path := .path -}}
 {{- $target := .target | default ($path.target | default "mcp") -}}
-{{- if not (or (eq $target "mcp") (eq $target "backendApi")) -}}
-{{- fail (printf "Invalid mcp.ingress.paths target %q for path %q. Valid targets are \"mcp\" and \"backendApi\"." $target $path.path) -}}
+{{- if not (or (eq $target "mcp") (eq $target "backendInternal")) -}}
+{{- fail (printf "Invalid mcp.ingress.paths target %q for path %q. Valid targets are \"mcp\" and \"backendInternal\"." $target $path.path) -}}
 {{- end -}}
 {{- $mcpService := (($root.Values.mcp).service) | default dict -}}
 {{- $serviceName := include "retool.mcp.name" $root -}}
 {{- $servicePort := $path.port | default ($mcpService.externalPort | default 4010) -}}
 {{- $pathType := $path.pathType | default "ImplementationSpecific" -}}
-{{- if eq $target "backendApi" -}}
-{{- $serviceName = include "retool.backendApi.name" $root -}}
-{{- $servicePort = $path.port | default (.backendApiPort | default 3001) -}}
+{{- if eq $target "backendInternal" -}}
+{{- $serviceName = include "retool.backendInternal.name" $root -}}
+{{- $servicePort = $path.port | default (.backendInternalPort | default 3001) -}}
 {{- $pathType = $path.pathType | default "Exact" -}}
 {{- end -}}
 - path: {{ $path.path }}
@@ -71,22 +92,22 @@ target: backendApi routes to the main backend API Service instead.
 
 {{/*
 Render an MCP-related HTTPRoute rule. By default rules route to the MCP service;
-target: backendApi routes to the main backend API Service instead.
+target: backendInternal routes to the main backend API Service instead.
 */}}
 {{- define "retool.httpRoute.mcpRule" -}}
 {{- $root := .root -}}
 {{- $rule := .rule -}}
 {{- $target := .target | default ($rule.target | default "mcp") -}}
-{{- if not (or (eq $target "mcp") (eq $target "backendApi")) -}}
-{{- fail (printf "Invalid mcp.httpRoute.rules target %q for path %q. Valid targets are \"mcp\" and \"backendApi\"." $target $rule.path) -}}
+{{- if not (or (eq $target "mcp") (eq $target "backendInternal")) -}}
+{{- fail (printf "Invalid mcp.httpRoute.rules target %q for path %q. Valid targets are \"mcp\" and \"backendInternal\"." $target $rule.path) -}}
 {{- end -}}
 {{- $mcpService := (($root.Values.mcp).service) | default dict -}}
 {{- $serviceName := include "retool.mcp.name" $root -}}
 {{- $servicePort := $rule.port | default ($mcpService.externalPort | default 4010) -}}
 {{- $pathType := $rule.pathType | default "PathPrefix" -}}
-{{- if eq $target "backendApi" -}}
-{{- $serviceName = include "retool.backendApi.name" $root -}}
-{{- $servicePort = $rule.port | default (.backendApiPort | default 3001) -}}
+{{- if eq $target "backendInternal" -}}
+{{- $serviceName = include "retool.backendInternal.name" $root -}}
+{{- $servicePort = $rule.port | default (.backendInternalPort | default 3001) -}}
 {{- $pathType = $rule.pathType | default "Exact" -}}
 {{- end -}}
 - matches:
@@ -862,10 +883,10 @@ Set MCP server service name
 {{- end -}}
 
 {{/*
-Set backend API service name
+Set backend internal service name
 */}}
-{{- define "retool.backendApi.name" -}}
-{{ include "retool.fullnameWithSuffix" (list . "backend-api") }}
+{{- define "retool.backendInternal.name" -}}
+{{ include "retool.fullnameWithSuffix" (list . "backend-internal") }}
 {{- end -}}
 
 {{/*

--- a/charts/retool/templates/deployment_mcp.yaml
+++ b/charts/retool/templates/deployment_mcp.yaml
@@ -6,8 +6,7 @@
   {{- if and $mcpServiceExternalUrl (not (or (hasPrefix "http://" $mcpServiceExternalUrl) (hasPrefix "https://" $mcpServiceExternalUrl))) }}
     {{- $mcpServiceExternalUrl = printf "https://%s" $mcpServiceExternalUrl }}
   {{- end }}
-  {{- $mcpOAuthMainDomain := ($mcpConfig.oauthMainDomain | default "") }}
-  {{- $mcpOAuthMainDomain = trimSuffix "/" (trimPrefix "http://" (trimPrefix "https://" (toString $mcpOAuthMainDomain))) }}
+  {{- $mcpOAuthMainDomain := include "retool.mcp.oauthMainDomain" . }}
   {{- $hasOAuthMainDomainEnv := false }}
   {{- range .Values.mcp.environmentVariables }}
     {{- if eq .name "OAUTH_MAIN_DOMAIN" }}
@@ -38,7 +37,7 @@
     {{- end }}
   {{- end }}
   {{- if not (or $mcpOAuthMainDomain $hasOAuthMainDomainEnv) }}
-    {{- fail "Please set .Values.mcp.config.oauthMainDomain or an OAUTH_MAIN_DOMAIN entry in .Values.mcp.environmentVariables when the MCP server is enabled (.Values.mcp.enabled)" }}
+    {{- fail "Please set .Values.mcp.config.oauthMainDomain, .Values.env.BASE_DOMAIN, or an OAUTH_MAIN_DOMAIN entry in .Values.mcp.environmentVariables when the MCP server is enabled (.Values.mcp.enabled)" }}
   {{- end }}
   {{- if not (or $mcpConfig.oauthIntrospectionAuthTokenSecretName $mcpConfig.oauthIntrospectionAuthToken $hasOAuthIntrospectionAuthTokenEnv $chartOwnedConfigSecret) }}
     {{- fail "Please set .Values.mcp.config.oauthIntrospectionAuthTokenSecretName, .Values.mcp.config.oauthIntrospectionAuthToken, or an OAUTH_INTROSPECTION_AUTH_TOKEN entry in .Values.mcp.environmentVariables when the MCP server is enabled and chart-owned config secrets are disabled" }}

--- a/charts/retool/templates/httproute.yaml
+++ b/charts/retool/templates/httproute.yaml
@@ -4,8 +4,8 @@
 {{- $mcp := .Values.mcp | default dict -}}
 {{- $mcpBackendMetadata := $mcp.backendMetadata | default dict -}}
 {{- $mcpHttpRoute := $mcp.httpRoute | default dict -}}
-{{- $backendApiService := $mcpBackendMetadata.service | default dict -}}
-{{- $backendApiPort := $backendApiService.externalPort | default 3001 -}}
+{{- $backendInternalService := $mcpBackendMetadata.service | default dict -}}
+{{- $backendInternalPort := $backendInternalService.externalPort | default 3001 -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -42,7 +42,7 @@ spec:
     {{- end }}
     {{- if ( and ((.Values.mcp).enabled) $mcpHttpRoute.enabled ) }}
     {{- range $mcpHttpRoute.rules }}
-    {{- include "retool.httpRoute.mcpRule" (dict "root" $ "rule" . "backendApiPort" $backendApiPort) | nindent 4 }}
+    {{- include "retool.httpRoute.mcpRule" (dict "root" $ "rule" . "backendInternalPort" $backendInternalPort) | nindent 4 }}
     {{- end }}
     {{- end }}
     {{- if .Values.httpRoute.rules }}

--- a/charts/retool/templates/ingress.yaml
+++ b/charts/retool/templates/ingress.yaml
@@ -4,8 +4,8 @@
 {{- $mcp := .Values.mcp | default dict -}}
 {{- $mcpBackendMetadata := $mcp.backendMetadata | default dict -}}
 {{- $mcpIngress := $mcp.ingress | default dict -}}
-{{- $backendApiService := $mcpBackendMetadata.service | default dict -}}
-{{- $backendApiPort := $backendApiService.externalPort | default 3001 -}}
+{{- $backendInternalService := $mcpBackendMetadata.service | default dict -}}
+{{- $backendInternalPort := $backendInternalService.externalPort | default 3001 -}}
 {{- $pathType := .Values.ingress.pathType -}}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.Version -}}
 apiVersion: networking.k8s.io/v1
@@ -52,7 +52,7 @@ spec:
           # MCP-related paths must be added before the main path to avoid less specific paths being matched first.
           {{- if ( and ((.Values.mcp).enabled) $mcpIngress.enabled ) }}
           {{- range $mcpIngress.paths }}
-          {{- include "retool.ingress.mcpPath" (dict "root" $ "path" . "backendApiPort" $backendApiPort) | nindent 10 }}
+          {{- include "retool.ingress.mcpPath" (dict "root" $ "path" . "backendInternalPort" $backendInternalPort) | nindent 10 }}
           {{- end }}
           {{- end }}
           - path:
@@ -94,7 +94,7 @@ spec:
           # MCP-related paths must be added before the main path to avoid less specific paths being matched first.
           {{- if ( and (($.Values.mcp).enabled) $mcpIngress.enabled ) }}
           {{- range $mcpIngress.paths }}
-          {{- include "retool.ingress.mcpPath" (dict "root" $ "path" . "backendApiPort" $backendApiPort) | nindent 10 }}
+          {{- include "retool.ingress.mcpPath" (dict "root" $ "path" . "backendInternalPort" $backendInternalPort) | nindent 10 }}
           {{- end }}
           {{- end }}
           {{- range .paths }}

--- a/charts/retool/templates/service.yaml
+++ b/charts/retool/templates/service.yaml
@@ -1,8 +1,8 @@
 {{- $mcpEnabled := ((.Values.mcp).enabled) | default false -}}
-{{- $backendApiService := (((.Values.mcp).backendMetadata).service) | default dict -}}
-{{- $backendApiServiceEnabled := $mcpEnabled -}}
-{{- if hasKey $backendApiService "enabled" -}}
-{{- $backendApiServiceEnabled = and $mcpEnabled $backendApiService.enabled -}}
+{{- $backendInternalService := (((.Values.mcp).backendMetadata).service) | default dict -}}
+{{- $backendInternalServiceEnabled := $mcpEnabled -}}
+{{- if hasKey $backendInternalService "enabled" -}}
+{{- $backendInternalServiceEnabled = and $mcpEnabled $backendInternalService.enabled -}}
 {{- end -}}
 apiVersion: v1
 kind: Service
@@ -52,18 +52,18 @@ spec:
 {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
 {{- end }}
-{{- if $backendApiServiceEnabled }}
+{{- if $backendInternalServiceEnabled }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
     {{- include "retool.labels" . | nindent 4 }}
-  {{- range $key, $value := $backendApiService.labels }}
+  {{- range $key, $value := $backendInternalService.labels }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}
-  name: {{ template "retool.backendApi.name" . }}
-  {{- with $backendApiService.annotations }}
+  name: {{ template "retool.backendInternal.name" . }}
+  {{- with $backendInternalService.annotations }}
   annotations:
     {{- range $key, $value := . }}
       {{ $key }}: {{ $value | quote }}
@@ -72,9 +72,9 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - name: {{ $backendApiService.portName | default "http-api" }}
-      port: {{ $backendApiService.externalPort | default 3001 }}
-      targetPort: {{ $backendApiService.internalPort | default 3001 }}
+    - name: {{ $backendInternalService.portName | default "http-api" }}
+      port: {{ $backendInternalService.externalPort | default 3001 }}
+      targetPort: {{ $backendInternalService.internalPort | default 3001 }}
       protocol: TCP
   selector:
 {{- include "retool.selectorLabels" . | nindent 4 }}

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -624,12 +624,11 @@ mcp:
   #   # Deprecated alias for mcpServiceExternalUrl.
   #   retoolUrl:
   #
-  #   # Required when mcp.enabled is true unless OAUTH_MAIN_DOMAIN is provided
-  #   # directly in mcp.environmentVariables. Public Retool host that serves MCP
-  #   # OAuth metadata routes and /api/oauth2/* endpoints. This is usually the
-  #   # same host users use to access Retool, not an oauth.* subdomain. The MCP
-  #   # service expects a host here, but the chart also accepts URL-shaped values
-  #   # and strips http(s)://.
+  #   # Public Retool host that serves MCP OAuth metadata routes and
+  #   # /api/oauth2/* endpoints. Defaults to env.BASE_DOMAIN when unset. This is
+  #   # usually the same host users use to access Retool, not an oauth.*
+  #   # subdomain. The MCP service expects a host here, but the chart also
+  #   # accepts URL-shaped values and strips http(s)://.
   #   oauthMainDomain:
   #
   #   # Secret-backed token used by MCP to call /api/oauth2/introspect. When
@@ -679,14 +678,14 @@ mcp:
     limits:
       memory: "4096Mi"
 
-  # MCP OAuth metadata routes are served by the main Retool backend, not the MCP
-  # pod. When MCP is enabled, this config creates a dedicated backend API
-  # Service named <fullname>-backend-api for metadata routes, truncated to fit
-  # Kubernetes' 63-character DNS label limit when needed.
+  # Public ingress routes OAuth discovery metadata to the main Retool backend.
+  # When MCP is enabled, this config creates a dedicated backend API Service
+  # named <fullname>-backend-internal for those discovery routes, truncated to
+  # fit Kubernetes' 63-character DNS label limit when needed.
   backendMetadata:
     service:
       enabled: true
-      # Service port that exposes the backend API listener for metadata paths
+      # Service port that exposes the backend API listener for discovery routes
       # that should not fall through to the static frontend server.
       portName: http-api
       externalPort: 3001
@@ -695,56 +694,55 @@ mcp:
       labels: {}
 
   # Public MCP-related ingress paths. Paths are emitted in order before the main
-  # Retool route. Use target: backendApi for OAuth metadata routes that must hit
-  # the main backend API listener; use target: mcp for MCP server routes.
+  # Retool route:
+  #   - OAuth well-known metadata paths hit the main backend API listener.
+  #   - /mcp and its subpaths hit the MCP service.
+  #
+  # If you manage ingress outside this Helm chart, mcp.enabled only creates the
+  # chart-side resources. Your external ingress must route these paths, in this
+  # order before the "/" catch-all:
+  #
+  #   <fullname>-backend-internal:3001
+  #     /.well-known/oauth-authorization-server
+  #     /.well-known/oauth-protected-resource
+  #     /.well-known/oauth-protected-resource/mcp
+  #
+  #   <fullname>-mcp:4010
+  #     /mcp (Prefix; covers /mcp/.well-known/oauth-protected-resource)
+  #
+  #   <fullname>:3000
+  #     / (Prefix)
+  #
+  # Otherwise OAuth metadata requests can fall through to the frontend and
+  # return HTML instead of JSON. If you use nameOverride, fullnameOverride, or a
+  # non-default release name, service names may differ; run "kubectl get svc"
+  # after installation and look for the main Retool service, the *-backend-internal
+  # service, and the *-mcp service.
   ingress:
     # This conditional is dependent on mcp.enabled.
     enabled: true
     paths:
       - path: /.well-known/oauth-authorization-server
         pathType: Exact
-        target: backendApi
-        port: 3001
-      - path: /.well-known/oauth-protected-resource/mcp
-        pathType: Exact
-        target: backendApi
-        port: 3001
-      - path: /mcp/.well-known/oauth-protected-resource
-        pathType: Exact
-        target: backendApi
-        port: 3001
-      - path: /mcp
-        target: mcp
-        port: 4010
+        target: backendInternal
       - path: /.well-known/oauth-protected-resource
         pathType: Exact
-        target: mcp
-        port: 4010
+        target: backendInternal
+      - path: /.well-known/oauth-protected-resource/mcp
+        pathType: Exact
+        target: backendInternal
+      - path: /mcp
+        pathType: Prefix
 
   # HTTPRoute rules for MCP when using Gateway API instead of ingress.
   httpRoute:
     # This conditional is dependent on mcp.enabled.
     enabled: true
     rules:
-      - path: /.well-known/oauth-authorization-server
-        pathType: Exact
-        target: backendApi
-        port: 3001
-      - path: /.well-known/oauth-protected-resource/mcp
-        pathType: Exact
-        target: backendApi
-        port: 3001
-      - path: /mcp/.well-known/oauth-protected-resource
-        pathType: Exact
-        target: backendApi
-        port: 3001
+      - path: ^/\.well-known/oauth
+        pathType: RegularExpression
+        target: backendInternal
       - path: /mcp
-        target: mcp
-        port: 4010
-      - path: /.well-known/oauth-protected-resource
-        pathType: Exact
-        target: mcp
-        port: 4010
 
   service:
     externalPort: 4010

--- a/values.yaml
+++ b/values.yaml
@@ -624,12 +624,11 @@ mcp:
   #   # Deprecated alias for mcpServiceExternalUrl.
   #   retoolUrl:
   #
-  #   # Required when mcp.enabled is true unless OAUTH_MAIN_DOMAIN is provided
-  #   # directly in mcp.environmentVariables. Public Retool host that serves MCP
-  #   # OAuth metadata routes and /api/oauth2/* endpoints. This is usually the
-  #   # same host users use to access Retool, not an oauth.* subdomain. The MCP
-  #   # service expects a host here, but the chart also accepts URL-shaped values
-  #   # and strips http(s)://.
+  #   # Public Retool host that serves MCP OAuth metadata routes and
+  #   # /api/oauth2/* endpoints. Defaults to env.BASE_DOMAIN when unset. This is
+  #   # usually the same host users use to access Retool, not an oauth.*
+  #   # subdomain. The MCP service expects a host here, but the chart also
+  #   # accepts URL-shaped values and strips http(s)://.
   #   oauthMainDomain:
   #
   #   # Secret-backed token used by MCP to call /api/oauth2/introspect. When
@@ -679,14 +678,14 @@ mcp:
     limits:
       memory: "4096Mi"
 
-  # MCP OAuth metadata routes are served by the main Retool backend, not the MCP
-  # pod. When MCP is enabled, this config creates a dedicated backend API
-  # Service named <fullname>-backend-api for metadata routes, truncated to fit
-  # Kubernetes' 63-character DNS label limit when needed.
+  # Public ingress routes OAuth discovery metadata to the main Retool backend.
+  # When MCP is enabled, this config creates a dedicated backend API Service
+  # named <fullname>-backend-internal for those discovery routes, truncated to
+  # fit Kubernetes' 63-character DNS label limit when needed.
   backendMetadata:
     service:
       enabled: true
-      # Service port that exposes the backend API listener for metadata paths
+      # Service port that exposes the backend API listener for discovery routes
       # that should not fall through to the static frontend server.
       portName: http-api
       externalPort: 3001
@@ -695,56 +694,55 @@ mcp:
       labels: {}
 
   # Public MCP-related ingress paths. Paths are emitted in order before the main
-  # Retool route. Use target: backendApi for OAuth metadata routes that must hit
-  # the main backend API listener; use target: mcp for MCP server routes.
+  # Retool route:
+  #   - OAuth well-known metadata paths hit the main backend API listener.
+  #   - /mcp and its subpaths hit the MCP service.
+  #
+  # If you manage ingress outside this Helm chart, mcp.enabled only creates the
+  # chart-side resources. Your external ingress must route these paths, in this
+  # order before the "/" catch-all:
+  #
+  #   <fullname>-backend-internal:3001
+  #     /.well-known/oauth-authorization-server
+  #     /.well-known/oauth-protected-resource
+  #     /.well-known/oauth-protected-resource/mcp
+  #
+  #   <fullname>-mcp:4010
+  #     /mcp (Prefix; covers /mcp/.well-known/oauth-protected-resource)
+  #
+  #   <fullname>:3000
+  #     / (Prefix)
+  #
+  # Otherwise OAuth metadata requests can fall through to the frontend and
+  # return HTML instead of JSON. If you use nameOverride, fullnameOverride, or a
+  # non-default release name, service names may differ; run "kubectl get svc"
+  # after installation and look for the main Retool service, the *-backend-internal
+  # service, and the *-mcp service.
   ingress:
     # This conditional is dependent on mcp.enabled.
     enabled: true
     paths:
       - path: /.well-known/oauth-authorization-server
         pathType: Exact
-        target: backendApi
-        port: 3001
-      - path: /.well-known/oauth-protected-resource/mcp
-        pathType: Exact
-        target: backendApi
-        port: 3001
-      - path: /mcp/.well-known/oauth-protected-resource
-        pathType: Exact
-        target: backendApi
-        port: 3001
-      - path: /mcp
-        target: mcp
-        port: 4010
+        target: backendInternal
       - path: /.well-known/oauth-protected-resource
         pathType: Exact
-        target: mcp
-        port: 4010
+        target: backendInternal
+      - path: /.well-known/oauth-protected-resource/mcp
+        pathType: Exact
+        target: backendInternal
+      - path: /mcp
+        pathType: Prefix
 
   # HTTPRoute rules for MCP when using Gateway API instead of ingress.
   httpRoute:
     # This conditional is dependent on mcp.enabled.
     enabled: true
     rules:
-      - path: /.well-known/oauth-authorization-server
-        pathType: Exact
-        target: backendApi
-        port: 3001
-      - path: /.well-known/oauth-protected-resource/mcp
-        pathType: Exact
-        target: backendApi
-        port: 3001
-      - path: /mcp/.well-known/oauth-protected-resource
-        pathType: Exact
-        target: backendApi
-        port: 3001
+      - path: ^/\.well-known/oauth
+        pathType: RegularExpression
+        target: backendInternal
       - path: /mcp
-        target: mcp
-        port: 4010
-      - path: /.well-known/oauth-protected-resource
-        pathType: Exact
-        target: mcp
-        port: 4010
 
   service:
     externalPort: 4010


### PR DESCRIPTION
Cherry picking [this PR](https://app.graphite.com/github/pr/tryretool/retool_development/80215/%5Bcp%5D%5Bchore%5D%5BAGI%5D-Serve-MCP-OAuth-metadata-aliases) allows us to simplify the `/.well-known` ingress rules.

Additionally, Ryan had some comments on https://github.com/tryretool/retool-helm/pull/337 that remained unaddressed:

- `backend-internal`rather than `backend-api`
- Added some guidance for non-chart managed ingress setup