### PR TITLE
[INF-7570] startupProbe support for all deployments

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.11.22
+version: 6.11.23
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/ci/test-agent-sandbox-enabled-option.yaml
+++ b/charts/retool/ci/test-agent-sandbox-enabled-option.yaml
@@ -54,6 +54,14 @@ rr:
     # replicaCount > 1 renders the controller PodDisruptionBudget.
     controller:
       replicaCount: 2
+      startupProbe:
+        enabled: true
+        path: /livez
+        initialDelaySeconds: 0
+        timeoutSeconds: 5
+        periodSeconds: 10
+        successThreshold: 1
+        failureThreshold: 18
 
     proxy:
       replicaCount: 2

--- a/charts/retool/ci/test-workflows-startup-probe-option.yaml
+++ b/charts/retool/ci/test-workflows-startup-probe-option.yaml
@@ -1,0 +1,17 @@
+# Exercises workflows.backend.startupProbe rendering. Overlaid on
+# test-install-values.yaml. The image tag must be high enough to pass the
+# workflows version gate so deployment_workflows.yaml is rendered.
+image:
+  tag: "3.200.0"
+
+workflows:
+  enabled: true
+  backend:
+    startupProbe:
+      enabled: true
+      path: /api/checkHealth
+      initialDelaySeconds: 10
+      timeoutSeconds: 10
+      periodSeconds: 10
+      successThreshold: 1
+      failureThreshold: 30

--- a/charts/retool/templates/_helpers.tpl
+++ b/charts/retool/templates/_helpers.tpl
@@ -322,6 +322,39 @@ Map values allow structured EnvVar fields such as valueFrom.
 {{- end }}
 {{- end }}
 
+{{/*
+Render a container startupProbe from a values block.
+Pass dict "probe" and "port" (name or number). Set probe.tcpSocket to use a
+TCP probe instead of httpGet (git-server). Empty when probe.enabled is false.
+*/}}
+{{- define "retool.startupProbe" -}}
+{{- $p := .probe | default dict -}}
+{{- if $p.enabled }}
+startupProbe:
+  {{- if $p.tcpSocket }}
+  tcpSocket:
+    port: {{ .port }}
+  {{- else }}
+  httpGet:
+    path: {{ $p.path }}
+    port: {{ .port }}
+    {{- with $p.host }}
+    host: {{ . | quote }}
+    {{- end }}
+    {{- with $p.scheme }}
+    scheme: {{ . }}
+    {{- end }}
+  {{- end }}
+  initialDelaySeconds: {{ $p.initialDelaySeconds }}
+  timeoutSeconds: {{ $p.timeoutSeconds }}
+  periodSeconds: {{ $p.periodSeconds }}
+  successThreshold: {{ $p.successThreshold }}
+  {{- with $p.failureThreshold }}
+  failureThreshold: {{ . }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
 {{- define "retool.postgresql.fullname" -}}
 {{- $name := default "postgresql" .Values.postgresql.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}

--- a/charts/retool/templates/_workers.tpl
+++ b/charts/retool/templates/_workers.tpl
@@ -384,6 +384,7 @@ spec:
           successThreshold: {{ $.Values.readinessProbe.successThreshold }}
           periodSeconds: {{ $.Values.readinessProbe.periodSeconds }}
 {{- end }}
+        {{- include "retool.startupProbe" (dict "probe" ($workerValues.startupProbe | default dict) "port" $healthcheckPort) | nindent 8 }}
         resources:
 {{ toYaml ($workerValues.resources | default $parentValues.resources | default $.Values.resources) | indent 10 }}
         volumeMounts:

--- a/charts/retool/templates/deployment_agent_sandbox.yaml
+++ b/charts/retool/templates/deployment_agent_sandbox.yaml
@@ -400,6 +400,25 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 5
+          {{- with $as.controller.startupProbe }}
+          {{- if .enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .path }}
+              port: http
+              {{- with .host }}
+              host: {{ . | quote }}
+              {{- end }}
+              {{- with .scheme }}
+              scheme: {{ . }}
+              {{- end }}
+            initialDelaySeconds: {{ .initialDelaySeconds }}
+            timeoutSeconds: {{ .timeoutSeconds }}
+            successThreshold: {{ .successThreshold }}
+            periodSeconds: {{ .periodSeconds }}
+            failureThreshold: {{ .failureThreshold }}
+          {{- end }}
+          {{- end }}
           readinessProbe:
             httpGet:
               path: /health

--- a/charts/retool/templates/deployment_agent_sandbox.yaml
+++ b/charts/retool/templates/deployment_agent_sandbox.yaml
@@ -400,25 +400,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 5
-          {{- with $as.controller.startupProbe }}
-          {{- if .enabled }}
-          startupProbe:
-            httpGet:
-              path: {{ .path }}
-              port: http
-              {{- with .host }}
-              host: {{ . | quote }}
-              {{- end }}
-              {{- with .scheme }}
-              scheme: {{ . }}
-              {{- end }}
-            initialDelaySeconds: {{ .initialDelaySeconds }}
-            timeoutSeconds: {{ .timeoutSeconds }}
-            successThreshold: {{ .successThreshold }}
-            periodSeconds: {{ .periodSeconds }}
-            failureThreshold: {{ .failureThreshold }}
-          {{- end }}
-          {{- end }}
+          {{- include "retool.startupProbe" (dict "probe" $as.controller.startupProbe "port" "http") | nindent 10 }}
           readinessProbe:
             httpGet:
               path: /health
@@ -643,6 +625,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 5
+          {{- include "retool.startupProbe" (dict "probe" $as.proxy.startupProbe "port" "http") | nindent 10 }}
           readinessProbe:
             httpGet:
               path: /health

--- a/charts/retool/templates/deployment_backend.yaml
+++ b/charts/retool/templates/deployment_backend.yaml
@@ -386,22 +386,7 @@ spec:
             exec:
               command: ["sleep", "30"]
 {{- end }}
-{{- if .Values.startupProbe.enabled }}
-        startupProbe:
-          httpGet:
-            path: {{ .Values.startupProbe.path }}
-            port: {{ .Values.service.internalPort }}
-            {{- with .Values.startupProbe.host }}
-            host: {{ . | quote }}
-            {{- end }}
-            {{- with .Values.startupProbe.scheme }}
-            scheme: {{ . }}
-            {{- end }}
-          initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
-          timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.startupProbe.successThreshold }}
-          periodSeconds: {{ .Values.startupProbe.periodSeconds }}
-{{- end }}
+        {{- include "retool.startupProbe" (dict "probe" .Values.startupProbe "port" .Values.service.internalPort) | nindent 8 }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:

--- a/charts/retool/templates/deployment_code_executor.yaml
+++ b/charts/retool/templates/deployment_code_executor.yaml
@@ -201,6 +201,7 @@ spec:
           successThreshold: {{ .Values.readinessProbe.successThreshold }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
 {{- end }}
+        {{- include "retool.startupProbe" (dict "probe" .Values.codeExecutor.startupProbe "port" 3004) | nindent 8 }}
         resources:
 {{ toYaml .Values.codeExecutor.resources | indent 10 }}
         volumeMounts:

--- a/charts/retool/templates/deployment_dbconnector.yaml
+++ b/charts/retool/templates/deployment_dbconnector.yaml
@@ -70,6 +70,7 @@ spec:
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           failureThreshold:  {{ .Values.livenessProbe.failureThreshold }}
+        {{- include "retool.startupProbe" (dict "probe" .Values.dbconnector.startupProbe "port" .Values.dbconnector.port) | nindent 8 }}
         resources:
           {{- if .Values.dbconnector.resources }}
           {{- toYaml .Values.dbconnector.resources | nindent 10 }}

--- a/charts/retool/templates/deployment_git_server.yaml
+++ b/charts/retool/templates/deployment_git_server.yaml
@@ -213,6 +213,7 @@ spec:
           failureThreshold: 10
           timeoutSeconds: 10
           periodSeconds: 20
+        {{- include "retool.startupProbe" (dict "probe" $gitServerValues.startupProbe "port" $gitServerPort) | nindent 8 }}
         resources:
 {{ toYaml ($gitServerValues.resources | default .Values.resources) | indent 10 }}
         volumeMounts:

--- a/charts/retool/templates/deployment_jobs.yaml
+++ b/charts/retool/templates/deployment_jobs.yaml
@@ -251,6 +251,7 @@ spec:
           initialDelaySeconds: 120
           periodSeconds: 30
           timeoutSeconds: 3
+        {{- include "retool.startupProbe" (dict "probe" .Values.jobRunner.startupProbe "port" 3003) | nindent 8 }}
         {{- end }}
         {{- end }}
         volumeMounts:

--- a/charts/retool/templates/deployment_js_executor.yaml
+++ b/charts/retool/templates/deployment_js_executor.yaml
@@ -176,6 +176,7 @@ spec:
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
           successThreshold: {{ .Values.readinessProbe.successThreshold }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+        {{- include "retool.startupProbe" (dict "probe" .Values.rr.jsExecutor.startupProbe "port" 3000) | nindent 8 }}
         resources:
 {{ toYaml .Values.rr.jsExecutor.resources | indent 10 }}
         volumeMounts:

--- a/charts/retool/templates/deployment_mcp.yaml
+++ b/charts/retool/templates/deployment_mcp.yaml
@@ -248,6 +248,7 @@ spec:
           failureThreshold: 10
           timeoutSeconds: 10
           periodSeconds: 20
+        {{- include "retool.startupProbe" (dict "probe" .Values.mcp.startupProbe "port" $mcpInternalPort) | nindent 8 }}
         resources:
 {{ toYaml .Values.mcp.resources | indent 10 }}
         volumeMounts:

--- a/charts/retool/templates/deployment_multiplayer_ws.yaml
+++ b/charts/retool/templates/deployment_multiplayer_ws.yaml
@@ -199,6 +199,7 @@ spec:
           failureThreshold: 10
           timeoutSeconds: 10
           periodSeconds: 20
+        {{- include "retool.startupProbe" (dict "probe" .Values.multiplayer.startupProbe "port" 3001) | nindent 8 }}
         volumeMounts:
         {{- range $configFile := (keys .Values.files) }}
         - name: {{ template "retool.name" $ }}

--- a/charts/retool/templates/deployment_workflows.yaml
+++ b/charts/retool/templates/deployment_workflows.yaml
@@ -303,25 +303,7 @@ spec:
           successThreshold: {{ .Values.readinessProbe.successThreshold }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
 {{- end }}
-{{- with .Values.workflows.backend.startupProbe }}
-{{- if .enabled }}
-        startupProbe:
-          httpGet:
-            path: {{ .path }}
-            port: {{ $.Values.service.internalPort }}
-            {{- with .host }}
-            host: {{ . | quote }}
-            {{- end }}
-            {{- with .scheme }}
-            scheme: {{ . }}
-            {{- end }}
-          initialDelaySeconds: {{ .initialDelaySeconds }}
-          timeoutSeconds: {{ .timeoutSeconds }}
-          successThreshold: {{ .successThreshold }}
-          periodSeconds: {{ .periodSeconds }}
-          failureThreshold: {{ .failureThreshold }}
-{{- end }}
-{{- end }}
+        {{- include "retool.startupProbe" (dict "probe" .Values.workflows.backend.startupProbe "port" .Values.service.internalPort) | nindent 8 }}
         resources:
 {{- if .Values.workflows.backend.resources }}
 {{ toYaml .Values.workflows.backend.resources | indent 10 }}

--- a/charts/retool/templates/deployment_workflows.yaml
+++ b/charts/retool/templates/deployment_workflows.yaml
@@ -303,6 +303,25 @@ spec:
           successThreshold: {{ .Values.readinessProbe.successThreshold }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
 {{- end }}
+{{- with .Values.workflows.backend.startupProbe }}
+{{- if .enabled }}
+        startupProbe:
+          httpGet:
+            path: {{ .path }}
+            port: {{ $.Values.service.internalPort }}
+            {{- with .host }}
+            host: {{ . | quote }}
+            {{- end }}
+            {{- with .scheme }}
+            scheme: {{ . }}
+            {{- end }}
+          initialDelaySeconds: {{ .initialDelaySeconds }}
+          timeoutSeconds: {{ .timeoutSeconds }}
+          successThreshold: {{ .successThreshold }}
+          periodSeconds: {{ .periodSeconds }}
+          failureThreshold: {{ .failureThreshold }}
+{{- end }}
+{{- end }}
         resources:
 {{- if .Values.workflows.backend.resources }}
 {{ toYaml .Values.workflows.backend.resources | indent 10 }}

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -323,19 +323,20 @@ readinessProbe:
 preStopHook:
   enabled: true
 
-# To avoid increasing livenessProbe initialDelaySeconds the good practice is to use a startupProbe.
-# Applies only to the main backend. For workflow-backend, use workflows.backend.startupProbe.
-# For the agent-sandbox controller, use rr.agentSandbox.controller.startupProbe.
+# Startup probe for the main backend. Other deployments have their own
+# <component>.startupProbe, also enabled by default. Set enabled: false to
+# disable a given deployment. Optional host/scheme: see livenessProbe.
 startupProbe:
-  enabled: false
+  enabled: true
   path: /api/checkHealth
   # Optional; see livenessProbe above. Set host: 127.0.0.1 on IPv6/dual-stack clusters.
   # host: 127.0.0.1
   # scheme: HTTP
-  initialDelaySeconds: 60
+  initialDelaySeconds: 0
   timeoutSeconds: 10
   periodSeconds: 10
   successThreshold: 1
+  failureThreshold: 30
 
 extraContainers: []
 
@@ -426,6 +427,16 @@ jobRunner:
   # Labels for job runner pods
   labels: {}
 
+  # Optional host/scheme: see top-level livenessProbe.
+  startupProbe:
+    enabled: true
+    path: /api/checkJobsRunnerHealth
+    initialDelaySeconds: 0
+    timeoutSeconds: 3
+    periodSeconds: 10
+    successThreshold: 1
+    failureThreshold: 18
+
 backend:
   # Annotations for backend pods
   annotations: {}
@@ -460,6 +471,15 @@ workflows:
     # Override the connection pool size used by workflow workers when calling the dbconnector service
     postgresPoolMaxSize: 100
 
+    startupProbe:
+      enabled: true
+      path: /api/checkHealth
+      initialDelaySeconds: 0
+      timeoutSeconds: 10
+      periodSeconds: 10
+      successThreshold: 1
+      failureThreshold: 30
+
   backend:
     # A replicaCount of 1 will launch 6 pods -- 1 workflow backend, 1 workflow worker, and 4 pods that make up the executor temporal cluster
     # Scaling this number will increase the number of workflow backends, e.g. a replicaCount of 4
@@ -478,16 +498,13 @@ workflows:
     #     memory: 4096Mi
 
     # Startup probe for the workflow-backend pod only. Independent of the
-    # top-level startupProbe, which applies only to the main backend.
-    # Enable this when workflow-backend takes longer to bind than the
-    # default liveness window (30s delay + 3x10s).
+    # top-level startupProbe (main backend). Optional host/scheme: see livenessProbe.
     startupProbe:
-      enabled: false
+      enabled: true
       path: /api/checkHealth
-      # Optional; see livenessProbe above. Set host: 127.0.0.1 on IPv6/dual-stack clusters.
       # host: 127.0.0.1
       # scheme: HTTP
-      initialDelaySeconds: 60
+      initialDelaySeconds: 0
       timeoutSeconds: 10
       periodSeconds: 10
       successThreshold: 1
@@ -579,6 +596,15 @@ dbconnector:
   # Extra annotations specific to standalone dbconnector pods.
   annotations: {}
 
+  startupProbe:
+    enabled: true
+    path: /api/checkHealth
+    initialDelaySeconds: 0
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    failureThreshold: 30
+
 
 multiplayer:
   # Enable this to use Retool's experimental multiplayer editing feature.
@@ -604,6 +630,15 @@ multiplayer:
 
   # Labels for multiplayer pods
   labels: {}
+
+  startupProbe:
+    enabled: true
+    path: /api/checkHealth
+    initialDelaySeconds: 0
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    failureThreshold: 30
 
   # Paths to route to multiplayer pods; defaults to /api/multiplayer. Can specify both path and port.
   ingress:
@@ -658,6 +693,15 @@ mcp:
   annotations: {}
 
   labels: {}
+
+  startupProbe:
+    enabled: true
+    path: /healthcheck
+    initialDelaySeconds: 0
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    failureThreshold: 18
 
   # Additional MCP environment variables, including valueFrom entries.
   # Use for settings not exposed under mcp.config.
@@ -820,6 +864,15 @@ codeExecutor:
   # Labels for code executor pods
   labels: {}
 
+  startupProbe:
+    enabled: true
+    path: /api/checkHealth
+    initialDelaySeconds: 0
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    failureThreshold: 30
+
   # Config for code executor. Node heap size limits can be overridden here
   config: {}
   # config: {
@@ -927,6 +980,15 @@ rr:
     # Labels for JS executor pods
     labels: {}
 
+    startupProbe:
+      enabled: true
+      path: /api/health
+      initialDelaySeconds: 0
+      timeoutSeconds: 10
+      periodSeconds: 10
+      successThreshold: 1
+      failureThreshold: 30
+
     volumes: {}
     volumeMounts: {}
 
@@ -963,6 +1025,15 @@ rr:
     # RR agent worker configuration
     worker:
       replicaCount: 1
+
+      startupProbe:
+        enabled: true
+        path: /api/checkHealth
+        initialDelaySeconds: 0
+        timeoutSeconds: 10
+        periodSeconds: 10
+        successThreshold: 1
+        failureThreshold: 30
 
       resources:
         limits:
@@ -1169,12 +1240,10 @@ rr:
           memory: 512Mi
       # Startup probe for the controller. The image entrypoint copies the JS
       # bundle before launching node, which can exceed the hardcoded liveness
-      # window (10s delay + 5x10s) under the default CPU limit. Enable this so
-      # kubelet waits for /livez before applying liveness.
+      # window (10s delay + 5x10s) under the default CPU limit.
       startupProbe:
-        enabled: false
+        enabled: true
         path: /livez
-        # Optional; see livenessProbe above. Set host: 127.0.0.1 on IPv6/dual-stack clusters.
         # host: 127.0.0.1
         # scheme: HTTP
         initialDelaySeconds: 0
@@ -1205,6 +1274,14 @@ rr:
         limits:
           cpu: '1'
           memory: 512Mi
+      startupProbe:
+        enabled: true
+        path: /livez
+        initialDelaySeconds: 0
+        timeoutSeconds: 5
+        periodSeconds: 10
+        successThreshold: 1
+        failureThreshold: 18
       allowedDomains: ''
       # URL the proxy uses to reach the Retool backend for token exchange.
       # Defaults to http://<fullname>:3000 (same-cluster backend service).
@@ -1357,6 +1434,14 @@ rr:
       # Annotations/labels applied to the git-server pod template.
       annotations: {}
       labels: {}
+      startupProbe:
+        enabled: true
+        tcpSocket: true
+        initialDelaySeconds: 0
+        timeoutSeconds: 10
+        periodSeconds: 10
+        successThreshold: 1
+        failureThreshold: 18
       # Annotations/labels applied to the git-server Service (kept separate from
       # the pod ones above).
       service:
@@ -1424,6 +1509,15 @@ agents:
   worker:
     replicaCount: 1
 
+    startupProbe:
+      enabled: true
+      path: /api/checkHealth
+      initialDelaySeconds: 0
+      timeoutSeconds: 10
+      periodSeconds: 10
+      successThreshold: 1
+      failureThreshold: 30
+
     resources:
       limits:
         cpu: 2000m
@@ -1435,6 +1529,15 @@ agents:
   # Agent eval worker configuration
   evalWorker:
     replicaCount: 1
+
+    startupProbe:
+      enabled: true
+      path: /api/checkHealth
+      initialDelaySeconds: 0
+      timeoutSeconds: 10
+      periodSeconds: 10
+      successThreshold: 1
+      failureThreshold: 30
 
     resources:
       limits:

--- a/charts/retool/values.yaml
+++ b/charts/retool/values.yaml
@@ -324,6 +324,8 @@ preStopHook:
   enabled: true
 
 # To avoid increasing livenessProbe initialDelaySeconds the good practice is to use a startupProbe.
+# Applies only to the main backend. For workflow-backend, use workflows.backend.startupProbe.
+# For the agent-sandbox controller, use rr.agentSandbox.controller.startupProbe.
 startupProbe:
   enabled: false
   path: /api/checkHealth
@@ -474,6 +476,22 @@ workflows:
     #   requests:
     #     cpu: 2048m
     #     memory: 4096Mi
+
+    # Startup probe for the workflow-backend pod only. Independent of the
+    # top-level startupProbe, which applies only to the main backend.
+    # Enable this when workflow-backend takes longer to bind than the
+    # default liveness window (30s delay + 3x10s).
+    startupProbe:
+      enabled: false
+      path: /api/checkHealth
+      # Optional; see livenessProbe above. Set host: 127.0.0.1 on IPv6/dual-stack clusters.
+      # host: 127.0.0.1
+      # scheme: HTTP
+      initialDelaySeconds: 60
+      timeoutSeconds: 10
+      periodSeconds: 10
+      successThreshold: 1
+      failureThreshold: 30
 
   # Timeout for queries, in ms. This will set the timeout for workflows-related pods only
   # If this value is not set but config.dbConnectorTimeout is, we will set workflows pod timeouts
@@ -1149,6 +1167,21 @@ rr:
         limits:
           cpu: 500m
           memory: 512Mi
+      # Startup probe for the controller. The image entrypoint copies the JS
+      # bundle before launching node, which can exceed the hardcoded liveness
+      # window (10s delay + 5x10s) under the default CPU limit. Enable this so
+      # kubelet waits for /livez before applying liveness.
+      startupProbe:
+        enabled: false
+        path: /livez
+        # Optional; see livenessProbe above. Set host: 127.0.0.1 on IPv6/dual-stack clusters.
+        # host: 127.0.0.1
+        # scheme: HTTP
+        initialDelaySeconds: 0
+        timeoutSeconds: 5
+        periodSeconds: 10
+        successThreshold: 1
+        failureThreshold: 18
       scaling:
         prewarmPoolSize: 5
         maxTotalJobs: 50

--- a/values.yaml
+++ b/values.yaml
@@ -323,19 +323,20 @@ readinessProbe:
 preStopHook:
   enabled: true
 
-# To avoid increasing livenessProbe initialDelaySeconds the good practice is to use a startupProbe.
-# Applies only to the main backend. For workflow-backend, use workflows.backend.startupProbe.
-# For the agent-sandbox controller, use rr.agentSandbox.controller.startupProbe.
+# Startup probe for the main backend. Other deployments have their own
+# <component>.startupProbe, also enabled by default. Set enabled: false to
+# disable a given deployment. Optional host/scheme: see livenessProbe.
 startupProbe:
-  enabled: false
+  enabled: true
   path: /api/checkHealth
   # Optional; see livenessProbe above. Set host: 127.0.0.1 on IPv6/dual-stack clusters.
   # host: 127.0.0.1
   # scheme: HTTP
-  initialDelaySeconds: 60
+  initialDelaySeconds: 0
   timeoutSeconds: 10
   periodSeconds: 10
   successThreshold: 1
+  failureThreshold: 30
 
 extraContainers: []
 
@@ -426,6 +427,16 @@ jobRunner:
   # Labels for job runner pods
   labels: {}
 
+  # Optional host/scheme: see top-level livenessProbe.
+  startupProbe:
+    enabled: true
+    path: /api/checkJobsRunnerHealth
+    initialDelaySeconds: 0
+    timeoutSeconds: 3
+    periodSeconds: 10
+    successThreshold: 1
+    failureThreshold: 18
+
 backend:
   # Annotations for backend pods
   annotations: {}
@@ -460,6 +471,15 @@ workflows:
     # Override the connection pool size used by workflow workers when calling the dbconnector service
     postgresPoolMaxSize: 100
 
+    startupProbe:
+      enabled: true
+      path: /api/checkHealth
+      initialDelaySeconds: 0
+      timeoutSeconds: 10
+      periodSeconds: 10
+      successThreshold: 1
+      failureThreshold: 30
+
   backend:
     # A replicaCount of 1 will launch 6 pods -- 1 workflow backend, 1 workflow worker, and 4 pods that make up the executor temporal cluster
     # Scaling this number will increase the number of workflow backends, e.g. a replicaCount of 4
@@ -478,16 +498,13 @@ workflows:
     #     memory: 4096Mi
 
     # Startup probe for the workflow-backend pod only. Independent of the
-    # top-level startupProbe, which applies only to the main backend.
-    # Enable this when workflow-backend takes longer to bind than the
-    # default liveness window (30s delay + 3x10s).
+    # top-level startupProbe (main backend). Optional host/scheme: see livenessProbe.
     startupProbe:
-      enabled: false
+      enabled: true
       path: /api/checkHealth
-      # Optional; see livenessProbe above. Set host: 127.0.0.1 on IPv6/dual-stack clusters.
       # host: 127.0.0.1
       # scheme: HTTP
-      initialDelaySeconds: 60
+      initialDelaySeconds: 0
       timeoutSeconds: 10
       periodSeconds: 10
       successThreshold: 1
@@ -579,6 +596,15 @@ dbconnector:
   # Extra annotations specific to standalone dbconnector pods.
   annotations: {}
 
+  startupProbe:
+    enabled: true
+    path: /api/checkHealth
+    initialDelaySeconds: 0
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    failureThreshold: 30
+
 
 multiplayer:
   # Enable this to use Retool's experimental multiplayer editing feature.
@@ -604,6 +630,15 @@ multiplayer:
 
   # Labels for multiplayer pods
   labels: {}
+
+  startupProbe:
+    enabled: true
+    path: /api/checkHealth
+    initialDelaySeconds: 0
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    failureThreshold: 30
 
   # Paths to route to multiplayer pods; defaults to /api/multiplayer. Can specify both path and port.
   ingress:
@@ -658,6 +693,15 @@ mcp:
   annotations: {}
 
   labels: {}
+
+  startupProbe:
+    enabled: true
+    path: /healthcheck
+    initialDelaySeconds: 0
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    failureThreshold: 18
 
   # Additional MCP environment variables, including valueFrom entries.
   # Use for settings not exposed under mcp.config.
@@ -820,6 +864,15 @@ codeExecutor:
   # Labels for code executor pods
   labels: {}
 
+  startupProbe:
+    enabled: true
+    path: /api/checkHealth
+    initialDelaySeconds: 0
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    failureThreshold: 30
+
   # Config for code executor. Node heap size limits can be overridden here
   config: {}
   # config: {
@@ -927,6 +980,15 @@ rr:
     # Labels for JS executor pods
     labels: {}
 
+    startupProbe:
+      enabled: true
+      path: /api/health
+      initialDelaySeconds: 0
+      timeoutSeconds: 10
+      periodSeconds: 10
+      successThreshold: 1
+      failureThreshold: 30
+
     volumes: {}
     volumeMounts: {}
 
@@ -963,6 +1025,15 @@ rr:
     # RR agent worker configuration
     worker:
       replicaCount: 1
+
+      startupProbe:
+        enabled: true
+        path: /api/checkHealth
+        initialDelaySeconds: 0
+        timeoutSeconds: 10
+        periodSeconds: 10
+        successThreshold: 1
+        failureThreshold: 30
 
       resources:
         limits:
@@ -1169,12 +1240,10 @@ rr:
           memory: 512Mi
       # Startup probe for the controller. The image entrypoint copies the JS
       # bundle before launching node, which can exceed the hardcoded liveness
-      # window (10s delay + 5x10s) under the default CPU limit. Enable this so
-      # kubelet waits for /livez before applying liveness.
+      # window (10s delay + 5x10s) under the default CPU limit.
       startupProbe:
-        enabled: false
+        enabled: true
         path: /livez
-        # Optional; see livenessProbe above. Set host: 127.0.0.1 on IPv6/dual-stack clusters.
         # host: 127.0.0.1
         # scheme: HTTP
         initialDelaySeconds: 0
@@ -1205,6 +1274,14 @@ rr:
         limits:
           cpu: '1'
           memory: 512Mi
+      startupProbe:
+        enabled: true
+        path: /livez
+        initialDelaySeconds: 0
+        timeoutSeconds: 5
+        periodSeconds: 10
+        successThreshold: 1
+        failureThreshold: 18
       allowedDomains: ''
       # URL the proxy uses to reach the Retool backend for token exchange.
       # Defaults to http://<fullname>:3000 (same-cluster backend service).
@@ -1357,6 +1434,14 @@ rr:
       # Annotations/labels applied to the git-server pod template.
       annotations: {}
       labels: {}
+      startupProbe:
+        enabled: true
+        tcpSocket: true
+        initialDelaySeconds: 0
+        timeoutSeconds: 10
+        periodSeconds: 10
+        successThreshold: 1
+        failureThreshold: 18
       # Annotations/labels applied to the git-server Service (kept separate from
       # the pod ones above).
       service:
@@ -1424,6 +1509,15 @@ agents:
   worker:
     replicaCount: 1
 
+    startupProbe:
+      enabled: true
+      path: /api/checkHealth
+      initialDelaySeconds: 0
+      timeoutSeconds: 10
+      periodSeconds: 10
+      successThreshold: 1
+      failureThreshold: 30
+
     resources:
       limits:
         cpu: 2000m
@@ -1435,6 +1529,15 @@ agents:
   # Agent eval worker configuration
   evalWorker:
     replicaCount: 1
+
+    startupProbe:
+      enabled: true
+      path: /api/checkHealth
+      initialDelaySeconds: 0
+      timeoutSeconds: 10
+      periodSeconds: 10
+      successThreshold: 1
+      failureThreshold: 30
 
     resources:
       limits:

--- a/values.yaml
+++ b/values.yaml
@@ -324,6 +324,8 @@ preStopHook:
   enabled: true
 
 # To avoid increasing livenessProbe initialDelaySeconds the good practice is to use a startupProbe.
+# Applies only to the main backend. For workflow-backend, use workflows.backend.startupProbe.
+# For the agent-sandbox controller, use rr.agentSandbox.controller.startupProbe.
 startupProbe:
   enabled: false
   path: /api/checkHealth
@@ -474,6 +476,22 @@ workflows:
     #   requests:
     #     cpu: 2048m
     #     memory: 4096Mi
+
+    # Startup probe for the workflow-backend pod only. Independent of the
+    # top-level startupProbe, which applies only to the main backend.
+    # Enable this when workflow-backend takes longer to bind than the
+    # default liveness window (30s delay + 3x10s).
+    startupProbe:
+      enabled: false
+      path: /api/checkHealth
+      # Optional; see livenessProbe above. Set host: 127.0.0.1 on IPv6/dual-stack clusters.
+      # host: 127.0.0.1
+      # scheme: HTTP
+      initialDelaySeconds: 60
+      timeoutSeconds: 10
+      periodSeconds: 10
+      successThreshold: 1
+      failureThreshold: 30
 
   # Timeout for queries, in ms. This will set the timeout for workflows-related pods only
   # If this value is not set but config.dbConnectorTimeout is, we will set workflows pod timeouts
@@ -1149,6 +1167,21 @@ rr:
         limits:
           cpu: 500m
           memory: 512Mi
+      # Startup probe for the controller. The image entrypoint copies the JS
+      # bundle before launching node, which can exceed the hardcoded liveness
+      # window (10s delay + 5x10s) under the default CPU limit. Enable this so
+      # kubelet waits for /livez before applying liveness.
+      startupProbe:
+        enabled: false
+        path: /livez
+        # Optional; see livenessProbe above. Set host: 127.0.0.1 on IPv6/dual-stack clusters.
+        # host: 127.0.0.1
+        # scheme: HTTP
+        initialDelaySeconds: 0
+        timeoutSeconds: 5
+        periodSeconds: 10
+        successThreshold: 1
+        failureThreshold: 18
       scaling:
         prewarmPoolSize: 5
         maxTotalJobs: 50


### PR DESCRIPTION
Add startup probe support in the chart for all deployments, addressing issues with both workflows-backend and agent-sandbox-controller slow startups