### PR TITLE
[INF-7190] allow disable of seccomp profile installation

### DIFF
--- a/charts/retool/ci/test-seccomp-install-disabled-option.yaml
+++ b/charts/retool/ci/test-seccomp-install-disabled-option.yaml
@@ -1,0 +1,18 @@
+# Exercises codeExecutor.installSeccompProfile / rr.jsExecutor.installSeccompProfile
+# set to false: the chart must render the seccompProfile.localhostProfile reference
+# but omit the install-seccomp initContainer, its ConfigMap, and the hostPath volume.
+# Overlaid on top of test-install-values.yaml.
+
+# Enable the code-executor (image.tag "latest" in the base does not match the
+# workflows semver gate, so enable it explicitly).
+workflows:
+  enabled: true
+
+codeExecutor:
+  useSeccompProfile: true
+  installSeccompProfile: false
+
+rr:
+  jsExecutor:
+    enabled: true
+    installSeccompProfile: false

--- a/charts/retool/templates/configmap_code_executor.yaml
+++ b/charts/retool/templates/configmap_code_executor.yaml
@@ -1,5 +1,5 @@
 {{- if include "retool.workflows.enabled" . }}
-{{- if and (not .Values.codeExecutor.securityContext) .Values.codeExecutor.useSeccompProfile }}
+{{- if and (not .Values.codeExecutor.securityContext) .Values.codeExecutor.useSeccompProfile .Values.codeExecutor.installSeccompProfile }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/retool/templates/configmap_js_executor.yaml
+++ b/charts/retool/templates/configmap_js_executor.yaml
@@ -1,4 +1,5 @@
 {{- if eq (include "retool.rr.componentEnabled" (dict "root" $ "component" "jsExecutor")) "1" }}
+{{- if .Values.rr.jsExecutor.installSeccompProfile }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,4 +9,5 @@ metadata:
 data:
   nsjail-seccomp.json: |
     {{- .Files.Get "files/nsjail-seccomp.json" | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/retool/templates/deployment_code_executor.yaml
+++ b/charts/retool/templates/deployment_code_executor.yaml
@@ -1,6 +1,8 @@
 {{- if include "retool.workflows.enabled" . }}
 {{- /* Use the less-privileged seccomp sandbox (see codeExecutor.useSeccompProfile in values.yaml) only when it is enabled and no explicit codeExecutor.securityContext is set. */ -}}
 {{- $useSecComp := and (not .Values.codeExecutor.securityContext) .Values.codeExecutor.useSeccompProfile -}}
+{{- /* Install the seccomp profile via initContainer only when the sandbox is enabled and the admin hasn't opted to manage the profile out of band. */ -}}
+{{- $installSeccomp := and $useSecComp .Values.codeExecutor.installSeccompProfile -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -53,9 +55,9 @@ spec:
 {{- if $useSecComp }}
       hostUsers: false
 {{- end }}
-{{- if or $useSecComp .Values.initContainers }}
+{{- if or $installSeccomp .Values.initContainers }}
       initContainers:
-{{- if $useSecComp }}
+{{- if $installSeccomp }}
         - name: install-seccomp
           image: busybox:1.37.0@sha256:b3255e7dfbcd10cb367af0d409747d511aeb66dfac98cf30e97e87e4207dd76f
           securityContext:
@@ -185,7 +187,7 @@ spec:
 {{ tpl . $ | indent 6 }}
 {{- end }}
       volumes:
-{{- if $useSecComp }}
+{{- if $installSeccomp }}
         - name: seccomp-profile
           configMap:
             name: {{ template "retool.fullname" . }}-code-executor-seccomp

--- a/charts/retool/templates/deployment_js_executor.yaml
+++ b/charts/retool/templates/deployment_js_executor.yaml
@@ -46,7 +46,9 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
+{{- if or .Values.rr.jsExecutor.installSeccompProfile .Values.initContainers }}
       initContainers:
+{{- if .Values.rr.jsExecutor.installSeccompProfile }}
         - name: install-seccomp
           image: busybox:1.37.0@sha256:b3255e7dfbcd10cb367af0d409747d511aeb66dfac98cf30e97e87e4207dd76f
           securityContext:
@@ -74,7 +76,7 @@ spec:
               mountPath: /seccomp-profile
             - name: host-seccomp
               mountPath: /host-seccomp
-{{- if .Values.initContainers }}
+{{- end }}
 {{- range $key, $value := .Values.initContainers }}
         - name: "{{ $key }}"
 {{ toYaml $value | indent 10 }}
@@ -158,6 +160,7 @@ spec:
 {{ tpl . $ | indent 6 }}
 {{- end }}
       volumes:
+{{- if .Values.rr.jsExecutor.installSeccompProfile }}
         - name: seccomp-profile
           configMap:
             name: {{ template "retool.fullname" . }}-js-executor-seccomp
@@ -165,6 +168,7 @@ spec:
           hostPath:
             path: /var/lib/kubelet/seccomp
             type: DirectoryOrCreate
+{{- end }}
 {{- if .Values.rr.jsExecutor.volumes }}
 {{ toYaml .Values.rr.jsExecutor.volumes | indent 8 }}
 {{- end }}

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -834,6 +834,14 @@ codeExecutor:
   useSeccompProfile: false
   seccompLocalhostProfile: profiles/nsjail-seccomp.json
 
+  # Only has an effect when useSeccompProfile is true. Set to false if a cluster
+  # admin installs the seccomp profile named by seccompLocalhostProfile out of band
+  # (baked into the node image, a separate DaemonSet, etc.). When false the chart
+  # skips the install-seccomp initContainer, its ConfigMap, and the hostPath mount,
+  # but the container still references the profile by that path -- which must already
+  # exist on every node, or the pod will fail to start.
+  installSeccompProfile: true
+
 # === RR (Retool agent runtime) =============================================
 # Master switch for the whole RR stack. Set `rr.enabled: true` to turn on the
 # components nested below — jsExecutor, agent, and agentSandbox — with a
@@ -860,6 +868,14 @@ rr:
     replicaCount: 1
 
     seccompLocalhostProfile: profiles/nsjail-seccomp.json
+
+    # Set to false if a cluster admin installs the seccomp profile named by
+    # seccompLocalhostProfile out of band (baked into the node image, a separate
+    # DaemonSet, etc.). When false the chart skips the install-seccomp initContainer,
+    # its ConfigMap, and the hostPath mount, but the container still references the
+    # profile by that path -- which must already exist on every node, or the pod will
+    # fail to start.
+    installSeccompProfile: true
 
     # JS-executor-specific environment; not inherited from the top-level
     # .Values.env / .Values.environmentSecrets / .Values.environmentVariables.

--- a/values.yaml
+++ b/values.yaml
@@ -834,6 +834,14 @@ codeExecutor:
   useSeccompProfile: false
   seccompLocalhostProfile: profiles/nsjail-seccomp.json
 
+  # Only has an effect when useSeccompProfile is true. Set to false if a cluster
+  # admin installs the seccomp profile named by seccompLocalhostProfile out of band
+  # (baked into the node image, a separate DaemonSet, etc.). When false the chart
+  # skips the install-seccomp initContainer, its ConfigMap, and the hostPath mount,
+  # but the container still references the profile by that path -- which must already
+  # exist on every node, or the pod will fail to start.
+  installSeccompProfile: true
+
 # === RR (Retool agent runtime) =============================================
 # Master switch for the whole RR stack. Set `rr.enabled: true` to turn on the
 # components nested below — jsExecutor, agent, and agentSandbox — with a
@@ -860,6 +868,14 @@ rr:
     replicaCount: 1
 
     seccompLocalhostProfile: profiles/nsjail-seccomp.json
+
+    # Set to false if a cluster admin installs the seccomp profile named by
+    # seccompLocalhostProfile out of band (baked into the node image, a separate
+    # DaemonSet, etc.). When false the chart skips the install-seccomp initContainer,
+    # its ConfigMap, and the hostPath mount, but the container still references the
+    # profile by that path -- which must already exist on every node, or the pod will
+    # fail to start.
+    installSeccompProfile: true
 
     # JS-executor-specific environment; not inherited from the top-level
     # .Values.env / .Values.environmentSecrets / .Values.environmentVariables.


### PR DESCRIPTION
Requested for scenarios where the operator prefers to manage custom seccomp profiles out of band, so pods don't need sensitive host mounts.