### PR TITLE
[chore][AI] Partial revert "[chore][AI] simplify MCP metadata ingress routing requirements"

### DIFF
--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -55,8 +55,8 @@ at template time.
 {{- end }}
 
 {{/*
-Render an MCP-related Ingress path. By default paths route to the MCP service;
-target: backendInternal routes to the main backend API Service instead.
+Render an MCP-related Ingress path. By default paths route to the MCP service.
+target: backendInternal routes to the backend API Service.
 */}}
 {{- define "retool.ingress.mcpPath" -}}
 {{- $root := .root -}}
@@ -91,8 +91,8 @@ target: backendInternal routes to the main backend API Service instead.
 {{- end }}
 
 {{/*
-Render an MCP-related HTTPRoute rule. By default rules route to the MCP service;
-target: backendInternal routes to the main backend API Service instead.
+Render an MCP-related HTTPRoute rule. By default rules route to the MCP service.
+target: backendInternal routes to the backend API Service.
 */}}
 {{- define "retool.httpRoute.mcpRule" -}}
 {{- $root := .root -}}

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -678,15 +678,17 @@ mcp:
     limits:
       memory: "4096Mi"
 
-  # Public ingress routes OAuth discovery metadata to the main Retool backend.
-  # When MCP is enabled, this config creates a dedicated backend API Service
-  # named <fullname>-backend-internal for those discovery routes, truncated to
-  # fit Kubernetes' 63-character DNS label limit when needed.
+  # Public ingress routes for MCP-related OAuth metadata. When MCP is enabled,
+  # this config creates a dedicated backend API Service named
+  # <fullname>-backend-internal for metadata routes that require the backend API
+  # listener, truncated to fit Kubernetes' 63-character DNS label limit when
+  # needed.
   backendMetadata:
     service:
       enabled: true
-      # Service port that exposes the backend API listener for discovery routes
-      # that should not fall through to the static frontend server.
+      # Service port that exposes the backend API listener for metadata routes
+      # that should not fall through to the static frontend server or MCP
+      # service.
       portName: http-api
       externalPort: 3001
       internalPort: 3001
@@ -695,8 +697,8 @@ mcp:
 
   # Public MCP-related ingress paths. Paths are emitted in order before the main
   # Retool route:
-  #   - OAuth well-known metadata paths hit the main backend API listener.
-  #   - /mcp and its subpaths hit the MCP service.
+  #   - OAuth authorization-server metadata hits the backend API service.
+  #   - Protected-resource metadata, /mcp, and /mcp subpaths hit the MCP service.
   #
   # If you manage ingress outside this Helm chart, mcp.enabled only creates the
   # chart-side resources. Your external ingress must route these paths, in this
@@ -704,11 +706,10 @@ mcp:
   #
   #   <fullname>-backend-internal:3001
   #     /.well-known/oauth-authorization-server
-  #     /.well-known/oauth-protected-resource
-  #     /.well-known/oauth-protected-resource/mcp
   #
   #   <fullname>-mcp:4010
-  #     /mcp (Prefix; covers /mcp/.well-known/oauth-protected-resource)
+  #     /.well-known/oauth-protected-resource
+  #     /mcp (Prefix)
   #
   #   <fullname>:3000
   #     / (Prefix)
@@ -727,10 +728,6 @@ mcp:
         target: backendInternal
       - path: /.well-known/oauth-protected-resource
         pathType: Exact
-        target: backendInternal
-      - path: /.well-known/oauth-protected-resource/mcp
-        pathType: Exact
-        target: backendInternal
       - path: /mcp
         pathType: Prefix
 
@@ -739,9 +736,11 @@ mcp:
     # This conditional is dependent on mcp.enabled.
     enabled: true
     rules:
-      - path: ^/\.well-known/oauth
-        pathType: RegularExpression
+      - path: /.well-known/oauth-authorization-server
+        pathType: Exact
         target: backendInternal
+      - path: /.well-known/oauth-protected-resource
+        pathType: Exact
       - path: /mcp
 
   service:

--- a/values.yaml
+++ b/values.yaml
@@ -678,15 +678,17 @@ mcp:
     limits:
       memory: "4096Mi"
 
-  # Public ingress routes OAuth discovery metadata to the main Retool backend.
-  # When MCP is enabled, this config creates a dedicated backend API Service
-  # named <fullname>-backend-internal for those discovery routes, truncated to
-  # fit Kubernetes' 63-character DNS label limit when needed.
+  # Public ingress routes for MCP-related OAuth metadata. When MCP is enabled,
+  # this config creates a dedicated backend API Service named
+  # <fullname>-backend-internal for metadata routes that require the backend API
+  # listener, truncated to fit Kubernetes' 63-character DNS label limit when
+  # needed.
   backendMetadata:
     service:
       enabled: true
-      # Service port that exposes the backend API listener for discovery routes
-      # that should not fall through to the static frontend server.
+      # Service port that exposes the backend API listener for metadata routes
+      # that should not fall through to the static frontend server or MCP
+      # service.
       portName: http-api
       externalPort: 3001
       internalPort: 3001
@@ -695,8 +697,8 @@ mcp:
 
   # Public MCP-related ingress paths. Paths are emitted in order before the main
   # Retool route:
-  #   - OAuth well-known metadata paths hit the main backend API listener.
-  #   - /mcp and its subpaths hit the MCP service.
+  #   - OAuth authorization-server metadata hits the backend API service.
+  #   - Protected-resource metadata, /mcp, and /mcp subpaths hit the MCP service.
   #
   # If you manage ingress outside this Helm chart, mcp.enabled only creates the
   # chart-side resources. Your external ingress must route these paths, in this
@@ -704,11 +706,10 @@ mcp:
   #
   #   <fullname>-backend-internal:3001
   #     /.well-known/oauth-authorization-server
-  #     /.well-known/oauth-protected-resource
-  #     /.well-known/oauth-protected-resource/mcp
   #
   #   <fullname>-mcp:4010
-  #     /mcp (Prefix; covers /mcp/.well-known/oauth-protected-resource)
+  #     /.well-known/oauth-protected-resource
+  #     /mcp (Prefix)
   #
   #   <fullname>:3000
   #     / (Prefix)
@@ -727,10 +728,6 @@ mcp:
         target: backendInternal
       - path: /.well-known/oauth-protected-resource
         pathType: Exact
-        target: backendInternal
-      - path: /.well-known/oauth-protected-resource/mcp
-        pathType: Exact
-        target: backendInternal
       - path: /mcp
         pathType: Prefix
 
@@ -739,9 +736,11 @@ mcp:
     # This conditional is dependent on mcp.enabled.
     enabled: true
     rules:
-      - path: ^/\.well-known/oauth
-        pathType: RegularExpression
+      - path: /.well-known/oauth-authorization-server
+        pathType: Exact
         target: backendInternal
+      - path: /.well-known/oauth-protected-resource
+        pathType: Exact
       - path: /mcp
 
   service:


### PR DESCRIPTION
Partial revert of #341  that maintains backwards compatibility on previous versions of 4.0.

- The problematic change simplifies the MCP OAuth discovery metadata endpoint ingress routing
- New routing would break old patch OAuth behavior

As of this PR, the MCP helm setup will be in a customer-ready state. Across #337 and #341 , we have made these improvements:

- `secrets.yaml`environment variable setup for OAUTH_INTROSPECTION_AUTH_TOKEN
- New backend internal service exposing port 3001
- Default variable selection for `AGENT_SANDBOX_JWT_SECRET_KEY, AGENT_EXECUTOR_PROXY_INGRESS_DOMAIN`, `RETOOL_BACKEND_URL`, and `OAUTH_MAIN_DOMAIN`