### PR TITLE
[fix][MCP] Wire OAUTH_INTROSPECTION_AUTH_TOKEN into the backend

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.11.6
+version: 6.11.7
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -312,13 +312,13 @@ spec:
           {{- end }}
           {{- end }}
           {{- if not $backendHasIntrospectionToken }}
-          {{- if $mcpConfig.oauthIntrospectionAuthTokenSecretName }}
+          {{- if and $mcpConfig.oauthIntrospectionAuthTokenSecretName (not $mcpEnvHasIntrospectionToken) }}
           - name: OAUTH_INTROSPECTION_AUTH_TOKEN
             valueFrom:
               secretKeyRef:
                 name: {{ $mcpConfig.oauthIntrospectionAuthTokenSecretName }}
                 key: {{ $mcpConfig.oauthIntrospectionAuthTokenSecretKey | default "oauthIntrospectionAuthToken" }}
-          {{- else if $mcpConfig.oauthIntrospectionAuthToken }}
+          {{- else if and $mcpConfig.oauthIntrospectionAuthToken (not $mcpEnvHasIntrospectionToken) }}
           - name: OAUTH_INTROSPECTION_AUTH_TOKEN
             value: {{ $mcpConfig.oauthIntrospectionAuthToken | quote }}
           {{- else if and $chartOwnedConfigSecret (not $mcpEnvHasIntrospectionToken) }}

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -287,6 +287,49 @@ spec:
           {{- with .Values.environmentVariables }}
 {{ toYaml . | indent 10 }}
           {{- end }}
+          {{- if .Values.mcp.enabled }}
+          {{- /* The backend serves /api/oauth2/introspect and rejects the call unless
+                 OAUTH_INTROSPECTION_AUTH_TOKEN matches what MCP sends. Pull it from the
+                 same source the MCP deployment uses so they stay in sync. Skip if the
+                 operator already set the token on the backend. */}}
+          {{- $mcpConfig := .Values.mcp.config | default dict }}
+          {{- $chartOwnedConfigSecret := eq (include "shouldIncludeConfigSecretsEnvVars" . | trim) "1" }}
+          {{- $mcpEnvHasIntrospectionToken := false }}
+          {{- range .Values.mcp.environmentVariables }}
+          {{- if eq .name "OAUTH_INTROSPECTION_AUTH_TOKEN" }}
+          {{- $mcpEnvHasIntrospectionToken = true }}
+          {{- end }}
+          {{- end }}
+          {{- $backendHasIntrospectionToken := hasKey (.Values.env | default dict) "OAUTH_INTROSPECTION_AUTH_TOKEN" }}
+          {{- range .Values.environmentSecrets }}
+          {{- if eq .name "OAUTH_INTROSPECTION_AUTH_TOKEN" }}
+          {{- $backendHasIntrospectionToken = true }}
+          {{- end }}
+          {{- end }}
+          {{- range .Values.environmentVariables }}
+          {{- if eq .name "OAUTH_INTROSPECTION_AUTH_TOKEN" }}
+          {{- $backendHasIntrospectionToken = true }}
+          {{- end }}
+          {{- end }}
+          {{- if not $backendHasIntrospectionToken }}
+          {{- if $mcpConfig.oauthIntrospectionAuthTokenSecretName }}
+          - name: OAUTH_INTROSPECTION_AUTH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: {{ $mcpConfig.oauthIntrospectionAuthTokenSecretName }}
+                key: {{ $mcpConfig.oauthIntrospectionAuthTokenSecretKey | default "oauthIntrospectionAuthToken" }}
+          {{- else if $mcpConfig.oauthIntrospectionAuthToken }}
+          - name: OAUTH_INTROSPECTION_AUTH_TOKEN
+            value: {{ $mcpConfig.oauthIntrospectionAuthToken | quote }}
+          {{- else if and $chartOwnedConfigSecret (not $mcpEnvHasIntrospectionToken) }}
+          - name: OAUTH_INTROSPECTION_AUTH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "retool.fullname" . }}
+                key: oauthIntrospectionAuthToken
+          {{- end }}
+          {{- end }}
+          {{- end }}
         {{- if .Values.externalSecrets.enabled }}
         envFrom:
         - secretRef:

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -634,7 +634,12 @@ mcp:
   #   # Secret-backed token used by MCP to call /api/oauth2/introspect. When
   #   # unset, the chart auto-generates one in the release Secret on first deploy
   #   # if chart-owned config secrets are enabled. Set this when using an
-  #   # externally managed Secret instead.
+  #   # externally managed Secret instead. The chart injects the same token into
+  #   # the main Retool backend (which serves /api/oauth2/introspect), so no
+  #   # separate backend env configuration is needed. The exception is supplying
+  #   # the token only via mcp.environmentVariables: that targets the MCP pod
+  #   # alone, so you must also set OAUTH_INTROSPECTION_AUTH_TOKEN in the global
+  #   # env: block for the backend.
   #   oauthIntrospectionAuthTokenSecretName:
   #   oauthIntrospectionAuthTokenSecretKey: oauthIntrospectionAuthToken
   #

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -636,10 +636,10 @@ mcp:
   #   # if chart-owned config secrets are enabled. Set this when using an
   #   # externally managed Secret instead. The chart injects the same token into
   #   # the main Retool backend (which serves /api/oauth2/introspect), so no
-  #   # separate backend env configuration is needed. The exception is supplying
-  #   # the token only via mcp.environmentVariables: that targets the MCP pod
-  #   # alone, so you must also set OAUTH_INTROSPECTION_AUTH_TOKEN in the global
-  #   # env: block for the backend.
+  #   # separate backend env configuration is needed. The exception is setting
+  #   # OAUTH_INTROSPECTION_AUTH_TOKEN in mcp.environmentVariables: the MCP pod
+  #   # then uses that value and the backend is not auto-wired, so you must also
+  #   # set OAUTH_INTROSPECTION_AUTH_TOKEN in the global env: block.
   #   oauthIntrospectionAuthTokenSecretName:
   #   oauthIntrospectionAuthTokenSecretKey: oauthIntrospectionAuthToken
   #

--- a/values.yaml
+++ b/values.yaml
@@ -634,7 +634,12 @@ mcp:
   #   # Secret-backed token used by MCP to call /api/oauth2/introspect. When
   #   # unset, the chart auto-generates one in the release Secret on first deploy
   #   # if chart-owned config secrets are enabled. Set this when using an
-  #   # externally managed Secret instead.
+  #   # externally managed Secret instead. The chart injects the same token into
+  #   # the main Retool backend (which serves /api/oauth2/introspect), so no
+  #   # separate backend env configuration is needed. The exception is supplying
+  #   # the token only via mcp.environmentVariables: that targets the MCP pod
+  #   # alone, so you must also set OAUTH_INTROSPECTION_AUTH_TOKEN in the global
+  #   # env: block for the backend.
   #   oauthIntrospectionAuthTokenSecretName:
   #   oauthIntrospectionAuthTokenSecretKey: oauthIntrospectionAuthToken
   #

--- a/values.yaml
+++ b/values.yaml
@@ -636,10 +636,10 @@ mcp:
   #   # if chart-owned config secrets are enabled. Set this when using an
   #   # externally managed Secret instead. The chart injects the same token into
   #   # the main Retool backend (which serves /api/oauth2/introspect), so no
-  #   # separate backend env configuration is needed. The exception is supplying
-  #   # the token only via mcp.environmentVariables: that targets the MCP pod
-  #   # alone, so you must also set OAUTH_INTROSPECTION_AUTH_TOKEN in the global
-  #   # env: block for the backend.
+  #   # separate backend env configuration is needed. The exception is setting
+  #   # OAUTH_INTROSPECTION_AUTH_TOKEN in mcp.environmentVariables: the MCP pod
+  #   # then uses that value and the backend is not auto-wired, so you must also
+  #   # set OAUTH_INTROSPECTION_AUTH_TOKEN in the global env: block.
   #   oauthIntrospectionAuthTokenSecretName:
   #   oauthIntrospectionAuthTokenSecretKey: oauthIntrospectionAuthToken
   #


### PR DESCRIPTION
## Summary

When the MCP server is enabled on a self-hosted Helm deployment, it can get stuck registering only the 4 read-only tools because OAuth token introspection fails. The MCP server calls `/api/oauth2/introspect` on the main Retool backend, and the backend rejects that call unless `OAUTH_INTROSPECTION_AUTH_TOKEN` is set to the same value MCP sends.

The chart only injected `OAUTH_INTROSPECTION_AUTH_TOKEN` into the **MCP deployment** (`deployment_mcp.yaml`), never the **backend**. So the backend logged `OAuth token introspection is not configured: OAUTH_INTROSPECTION_AUTH_TOKEN is missing`, the MCP server logged `Falling back to legacy MCP auth behavior after token introspection failure`, and only the read-only toolset registered. This was undiscoverable: the `mcp.config.oauthIntrospectionAuthToken` docs gave no hint the backend needed the same value, and the chart-owned auto-generate path made it worse by putting a token on MCP that the backend could never match.

Reported by a customer on a v4.0.3-stable / chart v6.11.6 deployment built from the `values.yaml` template.

## What changed

- `deployment_backend.yaml`: when `mcp.enabled`, inject `OAUTH_INTROSPECTION_AUTH_TOKEN` into the backend from the **same source** the MCP deployment uses, in the same precedence order:
  1. `mcp.config.oauthIntrospectionAuthTokenSecretName` → `secretKeyRef`
  2. `mcp.config.oauthIntrospectionAuthToken` → literal `value`
  3. chart-owned config secret → `secretKeyRef` into the release secret's `oauthIntrospectionAuthToken` key
  
  This guarantees backend and MCP always agree. It is skipped when the operator already wired the token onto the backend (`.Values.env`, `.Values.environmentVariables`, or `.Values.environmentSecrets`), so the existing global-`env:` workaround keeps working with no duplicate env entry. All three branches are also skipped when the token is supplied via `mcp.environmentVariables`: the MCP deployment uses that value over its config-based branches, so auto-wiring the backend from a config source could inject a differing value and silently break introspection. In that case the backend is not auto-wired; set `OAUTH_INTROSPECTION_AUTH_TOKEN` in the global `env:` block.
- `values.yaml` / `charts/retool/values.yaml`: document that the chart now wires the token into the backend automatically, and note the case where the token is set via `mcp.environmentVariables` and you must also set it in the global `env:` block.
- `Chart.yaml`: bump `6.11.6` → `6.11.7`.

## Test Plan

Rendered `helm template` across the token-source scenarios and confirmed the backend env matches what the MCP deployment uses:

| Scenario | Backend result |
| --- | --- |
| Chart-owned auto-generated secret | `secretKeyRef` → release secret / `oauthIntrospectionAuthToken` (identical to MCP) |
| `mcp.config.oauthIntrospectionAuthToken` literal | `value:` matches MCP literal |
| `mcp.config.oauthIntrospectionAuthTokenSecretName` (+ externalSecrets) | `secretKeyRef` → named secret / key |
| Token only via `mcp.environmentVariables` | no backend entry, no dangling secret ref |
| `mcp.environmentVariables` + `mcp.config.oauthIntrospectionAuthTokenSecretName` | no backend entry (MCP uses the env value; backend not auto-wired from config, avoiding a mismatch) |
| Operator set `env.OAUTH_INTROSPECTION_AUTH_TOKEN` + `mcp.config` token | exactly one backend entry, from `env` (no double-inject) |

`helm lint` passes; both `values.yaml` files remain byte-identical (sync check).

