### PR TITLE
fix: Revert AGENT_SANDBOX env var renames to AGENT_EXECUTOR

### DIFF
--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -732,7 +732,7 @@ or the catch-all externalSecret.name. No-op when agentSandbox is disabled.
 {{- end -}}
 
 {{/*
-Render the AGENT_EXECUTOR_POSTGRES_URL env entry for the controller/proxy (plus a
+Render the AGENT_SANDBOX_POSTGRES_URL env entry for the controller/proxy (plus a
 PGPASSWORD entry when assembling from fields). validateSecrets guarantees one of
 these applies, in order: postgres.url -> postgres.host -> postgres.urlSecretName
 -> inherit the backend's config.postgresql connection (the default when nothing
@@ -755,7 +755,7 @@ Usage: {{- include "retool.agentSandbox.postgresUrlEnv" . | nindent 12 }}
 {{- define "retool.agentSandbox.postgresUrlEnv" -}}
 {{- $pg := .Values.rr.agentSandbox.postgres -}}
 {{- if $pg.url }}
-- name: AGENT_EXECUTOR_POSTGRES_URL
+- name: AGENT_SANDBOX_POSTGRES_URL
   value: {{ $pg.url | quote }}
 {{- else if $pg.host }}
 {{- $port := $pg.port | default 5432 -}}
@@ -769,10 +769,10 @@ Usage: {{- include "retool.agentSandbox.postgresUrlEnv" . | nindent 12 }}
 - name: PGPASSWORD
   value: {{ $pg.password | quote }}
 {{- end }}
-- name: AGENT_EXECUTOR_POSTGRES_URL
+- name: AGENT_SANDBOX_POSTGRES_URL
   value: {{ printf "postgres://%s@%s:%v/%s" $pg.user $pg.host $port $pg.database | quote }}
 {{- else if $pg.urlSecretName }}
-- name: AGENT_EXECUTOR_POSTGRES_URL
+- name: AGENT_SANDBOX_POSTGRES_URL
   valueFrom:
     secretKeyRef:
       name: {{ $pg.urlSecretName }}
@@ -817,7 +817,7 @@ Usage: {{- include "retool.agentSandbox.postgresUrlEnv" . | nindent 12 }}
       {{- end }}
 {{- /* inherit the backend's SSL too (mirror POSTGRES_SSL_ENABLED) */}}
 {{- $sslSuffix := ternary "?sslmode=no-verify" "" (eq (include "retool.postgresql.ssl_enabled" . | trimAll "\"") "true") }}
-- name: AGENT_EXECUTOR_POSTGRES_URL
+- name: AGENT_SANDBOX_POSTGRES_URL
   value: {{ printf "postgres://%s@%s:%s/%s%s" (include "retool.postgresql.user" . | trimAll "\"") (include "retool.postgresql.host" . | trimAll "\"") (include "retool.postgresql.port" . | trimAll "\"" | default "5432") (include "retool.postgresql.database" . | trimAll "\"") $sslSuffix | quote }}
 {{- end }}
 {{- end -}}

--- a/charts/retool/templates/deployment_agent_sandbox.yaml
+++ b/charts/retool/templates/deployment_agent_sandbox.yaml
@@ -201,9 +201,9 @@ data:
                   ,{"name": "SANDBOX_GLOBAL_LIFETIME_MS", "value": "{{ $as.sandbox.sandboxGlobalLifetimeMs }}"}
                   ,{"name": "SANDBOX_READY_TIMEOUT_MS", "value": "{{ $as.sandbox.sandboxReadyTimeoutMs }}"}
                   {{- if $as.jwtPublicKey }}
-                  ,{"name": "AGENT_EXECUTOR_JWT_PUBLIC_KEY", "value": {{ $as.jwtPublicKey | toJson }}}
+                  ,{"name": "AGENT_SANDBOX_JWT_PUBLIC_KEY", "value": {{ $as.jwtPublicKey | toJson }}}
                   {{- else if $as.externalSecret.name }}
-                  ,{"name": "AGENT_EXECUTOR_JWT_PUBLIC_KEY", "valueFrom": {"secretKeyRef": {"name": "{{ $defaultSecretName }}", "key": "jwt-public-key"}}}
+                  ,{"name": "AGENT_SANDBOX_JWT_PUBLIC_KEY", "valueFrom": {"secretKeyRef": {"name": "{{ $defaultSecretName }}", "key": "jwt-public-key"}}}
                   {{- end }}
                   {{- if $as.proxy.backendDomainSuffixes }}
                   ,{"name": "BACKEND_DOMAIN_SUFFIXES", "value": "{{ $as.proxy.backendDomainSuffixes }}"}
@@ -325,16 +325,16 @@ spec:
           env:
             - name: NODE_ENV
               value: "production"
-            - name: AGENT_EXECUTOR_ROLE
+            - name: AGENT_SANDBOX_ROLE
               value: "controller"
             - name: CONTROLLER_PORT
               value: {{ $as.controller.port | quote }}
             - name: STATE_BACKEND
               value: "postgres"
             {{- include "retool.agentSandbox.postgresUrlEnv" . | nindent 12 }}
-            - name: AGENT_EXECUTOR_POSTGRES_SCHEMA
+            - name: AGENT_SANDBOX_POSTGRES_SCHEMA
               value: {{ $as.postgres.schema | quote }}
-            - name: AGENT_EXECUTOR_POSTGRES_POOL_MAX
+            - name: AGENT_SANDBOX_POSTGRES_POOL_MAX
               value: {{ $as.postgres.poolMax | quote }}
             - name: STATE_SWEEPER_INTERVAL_MS
               value: {{ $as.postgres.sweeperIntervalMs | quote }}
@@ -379,10 +379,10 @@ spec:
             - name: DAEMONSET_NAME
               value: {{ include "retool.agentSandbox.name" . }}-image-prepuller
             {{- if $as.jwtPublicKey }}
-            - name: AGENT_EXECUTOR_JWT_PUBLIC_KEY
+            - name: AGENT_SANDBOX_JWT_PUBLIC_KEY
               value: {{ $as.jwtPublicKey | quote }}
             {{- else if $as.externalSecret.name }}
-            - name: AGENT_EXECUTOR_JWT_PUBLIC_KEY
+            - name: AGENT_SANDBOX_JWT_PUBLIC_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ $defaultSecretName }}
@@ -531,16 +531,16 @@ spec:
           env:
             - name: NODE_ENV
               value: "production"
-            - name: AGENT_EXECUTOR_ROLE
+            - name: AGENT_SANDBOX_ROLE
               value: "proxy"
             - name: PROXY_PORT
               value: {{ $as.proxy.port | quote }}
             - name: STATE_BACKEND
               value: "postgres"
             {{- include "retool.agentSandbox.postgresUrlEnv" . | nindent 12 }}
-            - name: AGENT_EXECUTOR_POSTGRES_SCHEMA
+            - name: AGENT_SANDBOX_POSTGRES_SCHEMA
               value: {{ $as.postgres.schema | quote }}
-            - name: AGENT_EXECUTOR_POSTGRES_POOL_MAX
+            - name: AGENT_SANDBOX_POSTGRES_POOL_MAX
               value: {{ $as.postgres.poolMax | quote }}
             - name: STATE_SWEEPER_INTERVAL_MS
               value: {{ $as.postgres.sweeperIntervalMs | quote }}
@@ -555,20 +555,20 @@ spec:
               value: {{ $as.proxy.backendDomainSuffixes | quote }}
             {{- end }}
             {{- if $as.encryptionKey }}
-            - name: AGENT_EXECUTOR_ENCRYPTION_KEY
+            - name: AGENT_SANDBOX_ENCRYPTION_KEY
               value: {{ $as.encryptionKey | quote }}
             {{- else if $as.externalSecret.name }}
-            - name: AGENT_EXECUTOR_ENCRYPTION_KEY
+            - name: AGENT_SANDBOX_ENCRYPTION_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ $defaultSecretName }}
                   key: encryption-key
             {{- end }}
             {{- if $as.jwtPublicKey }}
-            - name: AGENT_EXECUTOR_JWT_PUBLIC_KEY
+            - name: AGENT_SANDBOX_JWT_PUBLIC_KEY
               value: {{ $as.jwtPublicKey | quote }}
             {{- else if $as.externalSecret.name }}
-            - name: AGENT_EXECUTOR_JWT_PUBLIC_KEY
+            - name: AGENT_SANDBOX_JWT_PUBLIC_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ $defaultSecretName }}


### PR DESCRIPTION
## Summary

Reverts the incorrect `AGENT_SANDBOX_*` → `AGENT_EXECUTOR_*` env var renames that were included in #353. The application expects `AGENT_SANDBOX_*` names.

Changes:
- `AGENT_EXECUTOR_POSTGRES_URL` → `AGENT_SANDBOX_POSTGRES_URL`
- `AGENT_EXECUTOR_ROLE` → `AGENT_SANDBOX_ROLE`
- `AGENT_EXECUTOR_POSTGRES_SCHEMA` → `AGENT_SANDBOX_POSTGRES_SCHEMA`
- `AGENT_EXECUTOR_POSTGRES_POOL_MAX` → `AGENT_SANDBOX_POSTGRES_POOL_MAX`
- `AGENT_EXECUTOR_JWT_PUBLIC_KEY` → `AGENT_SANDBOX_JWT_PUBLIC_KEY`
- `AGENT_EXECUTOR_ENCRYPTION_KEY` → `AGENT_SANDBOX_ENCRYPTION_KEY`

Made with [Cursor](https://cursor.com)