### PR TITLE
[docs][MCP] Document simplified ingress for Retool 4.0.7+

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.11.12
+version: 6.11.13
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.11.13
+version: 6.11.12
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -731,8 +731,21 @@ mcp:
       annotations: {}
       labels: {}
 
-  # Public MCP routes, rendered before the main Retool route. External ingress
-  # must preserve this order and target mapping:
+  # Retool 4.0.7 and later support a simplified ingress setup: route all public
+  # paths, including /mcp and /.well-known, to the main Retool Service on port
+  # 3000. The main backend must also be able to relay /mcp to the in-cluster MCP
+  # Service. Set its internal URL through the top-level env block:
+  #
+  #   env:
+  #     MCP_SERVICE_INGRESS_DOMAIN: http://<fullname>-mcp:4010
+  #
+  # With that backend setting, omit or disable the MCP-specific ingress or
+  # HTTPRoute rules below and keep only the normal "/" route to
+  # <fullname>:3000. Replace <fullname> with this chart release's full name.
+  #
+  # Retool versions before 4.0.7 require the explicit MCP routes below,
+  # rendered before the main Retool route. External ingress must preserve this
+  # order and target mapping:
   #   Exact  /.well-known/oauth-authorization-server -> <fullname>-backend-internal:3001
   #   Exact  /.well-known/oauth-protected-resource    -> <fullname>-mcp:4010
   #   Prefix /mcp                                     -> <fullname>-mcp:4010

--- a/values.yaml
+++ b/values.yaml
@@ -731,8 +731,21 @@ mcp:
       annotations: {}
       labels: {}
 
-  # Public MCP routes, rendered before the main Retool route. External ingress
-  # must preserve this order and target mapping:
+  # Retool 4.0.7 and later support a simplified ingress setup: route all public
+  # paths, including /mcp and /.well-known, to the main Retool Service on port
+  # 3000. The main backend must also be able to relay /mcp to the in-cluster MCP
+  # Service. Set its internal URL through the top-level env block:
+  #
+  #   env:
+  #     MCP_SERVICE_INGRESS_DOMAIN: http://<fullname>-mcp:4010
+  #
+  # With that backend setting, omit or disable the MCP-specific ingress or
+  # HTTPRoute rules below and keep only the normal "/" route to
+  # <fullname>:3000. Replace <fullname> with this chart release's full name.
+  #
+  # Retool versions before 4.0.7 require the explicit MCP routes below,
+  # rendered before the main Retool route. External ingress must preserve this
+  # order and target mapping:
   #   Exact  /.well-known/oauth-authorization-server -> <fullname>-backend-internal:3001
   #   Exact  /.well-known/oauth-protected-resource    -> <fullname>-mcp:4010
   #   Prefix /mcp                                     -> <fullname>-mcp:4010


### PR DESCRIPTION
## Summary

- document that Retool 4.0.7+ can route `/mcp`, OAuth discovery, and normal application traffic through the main Retool Service on port 3000
- document the required backend setting `MCP_SERVICE_INGRESS_DOMAIN=http://<fullname>-mcp:4010`
- retain the explicit 3001/4010 path mapping for Retool versions before 4.0.7

## Testing

- `helm lint charts/retool`
- `helm lint charts/retool -f charts/retool/ci/test-mcp-enabled-option.yaml`
- rendered the simplified setup with the MCP-specific Ingress and HTTPRoute rules disabled
- verified the backend receives `MCP_SERVICE_INGRESS_DOMAIN` and no public `/mcp` path is rendered
- verified `values.yaml` and `charts/retool/values.yaml` remain identical
- `git diff --check`