### PR TITLE
networkPolicy: make blockCloudMetadataEgress opt-out discoverable

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.11.9
+version: 6.11.10
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/NOTES.txt
+++ b/charts/retool/templates/NOTES.txt
@@ -43,4 +43,20 @@ Ensure exactly one blob-storage provider is supplied another way (e.g. envFrom) 
 otherwise git operations will FAIL at runtime. git_server stores all objects/packs
 in blob storage.
 ***************************************************************************
-{{- end }} 
+{{- end }}
+{{- if and .Release.IsInstall (eq (include "retool.networkPolicy.blockMetadata.enabled" .) "1") }}
+
+***************************************************************************
+NOTE: blob storage is keyless, so the metadata-egress NetworkPolicy is ENABLED
+(networkPolicy.blockCloudMetadataEgress). Backend pods can no longer reach the
+cloud instance-metadata endpoint (169.254.169.254).
+
+No action needed for EKS IRSA / GKE Workload Identity / Azure Workload Identity --
+those obtain credentials from a projected token, not the metadata service.
+
+But if blob storage authenticates via an EC2 instance profile, a GCE default
+service account, or an Azure IMDS-based managed identity, those read credentials
+FROM 169.254.169.254 and will FAIL. In that case set:
+  networkPolicy.blockCloudMetadataEgress: false
+***************************************************************************
+{{- end }}

--- a/charts/retool/templates/NOTES.txt
+++ b/charts/retool/templates/NOTES.txt
@@ -47,7 +47,7 @@ in blob storage.
 {{- if and .Release.IsInstall (eq (include "retool.networkPolicy.blockMetadata.enabled" .) "1") }}
 
 ***************************************************************************
-NOTE: blob storage is keyless, so the metadata-egress NetworkPolicy is ENABLED
+NOTE: metadata-egress blocking is enabled for backend pods
 (networkPolicy.blockCloudMetadataEgress). Backend pods can no longer reach the
 cloud instance-metadata endpoint (169.254.169.254).
 

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -272,15 +272,19 @@ networkPolicy:
   #
   # Tri-state:
   #   null (default) -> auto: ON when blob storage is keyless (no static
-  #                     credential set), OFF otherwise. Keyless auth (S3 IRSA /
-  #                     GCS Workload Identity / Azure managed identity) resolves
-  #                     credentials via a projected token file + the provider
-  #                     STS/IAM endpoint, NOT the metadata service, so blocking
-  #                     metadata is safe and is the recommended pairing.
+  #                     credential set), OFF otherwise.
   #   true / false   -> force on/off.
   #
-  # Do NOT enable if the backend relies on the metadata endpoint for credentials
-  # (e.g. an IAM-role data source connection using the instance profile).
+  # Auto-ON is safe for TOKEN-FEDERATED identities (EKS IRSA, GKE Workload
+  # Identity, Azure Workload Identity): they resolve credentials via a projected
+  # token file + the provider STS/IAM endpoint, not the metadata service.
+  #
+  # But "no static credential" also covers METADATA-BASED identities that the
+  # block breaks. Set this to false if blob storage authenticates via an EC2
+  # instance profile, a GCE default service account, or an Azure IMDS-based
+  # managed identity -- those read credentials from 169.254.169.254 and are
+  # misdetected as keyless. Also set false if a data source connection relies on
+  # the metadata endpoint (e.g. an IAM-role connection using the instance profile).
   # Defense in depth -- pair with IMDS hop-limit=1 at the node level and the
   # application-layer SSRF filter.
   blockCloudMetadataEgress: null

--- a/values.yaml
+++ b/values.yaml
@@ -272,15 +272,19 @@ networkPolicy:
   #
   # Tri-state:
   #   null (default) -> auto: ON when blob storage is keyless (no static
-  #                     credential set), OFF otherwise. Keyless auth (S3 IRSA /
-  #                     GCS Workload Identity / Azure managed identity) resolves
-  #                     credentials via a projected token file + the provider
-  #                     STS/IAM endpoint, NOT the metadata service, so blocking
-  #                     metadata is safe and is the recommended pairing.
+  #                     credential set), OFF otherwise.
   #   true / false   -> force on/off.
   #
-  # Do NOT enable if the backend relies on the metadata endpoint for credentials
-  # (e.g. an IAM-role data source connection using the instance profile).
+  # Auto-ON is safe for TOKEN-FEDERATED identities (EKS IRSA, GKE Workload
+  # Identity, Azure Workload Identity): they resolve credentials via a projected
+  # token file + the provider STS/IAM endpoint, not the metadata service.
+  #
+  # But "no static credential" also covers METADATA-BASED identities that the
+  # block breaks. Set this to false if blob storage authenticates via an EC2
+  # instance profile, a GCE default service account, or an Azure IMDS-based
+  # managed identity -- those read credentials from 169.254.169.254 and are
+  # misdetected as keyless. Also set false if a data source connection relies on
+  # the metadata endpoint (e.g. an IAM-role connection using the instance profile).
   # Defense in depth -- pair with IMDS hop-limit=1 at the node level and the
   # application-layer SSRF filter.
   blockCloudMetadataEgress: null


### PR DESCRIPTION
## problem

`networkPolicy.blockCloudMetadataEgress` (added in 6.11.9) auto-enables whenever blob storage is **keyless** — detected as "no static credential set." That heuristic is an over-approximation:

- **token-federated** identities (EKS IRSA, GKE Workload Identity, Azure Workload Identity) get creds from a projected token + the provider STS/IAM endpoint, never `169.254.169.254` → safe to block ✅
- **metadata-based** identities (EC2 instance profile, GCE default service account, Azure IMDS-based managed identity) also have "no static credential," but they fetch creds **from `169.254.169.254`** → the auto-block **silently breaks blob storage** ❌

The two helpers even contradict each other: `retool.blobStorage.keyless` lists "instance profile" as a keyless mode, while `retool.networkPolicy.blockMetadata.enabled` asserts keyless "never [uses] the metadata service." The values comment only warned about *data sources* using the metadata endpoint, not blob-storage auth itself — so an instance-profile user gets no signal.

## approach

Per discussion, **don't** try to detect the auth form (fragile). Keep the auto-enable as-is and just make the opt-out impossible to miss:

- **NOTES.txt** — print a note **on install only** (`.Release.IsInstall`, so it doesn't nag on every `helm upgrade`) when the block is active: no-op for IRSA/WI, but if blob storage uses instance profile / default SA / IMDS managed identity, set `blockCloudMetadataEgress: false`.
- **values.yaml** — fix the comment (the STS/IAM claim only holds for token-federated auth) and spell out exactly when to set `false`. Applied to both synced copies.

No behavior change to the auto-enable — discoverability only.

## verification

```
helm install … (keyless)  -> NOTES block shown
helm upgrade … (keyless)  -> silent (install-only gate)
static-credential install -> block + NOTES both absent
```
NetworkPolicy still renders and denies `169.254.169.254/32` for keyless. `helm lint` clean; both values.yaml copies in sync.

Chart bumped `6.11.9 -> 6.11.10`.

## follow-up (not in this PR)

The docs already carry the same opt-out guidance (tryretool/docs#2997). Longer term, the *robust* fix is to gate auto-enable on a positive federated-identity signal (IRSA annotation / WI label) rather than absence of a static key — but that's a behavior change for a separate discussion.