### PR TITLE
[chore][MCP] Configure backend MCP service ingress domain

### DIFF
--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -52,6 +52,26 @@ env.BASE_DOMAIN. Secret-backed values cannot be resolved at template time.
 {{- end }}
 
 {{/*
+MCP Service env var for the main Retool backend. Explicit backend env settings
+take precedence over the chart-generated in-cluster Service URL.
+*/}}
+{{- define "retool.mcp.backendEnvVars" -}}
+{{- if .Values.mcp.enabled }}
+{{- $backendHasMcpServiceIngressDomain := hasKey (.Values.env | default dict) "MCP_SERVICE_INGRESS_DOMAIN" -}}
+{{- range .Values.environmentVariables }}
+{{- if eq .name "MCP_SERVICE_INGRESS_DOMAIN" }}
+{{- $backendHasMcpServiceIngressDomain = true }}
+{{- end }}
+{{- end }}
+{{- if not $backendHasMcpServiceIngressDomain }}
+{{- $mcpService := .Values.mcp.service | default dict }}
+- name: MCP_SERVICE_INGRESS_DOMAIN
+  value: {{ printf "http://%s:%v" (include "retool.mcp.name" .) ($mcpService.externalPort | default 4010) | quote }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Render an MCP-related Ingress path. By default paths route to the MCP service.
 target: backendInternal routes to the backend API Service.
 */}}

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -170,6 +170,7 @@ spec:
           - name: CODE_EXECUTOR_INGRESS_DOMAIN
             value: http://{{ template "retool.codeExecutor.name" . }}
           {{- end }}
+          {{- include "retool.mcp.backendEnvVars" . | nindent 10 }}
           {{- include "retool.agentSandbox.backendEnvVars" . | nindent 10 }}
           {{- if ($temporalConfig).sslEnabled }}
           - name: WORKFLOW_TEMPORAL_TLS_ENABLED

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -734,14 +734,14 @@ mcp:
   # Retool 4.0.7 and later support a simplified ingress setup: route all public
   # paths, including /mcp and /.well-known, to the main Retool Service on port
   # 3000. The main backend must also be able to relay /mcp to the in-cluster MCP
-  # Service. Set its internal URL through the top-level env block:
+  # Service. When mcp.enabled is true, the chart configures the backend with
+  # MCP_SERVICE_INGRESS_DOMAIN=http://<fullname>-mcp:<service.externalPort>.
+  # You can override it through the top-level env, environmentSecrets, or
+  # environmentVariables settings.
   #
-  #   env:
-  #     MCP_SERVICE_INGRESS_DOMAIN: http://<fullname>-mcp:4010
-  #
-  # With that backend setting, omit or disable the MCP-specific ingress or
-  # HTTPRoute rules below and keep only the normal "/" route to
-  # <fullname>:3000. Replace <fullname> with this chart release's full name.
+  # With that setting, omit or disable the MCP-specific ingress or HTTPRoute
+  # rules below and keep only the normal "/" route to <fullname>:3000. Replace
+  # <fullname> with this chart release's full name.
   #
   # Retool versions before 4.0.7 require the explicit MCP routes below,
   # rendered before the main Retool route. External ingress must preserve this

--- a/values.yaml
+++ b/values.yaml
@@ -734,14 +734,14 @@ mcp:
   # Retool 4.0.7 and later support a simplified ingress setup: route all public
   # paths, including /mcp and /.well-known, to the main Retool Service on port
   # 3000. The main backend must also be able to relay /mcp to the in-cluster MCP
-  # Service. Set its internal URL through the top-level env block:
+  # Service. When mcp.enabled is true, the chart configures the backend with
+  # MCP_SERVICE_INGRESS_DOMAIN=http://<fullname>-mcp:<service.externalPort>.
+  # You can override it through the top-level env, environmentSecrets, or
+  # environmentVariables settings.
   #
-  #   env:
-  #     MCP_SERVICE_INGRESS_DOMAIN: http://<fullname>-mcp:4010
-  #
-  # With that backend setting, omit or disable the MCP-specific ingress or
-  # HTTPRoute rules below and keep only the normal "/" route to
-  # <fullname>:3000. Replace <fullname> with this chart release's full name.
+  # With that setting, omit or disable the MCP-specific ingress or HTTPRoute
+  # rules below and keep only the normal "/" route to <fullname>:3000. Replace
+  # <fullname> with this chart release's full name.
   #
   # Retool versions before 4.0.7 require the explicit MCP routes below,
   # rendered before the main Retool route. External ingress must preserve this


### PR DESCRIPTION
## Summary

- Inject MCP_SERVICE_INGRESS_DOMAIN into the main backend when MCP is enabled.
- Derive the internal URL from the release-specific MCP Service name and configured external port.
- Preserve explicit overrides from env, environmentSecrets, or environmentVariables.
- Update both synchronized values.yaml files to document the automatic configuration.

## Testing

- helm lint charts/retool
- helm template with test-install-values.yaml and test-mcp-enabled-option.yaml
- Verified MCP-disabled, default, custom Service name/port, and explicit override renders
- Confirmed values.yaml and charts/retool/values.yaml remain synchronized
- git diff --check