### PR TITLE
[chore][PLAT-1440] Raise termination grace periods so in-flight SLFs can finish

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.11.20
+version: 6.11.21
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -46,7 +46,7 @@ spec:
 {{ toYaml .Values.ui.labels | indent 8 }}
 {{- end }}
     spec:
-      terminationGracePeriodSeconds: {{ .Values.backend.terminationGracePeriodSeconds | default 136 }}
+      terminationGracePeriodSeconds: {{ .Values.backend.terminationGracePeriodSeconds | default 391 }}
       serviceAccountName: {{ template "retool.serviceAccountName" . }}
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"

--- a/charts/retool/templates/deployment_code_executor.yaml
+++ b/charts/retool/templates/deployment_code_executor.yaml
@@ -50,6 +50,7 @@ spec:
 {{ toYaml .Values.codeExecutor.labels | indent 8 }}
 {{- end }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.codeExecutor.terminationGracePeriodSeconds | default 391 }}
       serviceAccountName: {{ template "retool.serviceAccountName" . }}
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"

--- a/charts/retool/templates/deployment_js_executor.yaml
+++ b/charts/retool/templates/deployment_js_executor.yaml
@@ -46,6 +46,7 @@ spec:
 {{ toYaml .Values.rr.jsExecutor.labels | indent 8 }}
 {{- end }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.rr.jsExecutor.terminationGracePeriodSeconds | default 376 }}
       serviceAccountName: {{ template "retool.serviceAccountName" . }}
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"

--- a/charts/retool/templates/deployment_js_executor.yaml
+++ b/charts/retool/templates/deployment_js_executor.yaml
@@ -46,7 +46,7 @@ spec:
 {{ toYaml .Values.rr.jsExecutor.labels | indent 8 }}
 {{- end }}
     spec:
-      terminationGracePeriodSeconds: {{ .Values.rr.jsExecutor.terminationGracePeriodSeconds | default 376 }}
+      terminationGracePeriodSeconds: {{ .Values.rr.jsExecutor.terminationGracePeriodSeconds | default 391 }}
       serviceAccountName: {{ template "retool.serviceAccountName" . }}
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -432,9 +432,8 @@ backend:
   labels: {}
 
   # Make backend pods wait the specified time before kubernetes will forcibly kill them when they need to be rescheduled
-  # By default this is a 2 minutes + 15 seconds + 1 second (136) grace period to allow outstanding queries to complete
-  # Change this to 10 minutes 15 seconds + 1 second (616) if you are using long-running queries with a 10 minute timeout
-  terminationGracePeriodSeconds: 136
+  # By default this is a 6 minutes + 30 seconds + 1 second (391) grace period to allow outstanding queries to complete
+  terminationGracePeriodSeconds: 391
 
 ui:
   # Annotations for ui pods
@@ -538,7 +537,7 @@ dbconnector:
   # kubernetes will forcibly kill them when they need to be rescheduled. Setting
   # this to a long duration will minimize disruption to any long-running
   # resource queries during updates, at the cost of making updates take longer.
-  # terminationGracePeriodSeconds: 960
+  terminationGracePeriodSeconds: 391
 
   # If necessary, specify the resources to provision the workflows-backend pod
   # separately from the main backend pods. If unspecified, uses the same
@@ -794,6 +793,9 @@ codeExecutor:
 
   replicaCount: 1
 
+  # 6m in-flight request + 30s backend-style preStop buffer + 1s
+  terminationGracePeriodSeconds: 391
+
   # Annotations for code executor pods
   annotations: {}
 
@@ -867,6 +869,9 @@ rr:
       pullPolicy: IfNotPresent
 
     replicaCount: 1
+
+    # 6m in-flight SLF + 15s drain buffer + 1s
+    terminationGracePeriodSeconds: 376
 
     seccompLocalhostProfile: profiles/nsjail-seccomp.json
 

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -870,8 +870,8 @@ rr:
 
     replicaCount: 1
 
-    # 6m in-flight SLF + 15s drain buffer + 1s
-    terminationGracePeriodSeconds: 376
+    # 6m in-flight SLF + 30s drain buffer + 1s
+    terminationGracePeriodSeconds: 391
 
     seccompLocalhostProfile: profiles/nsjail-seccomp.json
 

--- a/values.yaml
+++ b/values.yaml
@@ -432,9 +432,8 @@ backend:
   labels: {}
 
   # Make backend pods wait the specified time before kubernetes will forcibly kill them when they need to be rescheduled
-  # By default this is a 2 minutes + 15 seconds + 1 second (136) grace period to allow outstanding queries to complete
-  # Change this to 10 minutes 15 seconds + 1 second (616) if you are using long-running queries with a 10 minute timeout
-  terminationGracePeriodSeconds: 136
+  # By default this is a 6 minutes + 30 seconds + 1 second (391) grace period to allow outstanding queries to complete
+  terminationGracePeriodSeconds: 391
 
 ui:
   # Annotations for ui pods
@@ -538,7 +537,7 @@ dbconnector:
   # kubernetes will forcibly kill them when they need to be rescheduled. Setting
   # this to a long duration will minimize disruption to any long-running
   # resource queries during updates, at the cost of making updates take longer.
-  # terminationGracePeriodSeconds: 960
+  terminationGracePeriodSeconds: 391
 
   # If necessary, specify the resources to provision the workflows-backend pod
   # separately from the main backend pods. If unspecified, uses the same
@@ -794,6 +793,9 @@ codeExecutor:
 
   replicaCount: 1
 
+  # 6m in-flight request + 30s backend-style preStop buffer + 1s
+  terminationGracePeriodSeconds: 391
+
   # Annotations for code executor pods
   annotations: {}
 
@@ -867,6 +869,9 @@ rr:
       pullPolicy: IfNotPresent
 
     replicaCount: 1
+
+    # 6m in-flight SLF + 15s drain buffer + 1s
+    terminationGracePeriodSeconds: 376
 
     seccompLocalhostProfile: profiles/nsjail-seccomp.json
 

--- a/values.yaml
+++ b/values.yaml
@@ -870,8 +870,8 @@ rr:
 
     replicaCount: 1
 
-    # 6m in-flight SLF + 15s drain buffer + 1s
-    terminationGracePeriodSeconds: 376
+    # 6m in-flight SLF + 30s drain buffer + 1s
+    terminationGracePeriodSeconds: 391
 
     seccompLocalhostProfile: profiles/nsjail-seccomp.json
 


### PR DESCRIPTION
Related:
- Cloud / MSH drain: https://github.com/tryretool/retool-k8s/pull/18842
- Helm (self-hosted): https://github.com/tryretool/retool-helm/pull/365
- JSE process shutdown: https://github.com/tryretool/retool_development/pull/83807

Standardize and increase `terminationGracePeriodSeconds` across backend, dbconnector, codeExecutor, and jsExecutor deployments to better accommodate in-flight requests during pod shutdown.

### What changed?

- `backend` `terminationGracePeriodSeconds` increased from 136s (2m 15s + 1s) to 391s (6m 30s + 1s)
- `dbconnector` `terminationGracePeriodSeconds` changed from a commented-out 960s default to an active value of 391s
- `codeExecutor` now has an explicit `terminationGracePeriodSeconds` of 391s (6m in-flight + 30s preStop buffer + 1s), previously unset
- `jsExecutor` now has an explicit `terminationGracePeriodSeconds` of 391s (6m in-flight SLF + 30s drain buffer + 1s), previously unset

### How to test?

Deploy the chart and verify that pods for the backend, dbconnector, codeExecutor, and jsExecutor reflect the updated `terminationGracePeriodSeconds` values in their pod specs. During a rolling update, confirm that in-flight requests are allowed to complete before pods are forcibly terminated.

### Why make this change?

The previous default grace period for the backend (136s) was based on a 2-minute query timeout, which no longer reflects the actual in-flight request duration. Aligning all services to a 6-minute baseline (plus appropriate drain buffers) ensures pods have sufficient time to finish processing requests before Kubernetes forcibly kills them, reducing disruption during updates and rescheduling events.