### PR TITLE
[fix][R2-2346] Add terminationGracePeriodSeconds and preStop hook to agent-executor proxy

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.11.12
+version: 6.11.13
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/deployment_agent_sandbox.yaml
+++ b/charts/retool/templates/deployment_agent_sandbox.yaml
@@ -474,6 +474,7 @@ spec:
 {{ toYaml $as.labels | indent 8 }}
 {{- end }}
     spec:
+      terminationGracePeriodSeconds: 30
       automountServiceAccountToken: false
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
@@ -550,6 +551,10 @@ spec:
             - name: SANDBOX_PROXY_TIMEOUT_MS
               value: {{ $as.proxy.sandboxProxyTimeoutMs | quote }}
             {{- end }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "5"]
           livenessProbe:
             httpGet:
               path: /livez


### PR DESCRIPTION
## Summary

- Adds `terminationGracePeriodSeconds: 30` to the agent-executor proxy pod spec
- Adds `lifecycle.preStop` sleep of 5s to the proxy container

Without `terminationGracePeriodSeconds`, kubelet's default 30s still applies but there's no `preStop` hook, so SIGTERM can arrive before kube-proxy finishes removing the endpoint — new connections still route to the terminating pod. The `preStop` sleep covers that gap, and `terminationGracePeriodSeconds: 30` ensures kubelet doesn't SIGKILL during the drain window (proxy has a 10s `DRAIN_TIMEOUT_MS`).

Closes R2-2346.

## Test Plan
- [ ] CI green
- [ ] `helm template` diff shows only the two new fields on the proxy deployment, not the controller