### PR TITLE
[chore][INF-7329] Allow selectively sending telemetry inputs to Retool

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.11.10
+version: 6.11.11
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.11.11
+version: 6.11.12
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/deployment_telemetry.yaml
+++ b/charts/retool/templates/deployment_telemetry.yaml
@@ -74,6 +74,10 @@ spec:
             value: {{ include "retool.telemetry.logSourcePodLabels" . | quote }}
           - name: RTEL_SEND_TO_RETOOL
             value: {{ .Values.telemetry.sendToRetool.enabled | quote }}
+          {{- if .Values.telemetry.sendToRetool.enabled }}
+          - name: RTEL_SEND_TO_RETOOL_INPUT_ALLOWLIST
+            value: {{ join "," .Values.telemetry.sendToRetool.inputs | quote }}
+          {{- end }}
           {{- if .Values.telemetry.extraEnv }}
           {{- .Values.telemetry.extraEnv | toYaml | nindent 10 }}
           {{- end }}

--- a/charts/retool/templates/deployment_telemetry.yaml
+++ b/charts/retool/templates/deployment_telemetry.yaml
@@ -75,6 +75,9 @@ spec:
           - name: RTEL_SEND_TO_RETOOL
             value: {{ .Values.telemetry.sendToRetool.enabled | quote }}
           {{- if .Values.telemetry.sendToRetool.enabled }}
+          {{- if not .Values.telemetry.sendToRetool.inputs }}
+          {{ fail "telemetry.sendToRetool.enabled is true, so telemetry.sendToRetool.inputs must contain at least one element" }}
+          {{- end }}
           - name: RTEL_SEND_TO_RETOOL_INPUT_ALLOWLIST
             value: {{ join "," .Values.telemetry.sendToRetool.inputs | quote }}
           {{- end }}

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -1549,7 +1549,8 @@ telemetry:
     address: "https://telemetry.retool.com:443"
 
     # Only relevant when `telemetry.sendToRetool.enabled = true`.
-    # Specify which inputs to send to Retool. Available inputs are:
+    # Specify which inputs to send to Retool. Must not be empty.
+    # Available inputs are:
     #   container_logs  - logs from all pods
     #   metrics         - app and infra metrics
     #   otlp_traces     - app request traces

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -1548,6 +1548,14 @@ telemetry:
     # Should not be changed except for chart testing.
     address: "https://telemetry.retool.com:443"
 
+    # Only relevant when `telemetry.sendToRetool.enabled = true`.
+    # Specify which inputs to send to Retool. Available inputs are:
+    #   container_logs  - logs from all pods
+    #   metrics         - app and infra metrics
+    #   otlp_traces     - app request traces
+    inputs:
+      - metrics
+
   image:
     repository: "tryretool/telemetry"
 

--- a/values.yaml
+++ b/values.yaml
@@ -1549,7 +1549,8 @@ telemetry:
     address: "https://telemetry.retool.com:443"
 
     # Only relevant when `telemetry.sendToRetool.enabled = true`.
-    # Specify which inputs to send to Retool. Available inputs are:
+    # Specify which inputs to send to Retool. Must not be empty.
+    # Available inputs are:
     #   container_logs  - logs from all pods
     #   metrics         - app and infra metrics
     #   otlp_traces     - app request traces

--- a/values.yaml
+++ b/values.yaml
@@ -1548,6 +1548,14 @@ telemetry:
     # Should not be changed except for chart testing.
     address: "https://telemetry.retool.com:443"
 
+    # Only relevant when `telemetry.sendToRetool.enabled = true`.
+    # Specify which inputs to send to Retool. Available inputs are:
+    #   container_logs  - logs from all pods
+    #   metrics         - app and infra metrics
+    #   otlp_traces     - app request traces
+    inputs:
+      - metrics
+
   image:
     repository: "tryretool/telemetry"
 


### PR DESCRIPTION
Counterpart to https://github.com/tryretool/retool_development/pull/67405: allow selectively enabling telemetry inputs to be sent to Retool when `telemetry.sendToRetool.enabled = true`, with only metrics enabled by default.

Note that collecting telemetry is still disabled by default.