### PR TITLE
[fix] Render blob storage env vars on the jobs runner deploymentFix/jobs runner blob storage env

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.11.12
+version: 6.11.13
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.11.14
+version: 6.11.15
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/deployment_jobs.yaml
+++ b/charts/retool/templates/deployment_jobs.yaml
@@ -186,11 +186,6 @@ spec:
           {{- end }}
           {{- end }}
           {{- if eq (include "retool.gitServer.enabled" .) "1" }}
-          {{- /*
-            Source-control sync for new-app-builder apps runs here and talks to
-            blob storage directly, so the jobs runner needs these vars even when
-            the git server is a separate deployment.
-          */}}
           {{- include "retool.gitServer.commonEnv" . | nindent 10 }}
           {{- end }}
           {{- include "retool.env" .Values.env | nindent 10 }}

--- a/charts/retool/templates/deployment_jobs.yaml
+++ b/charts/retool/templates/deployment_jobs.yaml
@@ -185,6 +185,14 @@ spec:
                 {{- end }}
           {{- end }}
           {{- end }}
+          {{- if eq (include "retool.gitServer.enabled" .) "1" }}
+          {{- /*
+            Source-control sync for new-app-builder apps runs here and talks to
+            blob storage directly, so the jobs runner needs these vars even when
+            the git server is a separate deployment.
+          */}}
+          {{- include "retool.gitServer.commonEnv" . | nindent 10 }}
+          {{- end }}
           {{- include "retool.env" .Values.env | nindent 10 }}
           {{- range .Values.environmentSecrets }}
           - name: {{ .name }}


### PR DESCRIPTION
**Problem**

With jobRunner.enabled: true and rr.blobStorage correctly configured, syncing a protected new-app-builder (R2) app fails with:

  Failed to sync app: Required environment variable RR_DEFAULT_S3_BUCKET is not set

  This happens regardless of provider — Azure and GCS users see the S3-flavored error too, because the backend defaults RR_BLOB_STORAGE_PROVIDER to s3 when the variable is absent.

  **Root cause**

  The retool.gitServer.commonEnv helper (which derives RR_BLOB_STORAGE_PROVIDER / RR_DEFAULT_* from rr.blobStorage) is included in deployment_backend.yaml, deployment_git_server.yaml, and the temporal worker template — but not in deployment_jobs.yaml. Source-control sync for protected R2 apps runs on the jobs runner and reads/writes git objects in blob storage directly, so a split-out jobs runner pod has no blob storage configuration at all and falls through to the S3 default.

  Deployments where the jobs runner runs inside the main backend pod are unaffected, which is why this only surfaces with jobRunner.enabled: true. This has caused several support escalations; the workaround until now was duplicating the three variables into top-level environmentVariables / environmentSecrets.

  **Fix**

  Include retool.gitServer.commonEnv in the jobs runner env block, gated on retool.gitServer.enabled — the same gate deployment_backend.yaml uses. Unlike the backend, the include is not skipped when rr.gitServer.separate.enabled is true: the backend proxies git operations to the standalone git server in that mode, but the jobs runner talks to blob storage directly and needs the vars in both modes.

