### PR TITLE
[fix][plat] Allow for npm registry env vars to be set

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.11.18
+version: 6.11.19
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -783,6 +783,9 @@ or the catch-all externalSecret.name. No-op when agentSandbox is disabled.
 {{- if and $npm.authTokenSecret.name (not $npm.authTokenSecret.key) -}}
 {{- fail "agentSandbox.proxy.npmRegistry.authTokenSecret.name is set without .key, which would render an empty secretKeyRef and leave the proxy unable to start. Set .key to the entry holding the registry token." -}}
 {{- end -}}
+{{- if and $npm.authToken $npm.authTokenSecret.name -}}
+{{- fail "agentSandbox.proxy.npmRegistry sets both authToken and authTokenSecret. The inline value wins and the Secret is never read, so the proxy would use a credential you may not have intended. Set exactly one." -}}
+{{- end -}}
 {{- if and (eq $npm.authMode "bearer") (not (or $npm.authToken $npm.authTokenSecret.name $npm.authTokenFile)) -}}
 {{- fail "agentSandbox.proxy.npmRegistry.url is set with authMode \"bearer\" but no credential. The proxy fails closed, so every package install would 503. Supply authToken / authTokenSecret / authTokenFile, or set authMode: none for a registry that allows anonymous reads." -}}
 {{- end -}}

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -775,6 +775,18 @@ or the catch-all externalSecret.name. No-op when agentSandbox is disabled.
 {{- if not (or $as.encryptionKey $ext) -}}
 {{- fail "agentSandbox.enabled requires an encryption key: the proxy derives the sandbox-iframe asset-token HMAC key from it and throws when serving a sandbox without it, and the backend must use the same value. Set agentSandbox.encryptionKey (64 hex chars, openssl rand -hex 32) or agentSandbox.externalSecret.name (with an encryption-key entry)." -}}
 {{- end -}}
+{{- $npm := $as.proxy.npmRegistry -}}
+{{- if not (has $npm.authMode (list "bearer" "none")) -}}
+{{- fail (printf "agentSandbox.proxy.npmRegistry.authMode must be \"bearer\" or \"none\" (got %q). The proxy rejects any other value at startup." $npm.authMode) -}}
+{{- end -}}
+{{- if $npm.url -}}
+{{- if and $npm.authTokenSecret.name (not $npm.authTokenSecret.key) -}}
+{{- fail "agentSandbox.proxy.npmRegistry.authTokenSecret.name is set without .key, which would render an empty secretKeyRef and leave the proxy unable to start. Set .key to the entry holding the registry token." -}}
+{{- end -}}
+{{- if and (eq $npm.authMode "bearer") (not (or $npm.authToken $npm.authTokenSecret.name $npm.authTokenFile)) -}}
+{{- fail "agentSandbox.proxy.npmRegistry.url is set with authMode \"bearer\" but no credential. The proxy fails closed, so every package install would 503. Supply authToken / authTokenSecret / authTokenFile, or set authMode: none for a registry that allows anonymous reads." -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/retool/templates/deployment_agent_sandbox.yaml
+++ b/charts/retool/templates/deployment_agent_sandbox.yaml
@@ -582,6 +582,30 @@ spec:
             - name: SANDBOX_PROXY_TIMEOUT_MS
               value: {{ $as.proxy.sandboxProxyTimeoutMs | quote }}
             {{- end }}
+            {{- if $as.proxy.npmRegistry.url }}
+            - name: NPM_PUBLIC_REGISTRY_URL
+              value: {{ $as.proxy.npmRegistry.url | quote }}
+            - name: NPM_PUBLIC_REGISTRY_AUTH_MODE
+              value: {{ $as.proxy.npmRegistry.authMode | quote }}
+            {{- if $as.proxy.npmRegistry.authToken }}
+            - name: NPM_PUBLIC_REGISTRY_AUTH_TOKEN
+              value: {{ $as.proxy.npmRegistry.authToken | quote }}
+            {{- else if $as.proxy.npmRegistry.authTokenSecret.name }}
+            - name: NPM_PUBLIC_REGISTRY_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $as.proxy.npmRegistry.authTokenSecret.name }}
+                  key: {{ $as.proxy.npmRegistry.authTokenSecret.key }}
+            {{- end }}
+            {{- if $as.proxy.npmRegistry.authTokenFile }}
+            - name: NPM_PUBLIC_REGISTRY_AUTH_TOKEN_FILE
+              value: {{ $as.proxy.npmRegistry.authTokenFile | quote }}
+            {{- end }}
+            {{- if $as.proxy.npmRegistry.authTokenTtlMs }}
+            - name: NPM_PUBLIC_REGISTRY_AUTH_TOKEN_TTL_MS
+              value: {{ $as.proxy.npmRegistry.authTokenTtlMs | quote }}
+            {{- end }}
+            {{- end }}
           lifecycle:
             preStop:
               exec:

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -1145,6 +1145,28 @@ rr:
       backendUrl: ''
       backendDomainSuffixes: ''
       sandboxProxyTimeoutMs: '180000'  # 3 minutes
+      # Where the proxy fetches public npm packages. Leave url empty to use
+      # registry.npmjs.org. Set it to an internal mirror when sandboxes have no public
+      # npm egress — note the *proxy pod* dials it, not the sandboxes, so that is the
+      # only network path that has to reach the mirror.
+      #
+      # Requests are read-only regardless: the sandbox may GET/HEAD and nothing else.
+      npmRegistry:
+        url: ''
+        # bearer | none. `bearer` (the default) attaches a token and refuses to send
+        # the request at all when none is available, so a Secret that fails to mount
+        # can't silently downgrade to unauthenticated. Use `none` only for a mirror
+        # that genuinely allows anonymous reads.
+        authMode: bearer
+        # Credential for authMode: bearer. Inline, or from an existing Secret, or from
+        # a mounted file. Prefer the file when the token rotates — it is re-read on a
+        # TTL, so rotation needs no proxy restart. All three are unused by authMode: none.
+        authToken: ''
+        authTokenSecret:
+          name: ''
+          key: ''
+        authTokenFile: ''
+        authTokenTtlMs: ''
       service:
         # Set to LoadBalancer or NodePort to expose the proxy externally.
         type: ClusterIP

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -1149,8 +1149,6 @@ rr:
       # registry.npmjs.org. Set it to an internal mirror when sandboxes have no public
       # npm egress — note the *proxy pod* dials it, not the sandboxes, so that is the
       # only network path that has to reach the mirror.
-      #
-      # Requests are read-only regardless: the sandbox may GET/HEAD and nothing else.
       npmRegistry:
         url: ''
         # bearer | none. `bearer` (the default) attaches a token and refuses to send

--- a/values.yaml
+++ b/values.yaml
@@ -1145,6 +1145,26 @@ rr:
       backendUrl: ''
       backendDomainSuffixes: ''
       sandboxProxyTimeoutMs: '180000'  # 3 minutes
+      # Where the proxy fetches public npm packages. Leave url empty to use
+      # registry.npmjs.org. Set it to an internal mirror when sandboxes have no public
+      # npm egress — note the *proxy pod* dials it, not the sandboxes, so that is the
+      # only network path that has to reach the mirror.
+      npmRegistry:
+        url: ''
+        # bearer | none. `bearer` (the default) attaches a token and refuses to send
+        # the request at all when none is available, so a Secret that fails to mount
+        # can't silently downgrade to unauthenticated. Use `none` only for a mirror
+        # that genuinely allows anonymous reads.
+        authMode: bearer
+        # Credential for authMode: bearer. Inline, or from an existing Secret, or from
+        # a mounted file. Prefer the file when the token rotates — it is re-read on a
+        # TTL, so rotation needs no proxy restart. All three are unused by authMode: none.
+        authToken: ''
+        authTokenSecret:
+          name: ''
+          key: ''
+        authTokenFile: ''
+        authTokenTtlMs: ''
       service:
         # Set to LoadBalancer or NodePort to expose the proxy externally.
         type: ClusterIP


### PR DESCRIPTION
Adds easy setting of npm registry settings for the agent executor proxy.