### PR TITLE
fix: Decouple AppArmor nsjail installer DaemonSet from workflows.enabled

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.11.13
+version: 6.11.14
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/ci/test-apparmor-nsjail-option.yaml
+++ b/charts/retool/ci/test-apparmor-nsjail-option.yaml
@@ -6,9 +6,12 @@
 #   - container.apparmor.security.beta.kubernetes.io annotations switch from
 #     "unconfined" to "localhost/retool-executor" on code-executor and js-executor
 #
-# Requires codeExecutor.useSeccompProfile: true (the annotation block is
-# gated on it) and workflows.enabled or image.tag: "latest" (the DaemonSet
-# template is gated on retool.workflows.enabled).
+# Requires codeExecutor.useSeccompProfile: true (the code-executor annotation
+# block is gated on it). The DaemonSet/ConfigMap render whenever
+# appArmorProfileInstaller is true AND at least one consumer can use them:
+# workflows.enabled (or image.tag implying workflows support) for
+# code-executor, or rr.jsExecutor.enabled for js-executor -- independently of
+# workflows, since js-executor doesn't require workflows to be on.
 #
 # Overlaid on test-install-values.yaml.
 

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -410,6 +410,33 @@ Usage: (include "retool.workflows.enabled" .)
 {{- end -}}
 
 {{/*
+Resolve whether the shared nsjail AppArmor profile installer (ConfigMap +
+DaemonSet, see apparmor_nsjail_configmap.yaml / apparmor_nsjail_daemonset.yaml)
+should render. That installer is consumed by two independent components that
+both switch their container.apparmor.security.beta.kubernetes.io annotation
+from "unconfined" to "localhost/retool-executor" when
+codeExecutor.appArmorProfileInstaller is set: the legacy code-executor (only
+rendered when workflows are enabled) and the RR js-executor (rendered
+whenever rr.jsExecutor is enabled, independent of workflows). The installer
+must render whenever either consumer needs it, so it is intentionally NOT
+gated on retool.workflows.enabled alone -- doing so would leave js-executor's
+wait-for-apparmor init container waiting forever on a DaemonSet that never
+gets created when workflows are disabled.
+Usage: (include "retool.appArmorNsjailInstaller.enabled" .)
+Returns "1" when it should render, "" otherwise.
+*/}}
+{{- define "retool.appArmorNsjailInstaller.enabled" -}}
+{{- $output := "" -}}
+{{- if .Values.codeExecutor.appArmorProfileInstaller -}}
+  {{- $jsExecutorEnabled := eq (include "retool.rr.componentEnabled" (dict "root" . "component" "jsExecutor")) "1" -}}
+  {{- if or (include "retool.workflows.enabled" .) $jsExecutorEnabled -}}
+    {{- $output = "1" -}}
+  {{- end -}}
+{{- end -}}
+{{- $output -}}
+{{- end -}}
+
+{{/*
 Set agents enabled
 Usage: (include "retool.agents.enabled" .)
 */}}

--- a/charts/retool/templates/apparmor_nsjail_configmap.yaml
+++ b/charts/retool/templates/apparmor_nsjail_configmap.yaml
@@ -1,5 +1,4 @@
-{{- if include "retool.workflows.enabled" . }}
-{{- if .Values.codeExecutor.appArmorProfileInstaller }}
+{{- if eq (include "retool.appArmorNsjailInstaller.enabled" .) "1" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -47,5 +46,4 @@ data:
       deny /sys/devices/virtual/powercap/** rwklx,
       deny /sys/kernel/security/** rwklx,
     }
-{{- end }}
 {{- end }}

--- a/charts/retool/templates/apparmor_nsjail_daemonset.yaml
+++ b/charts/retool/templates/apparmor_nsjail_daemonset.yaml
@@ -1,5 +1,4 @@
-{{- if include "retool.workflows.enabled" . }}
-{{- if .Values.codeExecutor.appArmorProfileInstaller }}
+{{- if eq (include "retool.appArmorNsjailInstaller.enabled" .) "1" }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -90,5 +89,4 @@ spec:
           hostPath:
             path: /run/retool/apparmor
             type: DirectoryOrCreate
-{{- end }}
 {{- end }}

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -834,7 +834,11 @@ codeExecutor:
   # When enabled, the code-executor and js-executor annotations switch from
   # "unconfined" to "localhost/retool-executor", which satisfies Ubuntu 24.04+'s
   # kernel.apparmor_restrict_unprivileged_userns=1 restriction by providing an
-  # explicit userns rule. Requires useSeccompProfile: true to take effect.
+  # explicit userns rule. Requires useSeccompProfile: true for code-executor to
+  # take effect (js-executor always uses the seccomp/AppArmor path). The
+  # DaemonSet itself renders whenever this is true and either workflows is
+  # enabled (for code-executor) or rr.jsExecutor is enabled -- it is not tied
+  # to workflows alone, since js-executor doesn't require workflows to run.
   appArmorProfileInstaller: false
 
 # === RR (Retool agent runtime) =============================================

--- a/values.yaml
+++ b/values.yaml
@@ -834,7 +834,11 @@ codeExecutor:
   # When enabled, the code-executor and js-executor annotations switch from
   # "unconfined" to "localhost/retool-executor", which satisfies Ubuntu 24.04+'s
   # kernel.apparmor_restrict_unprivileged_userns=1 restriction by providing an
-  # explicit userns rule. Requires useSeccompProfile: true to take effect.
+  # explicit userns rule. Requires useSeccompProfile: true for code-executor to
+  # take effect (js-executor always uses the seccomp/AppArmor path). The
+  # DaemonSet itself renders whenever this is true and either workflows is
+  # enabled (for code-executor) or rr.jsExecutor is enabled -- it is not tied
+  # to workflows alone, since js-executor doesn't require workflows to run.
   appArmorProfileInstaller: false
 
 # === RR (Retool agent runtime) =============================================


### PR DESCRIPTION
## Summary
Fixes an AppArmor installer gate mismatch flagged by Greptile on PR #355 (https://github.com/tryretool/retool-helm/pull/355#discussion_r3693002203): when `rr.jsExecutor.enabled=true` and `codeExecutor.appArmorProfileInstaller=true` but `workflows.enabled=false`, the js-executor pod's `wait-for-apparmor` init container polls forever for `/host-run/retool-executor.loaded`, but the DaemonSet that creates that file (`apparmor_nsjail_daemonset.yaml`) was gated on `retool.workflows.enabled` and never rendered — so js-executor pods hang in Init forever.

`rr.jsExecutor` is an independent RR component that does not require `workflows.enabled` to be true, so gating the shared AppArmor installer DaemonSet/ConfigMap on `workflows.enabled` alone was incorrect; it needs to render whenever EITHER of its two consumers needs it (legacy `code-executor`, which is workflows-gated, OR RR `js-executor`, which is not).

## Changes
- Added a new helper `retool.appArmorNsjailInstaller.enabled` in `_helpers.tpl` that returns "1" when `codeExecutor.appArmorProfileInstaller` is true AND either `retool.workflows.enabled` OR `rr.jsExecutor` is enabled.
- `apparmor_nsjail_daemonset.yaml` and `apparmor_nsjail_configmap.yaml` now gate on this new helper instead of the old `workflows.enabled` + `appArmorProfileInstaller` double-if.
- Updated doc comments in `values.yaml` and `charts/retool/ci/test-apparmor-nsjail-option.yaml` to describe the corrected gating logic.
- No other AppArmor config was affected — `rr.agentSandbox.appArmorProfileInstaller` (used by the separate gVisor-based agent-sandbox node-installer DaemonSet) was already self-contained and gated purely on its own component-enabled check, so it did not have this bug.

## Testing
- `helm lint` and `helm template` against all existing `charts/retool/ci/*option.yaml` overlays pass with no changes in behavior for existing configurations.
- Verified via `helm template` that the new gate correctly handles all 4 combinations of (`workflows.enabled`, `rr.jsExecutor.enabled`) x (`codeExecutor.appArmorProfileInstaller` true/false) — renders only when the flag is true AND at least one consumer is enabled; unaffected when neither consumer needs it.
- Live end-to-end validation on a real AKS cluster (Ubuntu 24.04, `kernel.apparmor_restrict_unprivileged_userns=1`): deployed just the DaemonSet + ConfigMap + js-executor Deployment into an isolated test namespace with `workflows.enabled: false`. Confirmed the DaemonSet still rolls out and loads the AppArmor profile on every node (`AppArmor profiles loaded successfully` in the `install` init container logs), and the js-executor pod's `wait-for-apparmor` init container completed instantly (Terminated/Completed, not hung) because the profile file was already present — the pod reached `1/1 Running` with the `container.apparmor.security.beta.kubernetes.io/js-executor: localhost/retool-executor` annotation correctly applied (confined, not unconfined). Test namespace was torn down afterward; the real deployed `retool` Helm release on that cluster was untouched throughout.
