### PR TITLE
[fix] Declare agent-sandbox proxy Service port as TCP for service-mesh compatibility

### DIFF
--- a/charts/retool/Chart.yaml
+++ b/charts/retool/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool
 description: A Helm chart for Kubernetes
 type: application
-version: 6.11.23
+version: 6.11.24
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/charts/retool/templates/deployment_agent_sandbox.yaml
+++ b/charts/retool/templates/deployment_agent_sandbox.yaml
@@ -685,8 +685,6 @@ spec:
     - port: {{ $as.proxy.port }}
       targetPort: http
       protocol: TCP
-      # tcp-, not http-: this port carries forward-proxy requests and CONNECT
-      # tunnels, which service-mesh L7 handling rewrites and breaks.
       name: tcp-proxy
   selector:
     {{- include "retool.agentSandbox.proxy.selectorLabels" . | nindent 4 }}

--- a/charts/retool/templates/deployment_agent_sandbox.yaml
+++ b/charts/retool/templates/deployment_agent_sandbox.yaml
@@ -685,7 +685,9 @@ spec:
     - port: {{ $as.proxy.port }}
       targetPort: http
       protocol: TCP
-      name: http
+      # tcp-, not http-: this port carries forward-proxy requests and CONNECT
+      # tunnels, which service-mesh L7 handling rewrites and breaks.
+      name: tcp-proxy
   selector:
     {{- include "retool.agentSandbox.proxy.selectorLabels" . | nindent 4 }}
 ---


### PR DESCRIPTION
## Problem

On clusters with a service mesh (verified: Istio with namespace-wide sidecar injection), R²/App Builder fails completely and silently: git clones from sandboxes return 404 "repository not found", sessions die ~5s after WebSocket connect, and the agent-sandbox-proxy log shows zero forwarded requests.

Root cause: sandboxes reach the agent-sandbox-proxy (port 3019) using **forward-proxy semantics** — absolute-form request lines (`GET http://host/path HTTP/1.1`) and CONNECT tunnels. The proxy dispatches on exactly that shape (`agent_executor/proxy/src/handlers.ts` — `req.url.startsWith('http://')`). The Service declares the port as `name: http`, which mesh protocol selection reads as an instruction to L7-parse traffic on that port. Envoy's re-serialization normalizes absolute-form to origin-form + Host header, so the proxy no longer recognizes the request as proxy traffic, falls through to its Express routes, and returns Express's default 404 — with no log line on any Retool component.

## Fix

Declare the port `tcp-proxy`. Mesh sidecars then handle 3019 as an opaque TCP stream: request bytes survive verbatim, and the hop **stays fully in-mesh** (sidecars on path, auto-mTLS intact). No exclusion annotations, no DestinationRules, no plaintext holes.

The headless `*-agent-sandbox-pods` Service keeps `name: http` deliberately — it carries ordinary origin-form HTTP/WebSocket, which meshes handle correctly.

## Field validation (customer AKS cluster, Istio, injection enabled everywhere, case 00121616)

| configuration | control plane → proxy | sandbox → proxy |
|---|---|---|
| stock chart (`name: http`) | 401 (works) | broken, git 404, proxy log silent |
| `excludeOutboundPorts` annotation only | works | broken identically |
| both exclude annotations | **503 (auto-mTLS vs excluded inbound port)** | never reached |
| both annotations + port-level `tls.mode: DISABLE` DestinationRule | works | works (plaintext, bypasses sidecars) |
| **this change only** (Service patched to `tcp-proxy`, no annotations/DR) | **works, over sidecar mTLS** | **works: ~1000 proxied requests (991×200/8×201), 12 WS connections, npm + full snapshot lifecycle, zero errors** |

Non-mesh clusters are unaffected: vanilla Kubernetes treats Service port names as labels; the Service's `targetPort: http` still refers to the (unchanged) container port name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)